### PR TITLE
feat: Rename Plugins panel to Claude panel with tabs

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Claude Code IDE - Module structure and IPC communication map",
-  "lastUpdated": "2026-02-13",
+  "lastUpdated": "2026-02-16",
   "architecture": {
     "type": "electron",
     "mainProcess": "src/main/index.js",
@@ -2087,82 +2087,89 @@
       ],
       "functions": {
         "init": {
-          "line": 20,
+          "line": 21,
           "purpose": "Initialize plugins panel"
         },
         "setupEventListeners": {
-          "line": 36,
+          "line": 37,
           "purpose": "Setup event listeners"
         },
         "setupIPCListeners": {
-          "line": 67,
+          "line": 76,
           "purpose": "Setup IPC listeners"
         },
         "loadPlugins": {
-          "line": 91,
+          "line": 100,
           "purpose": "Load plugins"
         },
         "refreshPlugins": {
-          "line": 105,
+          "line": 114,
           "purpose": "Refresh plugins from marketplace"
         },
         "show": {
-          "line": 139,
+          "line": 148,
           "purpose": "Show plugins panel"
         },
         "hide": {
-          "line": 150,
+          "line": 159,
           "purpose": "Hide plugins panel"
         },
         "toggle": {
-          "line": 160,
+          "line": 169,
           "purpose": "Toggle plugins panel visibility"
         },
+        "setTab": {
+          "line": 180,
+          "params": [
+            "tab"
+          ],
+          "purpose": "Set active tab"
+        },
         "setFilter": {
-          "line": 171,
+          "line": 197,
           "params": [
             "filter"
           ],
           "purpose": "Set filter"
         },
         "getFilteredPlugins": {
-          "line": 185,
+          "line": 211,
           "purpose": "Get filtered plugins"
         },
         "render": {
-          "line": 201,
+          "line": 227,
           "purpose": "Render plugins list"
         },
         "renderPluginItem": {
-          "line": 245,
+          "line": 271,
           "params": [
             "plugin"
           ],
           "purpose": "Render single plugin item"
         },
         "getPluginIcon": {
-          "line": 291,
+          "line": 317,
           "params": [
             "name"
           ],
           "purpose": "Get icon for plugin based on name"
         },
         "togglePlugin": {
-          "line": 330,
+          "line": 356,
           "params": [
             "pluginId"
           ],
           "purpose": "Toggle plugin enabled/disabled"
         },
         "installPlugin": {
-          "line": 342,
+          "line": 368,
           "params": [
             "pluginName"
           ],
           "purpose": "Install plugin via terminal command"
         },
         "showToast": {
-          "line": 359,
+          "line": 385,
           "params": [
             "message",
             "type = 'info'"
@@ -2170,14 +2177,14 @@
           "purpose": "Show toast notification"
         },
         "getToastIcon": {
-          "line": 394,
+          "line": 420,
           "params": [
             "type"
           ],
           "purpose": "Get toast icon based on type"
         },
         "escapeHtml": {
-          "line": 408,
+          "line": 434,
           "params": [
             "text"
           ],

--- a/index.html
+++ b/index.html
@@ -110,7 +110,7 @@
       </div>
     </div>
 
-    <!-- Plugins Panel -->
+    <!-- Claude Panel -->
     <div id="plugins-panel">
       <div id="plugins-header">
         <button id="plugins-collapse-btn" title="Collapse panel">
@@ -118,7 +118,7 @@
             <polyline points="9 18 15 12 9 6"/>
           </svg>
         </button>
-        <h3>Plugins</h3>
+        <h3>Claude</h3>
         <div class="plugins-header-actions">
           <button id="plugins-refresh-btn" tabindex="-1" title="Refresh plugin list">
             <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -128,13 +128,18 @@
           <button id="plugins-close" tabindex="-1">✕</button>
         </div>
       </div>
-      <div class="plugins-filter">
-        <button class="plugins-filter-btn active" data-filter="all">All</button>
-        <button class="plugins-filter-btn" data-filter="installed">Installed</button>
-        <button class="plugins-filter-btn" data-filter="enabled">Enabled</button>
+      <div class="claude-tabs">
+        <button class="claude-tab-btn active" data-tab="plugins">Plugins</button>
       </div>
-      <div id="plugins-content">
-        <!-- Plugins will be populated here -->
+      <div data-tab-content="plugins">
+        <div class="plugins-filter">
+          <button class="plugins-filter-btn active" data-filter="all">All</button>
+          <button class="plugins-filter-btn" data-filter="installed">Installed</button>
+          <button class="plugins-filter-btn" data-filter="enabled">Enabled</button>
+        </div>
+        <div id="plugins-content">
+          <!-- Plugins will be populated here -->
+        </div>
       </div>
     </div>
 

--- a/src/renderer/pluginsPanel.js
+++ b/src/renderer/pluginsPanel.js
@@ -9,6 +9,7 @@ const { IPC } = require('../shared/ipcChannels');
 let isVisible = false;
 let pluginsData = [];
 let currentFilter = 'all'; // all, installed, enabled
+let currentTab = 'plugins';
 
 // DOM Elements
 let panelElement = null;
@@ -57,6 +58,14 @@ function setupEventListeners() {
     btn.addEventListener('click', (e) => {
       const filter = e.target.dataset.filter;
       setFilter(filter);
+    });
+  });
+
+  // Tab buttons
+  document.querySelectorAll('.claude-tab-btn').forEach(btn => {
+    btn.addEventListener('click', (e) => {
+      const tab = e.target.dataset.tab;
+      setTab(tab);
     });
   });
 }
@@ -163,6 +172,23 @@ function toggle() {
   } else {
     show();
   }
+}
+
+/**
+ * Set active tab
+ */
+function setTab(tab) {
+  currentTab = tab;
+
+  // Update active tab button
+  document.querySelectorAll('.claude-tab-btn').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.tab === tab);
+  });
+
+  // Show/hide tab content
+  document.querySelectorAll('[data-tab-content]').forEach(el => {
+    el.style.display = el.dataset.tabContent === tab ? '' : 'none';
+  });
 }
 
 /**

--- a/src/renderer/styles/components/panels.css
+++ b/src/renderer/styles/components/panels.css
@@ -747,6 +747,36 @@
   background: var(--bg-hover);
 }
 
+/* Claude Tabs */
+.claude-tabs {
+  display: flex;
+  gap: 0;
+  padding: 0 var(--space-lg);
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-tertiary);
+}
+
+.claude-tab-btn {
+  background: transparent;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-tertiary);
+  padding: var(--space-sm) var(--space-md);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.claude-tab-btn:hover {
+  color: var(--text-secondary);
+}
+
+.claude-tab-btn.active {
+  color: var(--accent-primary);
+  border-bottom-color: var(--accent-primary);
+}
+
 /* Plugins Filter */
 .plugins-filter {
   display: flex;

--- a/src/renderer/terminalTabBar.js
+++ b/src/renderer/terminalTabBar.js
@@ -150,11 +150,11 @@ class TerminalTabBar {
           </svg>
           Tasks
         </button>
-        <button class="btn-plugins-toggle" title="Toggle Plugins Panel (Ctrl+Shift+P)">
+        <button class="btn-plugins-toggle" title="Toggle Claude Panel (Ctrl+Shift+P)">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
             <path d="M14.7 6.3a1 1 0 0 0 0 1.4l1.6 1.6a1 1 0 0 0 1.4 0l3.77-3.77a6 6 0 0 1-7.94 7.94l-6.91 6.91a2.12 2.12 0 0 1-3-3l6.91-6.91a6 6 0 0 1 7.94-7.94l-3.76 3.76z"/>
           </svg>
-          Plugins
+          Claude
         </button>
         <button class="btn-github-toggle" title="Toggle GitHub Panel">
           <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">


### PR DESCRIPTION
## Summary
- Renamed "Plugins" panel to "Claude" panel (header + toolbar button)
- Added tab bar infrastructure following the existing GitHub panel pattern
- Plugins content is now the first tab — ready for future Claude Code feature tabs
- No IPC, business logic, or file name changes

## Test plan
- [ ] `npm run build` passes
- [ ] Toolbar shows "Claude" button instead of "Plugins"
- [ ] Opening the Claude panel shows "Plugins" tab active with filter + plugin list working as before
- [ ] Ctrl+Shift+P shortcut still toggles the panel

🤖 Generated with [Claude Code](https://claude.com/claude-code)