### PR TITLE
feat: Add shell selector for new terminal creation

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Claude Code IDE - Module structure and IPC communication map",
-  "lastUpdated": "2026-01-29",
+  "lastUpdated": "2026-01-30",
   "architecture": {
     "type": "electron",
     "mainProcess": "src/main/index.js",
@@ -1479,7 +1479,7 @@
       }
     },
     "renderer/multiTerminalUI": {
-      "file": "src\\renderer\\multiTerminalUI.js",
+      "file": "src/renderer/multiTerminalUI.js",
       "description": "M",
       "exports": [
         "MultiTerminalUI"
@@ -1492,7 +1492,7 @@
       "functions": {}
     },
     "renderer/terminalManager": {
-      "file": "src\\renderer\\terminalManager.js",
+      "file": "src/renderer/terminalManager.js",
       "description": "T",
       "exports": [
         "TerminalManager"
@@ -1507,11 +1507,13 @@
       "ipc": {
         "listens": [
           "TERMINAL_CREATED",
+          "AVAILABLE_SHELLS_DATA",
           "TERMINAL_OUTPUT_ID",
           "TERMINAL_DESTROYED"
         ],
         "emits": [
           "TERMINAL_CREATE",
+          "GET_AVAILABLE_SHELLS",
           "TERMINAL_INPUT_ID",
           "TERMINAL_DESTROY",
           "TERMINAL_INPUT_ID",
@@ -1685,12 +1687,14 @@
         "hasTerminal",
         "getTerminalsByProject",
         "getTerminalInfo",
+        "getAvailableShells",
         "setupIPC"
       ],
       "depends": [
         "node-pty",
         "shared/ipcChannels",
-        "child_process"
+        "child_process",
+        "fs"
       ],
       "functions": {
         "init": {
@@ -1700,34 +1704,38 @@
           ],
           "purpose": "Initialize PTY manager with window reference"
         },
-        "getShell": {
+        "getDefaultShell": {
           "line": 25,
-          "purpose": "Get shell based on platform"
+          "purpose": "Get default shell based on platform"
+        },
+        "getAvailableShells": {
+          "line": 42,
+          "purpose": "Get available shells on the system"
         },
         "createTerminal": {
-          "line": 44,
+          "line": 128,
           "params": [
             "workingDir = null",
-            "projectPath = null"
-          ],
-          "purpose": "Create a new terminal instance"
+            "projectPath = null",
+            "shellPath = null"
+          ]
         },
         "getTerminalsByProject": {
-          "line": 93,
+          "line": 190,
           "params": [
             "projectPath"
           ],
           "purpose": "Get terminals for a specific project"
         },
         "getTerminalInfo": {
-          "line": 108,
+          "line": 205,
           "params": [
             "terminalId"
           ],
           "purpose": "Get terminal info"
         },
         "writeToTerminal": {
-          "line": 119,
+          "line": 216,
           "params": [
             "terminalId",
             "data"
@@ -1735,7 +1743,7 @@
           "purpose": "Write data to specific terminal"
         },
         "resizeTerminal": {
-          "line": 129,
+          "line": 226,
           "params": [
             "terminalId",
             "cols",
@@ -1744,33 +1752,33 @@
           "purpose": "Resize specific terminal"
         },
         "destroyTerminal": {
-          "line": 139,
+          "line": 236,
           "params": [
             "terminalId"
           ],
           "purpose": "Destroy specific terminal"
         },
         "destroyAll": {
-          "line": 151,
+          "line": 248,
           "purpose": "Destroy all terminals"
         },
         "getTerminalCount": {
-          "line": 162,
+          "line": 259,
           "purpose": "Get terminal count"
         },
         "getTerminalIds": {
-          "line": 169,
+          "line": 266,
           "purpose": "Get all terminal IDs"
         },
         "hasTerminal": {
-          "line": 176,
+          "line": 273,
           "params": [
             "terminalId"
           ],
           "purpose": "Check if terminal exists"
         },
         "setupIPC": {
-          "line": 183,
+          "line": 280,
           "params": [
             "ipcMain"
           ],
@@ -1779,6 +1787,7 @@
       },
       "ipc": {
         "listens": [
+          "GET_AVAILABLE_SHELLS",
           "TERMINAL_CREATE",
           "TERMINAL_DESTROY",
           "TERMINAL_INPUT_ID",
@@ -1877,7 +1886,7 @@
       "functions": {}
     },
     "renderer/terminalTabBar": {
-      "file": "src\\renderer\\terminalTabBar.js",
+      "file": "src/renderer/terminalTabBar.js",
       "description": "T",
       "exports": [
         "TerminalTabBar"

--- a/src/renderer/multiTerminalUI.js
+++ b/src/renderer/multiTerminalUI.js
@@ -78,6 +78,7 @@ class MultiTerminalUI {
   /**
    * Create a new terminal for the current project
    * @param {Object} options - Terminal options
+   * @param {string} options.shell - Shell path to use (optional)
    */
   async createTerminalForCurrentProject(options = {}) {
     const projectPath = this.manager.getCurrentProject();
@@ -85,6 +86,14 @@ class MultiTerminalUI {
       ...options,
       projectPath
     });
+  }
+
+  /**
+   * Get available shells
+   * @returns {Promise<Array<{id: string, name: string, path: string}>>}
+   */
+  async getAvailableShells() {
+    return this.manager.getAvailableShells();
   }
 
   /**

--- a/src/renderer/terminalManager.js
+++ b/src/renderer/terminalManager.js
@@ -179,6 +179,7 @@ class TerminalManager {
    * @param {string} options.cwd - Working directory
    * @param {string} options.projectPath - Associated project path (undefined = use current)
    * @param {string} options.name - Custom terminal name
+   * @param {string} options.shell - Shell path to use (optional)
    */
   async createTerminal(options = {}) {
     if (this.terminals.size >= this.maxTerminals) {
@@ -212,8 +213,29 @@ class TerminalManager {
       ipcRenderer.on(IPC.TERMINAL_CREATED, handler);
       ipcRenderer.send(IPC.TERMINAL_CREATE, {
         cwd: workingDir,
-        projectPath
+        projectPath,
+        shell: options.shell || null
       });
+    });
+  }
+
+  /**
+   * Get available shells from main process
+   * @returns {Promise<Array<{id: string, name: string, path: string}>>}
+   */
+  async getAvailableShells() {
+    return new Promise((resolve, reject) => {
+      const handler = (event, response) => {
+        ipcRenderer.removeListener(IPC.AVAILABLE_SHELLS_DATA, handler);
+        if (response.success) {
+          resolve(response.shells);
+        } else {
+          reject(new Error(response.error || 'Failed to get available shells'));
+        }
+      };
+
+      ipcRenderer.on(IPC.AVAILABLE_SHELLS_DATA, handler);
+      ipcRenderer.send(IPC.GET_AVAILABLE_SHELLS);
     });
   }
 

--- a/src/shared/ipcChannels.js
+++ b/src/shared/ipcChannels.js
@@ -58,6 +58,8 @@ const IPC = {
   TERMINAL_OUTPUT_ID: 'terminal-output-id',
   TERMINAL_RESIZE_ID: 'terminal-resize-id',
   TERMINAL_FOCUS: 'terminal-focus',
+  GET_AVAILABLE_SHELLS: 'get-available-shells',
+  AVAILABLE_SHELLS_DATA: 'available-shells-data',
 
   // Tasks Panel
   LOAD_TASKS: 'load-tasks',


### PR DESCRIPTION
Users can now choose which shell to open when creating a new terminal:
- Click the "+" button to see available shells (zsh, bash, fish, etc.)
- Right-click the "+" button to quickly open with default shell
- System automatically detects available shells on macOS/Linux/Windows
- Default shell is marked with a badge in the selection menu

Supported shells:
- macOS/Linux: zsh, bash, sh, fish, nushell
- Windows: PowerShell Core, PowerShell, CMD, Git Bash, WSL