### PR TITLE
fix: Add clipboard support for terminal copy/paste

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1483,7 +1483,7 @@
       "functions": {}
     },
     "renderer/terminalManager": {
-      "file": "src/renderer/terminalManager.js",
+      "file": "src\\renderer\\terminalManager.js",
       "description": "T",
       "exports": [
         "TerminalManager"


### PR DESCRIPTION
## Summary
- Add copy/paste keyboard shortcuts (`Ctrl+Shift+C`/`V` on Win/Linux, `Cmd+C`/`V` on macOS) to xterm.js terminals using Electron's clipboard module
- Add right-click context menu paste support
- Fix `Ctrl+Shift+C`/`V` being swallowed by the blanket `Ctrl+Shift` shortcut passthrough rule

## Problem
xterm.js uses canvas rendering, so standard browser/Electron clipboard operations don't work — copy and paste simply did nothing in the terminal.
