### PR TITLE
feat: Add intentIndex and find-module CLI tool

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,6 +33,15 @@ This project is managed with **Frame**. AI assistants should follow the rules be
 2. Identify relevant files based on the task
 3. Update STRUCTURE.json after making changes (if new modules/files are added)
 
+**Fast File Lookup:** When searching for files related to a feature or concept, run:
+```bash
+node scripts/find-module.js <keyword>
+```
+This searches STRUCTURE.json's intentIndex and returns the exact files you need. Use this **before** doing manual grep/glob searches. Examples:
+- `node scripts/find-module.js github` → finds githubManager.js + githubPanel.js
+- `node scripts/find-module.js terminal` → finds all terminal-related files
+- `node scripts/find-module.js --list` → lists all features and their files
+
 **Note:** This system doesn't prevent reading code - it just helps you know where to look.
 
 ---

--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -11,7 +11,7 @@
   "modules": {
     "main/index": {
       "file": "src/main/index.js",
-      "description": "M",
+      "description": "Main Process Entry Point",
       "exports": [
         "createWindow"
       ],
@@ -67,7 +67,7 @@
     },
     "main/pty": {
       "file": "src/main/pty.js",
-      "description": "P",
+      "description": "PTY Management Module",
       "exports": [
         "init",
         "startPTY",
@@ -158,7 +158,7 @@
     },
     "main/menu": {
       "file": "src/main/menu.js",
-      "description": "A",
+      "description": "Application Menu Module",
       "exports": [
         "init",
         "createMenu",
@@ -225,7 +225,7 @@
     },
     "main/dialogs": {
       "file": "src/main/dialogs.js",
-      "description": "D",
+      "description": "Dialogs Module",
       "exports": [
         "init",
         "showFolderPicker",
@@ -279,7 +279,7 @@
     },
     "main/fileTree": {
       "file": "src/main/fileTree.js",
-      "description": "F",
+      "description": "File Tree Module",
       "exports": [
         "getFileTree",
         "setupIPC"
@@ -317,7 +317,7 @@
     },
     "main/promptLogger": {
       "file": "src/main/promptLogger.js",
-      "description": "P",
+      "description": "Prompt Logger Module",
       "exports": [
         "init",
         "logInput",
@@ -372,7 +372,7 @@
     },
     "main/tasksManager": {
       "file": "src/main/tasksManager.js",
-      "description": "T",
+      "description": "Tasks Manager Module",
       "exports": [
         "init",
         "setProjectPath",
@@ -478,7 +478,7 @@
     },
     "main/frameProject": {
       "file": "src/main/frameProject.js",
-      "description": "F",
+      "description": "Frame Project Module",
       "exports": [
         "init",
         "isFrameProject",
@@ -623,7 +623,7 @@
     },
     "main/workspace": {
       "file": "src/main/workspace.js",
-      "description": "W",
+      "description": "Workspace Module",
       "exports": [
         "init",
         "loadWorkspace",
@@ -726,7 +726,7 @@
     },
     "renderer/index": {
       "file": "src/renderer/index.js",
-      "description": "R",
+      "description": "Renderer Entry Point",
       "exports": [],
       "depends": [
         "terminal",
@@ -758,7 +758,7 @@
     },
     "renderer/terminal": {
       "file": "src/renderer/terminal.js",
-      "description": "T",
+      "description": "Terminal UI Module",
       "exports": [
         "initTerminal",
         "writeToTerminal",
@@ -846,7 +846,7 @@
     },
     "renderer/fileTreeUI": {
       "file": "src/renderer/fileTreeUI.js",
-      "description": "F",
+      "description": "File Tree UI Module",
       "exports": [
         "init",
         "setProjectPathGetter",
@@ -948,7 +948,7 @@
     },
     "renderer/historyPanel": {
       "file": "src/renderer/historyPanel.js",
-      "description": "H",
+      "description": "History Panel Module",
       "exports": [
         "init",
         "isHistoryVisible",
@@ -1015,7 +1015,7 @@
     },
     "renderer/state": {
       "file": "src/renderer/state.js",
-      "description": "A",
+      "description": "Application State Module",
       "exports": [
         "init",
         "getProjectPath",
@@ -1150,7 +1150,7 @@
     },
     "renderer/tasksPanel": {
       "file": "src/renderer/tasksPanel.js",
-      "description": "T",
+      "description": "Tasks Panel Module",
       "exports": [
         "init",
         "show",
@@ -1327,7 +1327,7 @@
     },
     "renderer/editor": {
       "file": "src/renderer/editor.js",
-      "description": "F",
+      "description": "File Editor Module",
       "exports": [
         "init",
         "openFile",
@@ -1406,7 +1406,7 @@
     },
     "renderer/projectListUI": {
       "file": "src/renderer/projectListUI.js",
-      "description": "P",
+      "description": "Project List UI Module",
       "exports": [
         "init",
         "loadProjects",
@@ -1537,7 +1537,7 @@
     },
     "renderer/multiTerminalUI": {
       "file": "src/renderer/multiTerminalUI.js",
-      "description": "M",
+      "description": "Multi-Terminal UI Module",
       "exports": [
         "MultiTerminalUI"
       ],
@@ -1551,7 +1551,7 @@
     },
     "renderer/terminalManager": {
       "file": "src/renderer/terminalManager.js",
-      "description": "T",
+      "description": "Terminal Manager Module",
       "exports": [
         "TerminalManager"
       ],
@@ -1581,7 +1581,7 @@
     },
     "shared/ipcChannels": {
       "file": "src/shared/ipcChannels.js",
-      "description": "I",
+      "description": "IPC Channel Constants",
       "exports": [
         "IPC"
       ],
@@ -1590,7 +1590,7 @@
     },
     "shared/frameConstants": {
       "file": "src/shared/frameConstants.js",
-      "description": "F",
+      "description": "Frame Constants",
       "exports": [
         "FRAME_DIR",
         "FRAME_CONFIG_FILE",
@@ -1605,7 +1605,7 @@
     },
     "shared/frameTemplates": {
       "file": "src/shared/frameTemplates.js",
-      "description": "F",
+      "description": "Frame Templates",
       "exports": [
         "getAgentsTemplate",
         "getStructureTemplate",
@@ -1684,7 +1684,7 @@
     },
     "main/fileEditor": {
       "file": "src/main/fileEditor.js",
-      "description": "F",
+      "description": "File Editor Module",
       "exports": [
         "init",
         "readFile",
@@ -1747,7 +1747,7 @@
     },
     "main/ptyManager": {
       "file": "src/main/ptyManager.js",
-      "description": "P",
+      "description": "PTY Manager Module",
       "exports": [
         "init",
         "createTerminal",
@@ -1875,7 +1875,7 @@
     },
     "renderer/sidebarResize": {
       "file": "src/renderer/sidebarResize.js",
-      "description": "S",
+      "description": "Sidebar Resize Module",
       "exports": [
         "init",
         "getWidth",
@@ -1951,7 +1951,7 @@
     },
     "renderer/terminalGrid": {
       "file": "src/renderer/terminalGrid.js",
-      "description": "T",
+      "description": "Terminal Grid Module",
       "exports": [
         "TerminalGrid",
         "GRID_LAYOUTS"
@@ -1961,7 +1961,7 @@
     },
     "renderer/terminalTabBar": {
       "file": "src/renderer/terminalTabBar.js",
-      "description": "T",
+      "description": "Terminal Tab Bar Module",
       "exports": [
         "TerminalTabBar"
       ],
@@ -1985,7 +1985,7 @@
     },
     "main/pluginsManager": {
       "file": "src/main/pluginsManager.js",
-      "description": "P",
+      "description": "Plugins Manager Module",
       "exports": [
         "init",
         "setupIPC",
@@ -2074,7 +2074,7 @@
     },
     "renderer/pluginsPanel": {
       "file": "src/renderer/pluginsPanel.js",
-      "description": "P",
+      "description": "Plugins Panel Module",
       "exports": [
         "init",
         "show",
@@ -2244,7 +2244,7 @@
     },
     "main/githubManager": {
       "file": "src/main/githubManager.js",
-      "description": "G",
+      "description": "GitHub Manager Module",
       "exports": [
         "init",
         "setProjectPath",
@@ -2316,7 +2316,7 @@
     },
     "renderer/githubPanel": {
       "file": "src/renderer/githubPanel.js",
-      "description": "G",
+      "description": "GitHub Panel Module",
       "exports": [
         "init",
         "show",
@@ -2556,7 +2556,7 @@
     },
     "main/claudeUsageManager": {
       "file": "src/main/claudeUsageManager.js",
-      "description": "C",
+      "description": "Claude Usage Manager Module",
       "exports": [
         "init",
         "setupIPC",
@@ -2625,7 +2625,7 @@
     },
     "main/overviewManager": {
       "file": "src/main/overviewManager.js",
-      "description": "O",
+      "description": "Overview Manager Module",
       "exports": [
         "init",
         "loadOverview",
@@ -2752,7 +2752,7 @@
     },
     "renderer/overviewPanel": {
       "file": "src/renderer/overviewPanel.js",
-      "description": "O",
+      "description": "Overview Panel Module",
       "exports": [
         "init",
         "render",
@@ -2865,7 +2865,7 @@
     },
     "renderer/structureMap": {
       "file": "src/renderer/structureMap.js",
-      "description": "S",
+      "description": "Structure Map Module",
       "exports": [
         "init",
         "show",
@@ -3022,7 +3022,7 @@
     },
     "main/gitBranchesManager": {
       "file": "src/main/gitBranchesManager.js",
-      "description": "G",
+      "description": "Git Branches Manager Module",
       "exports": [
         "init",
         "loadBranches",
@@ -3148,7 +3148,7 @@
     },
     "main/aiToolManager": {
       "file": "src/main/aiToolManager.js",
-      "description": "A",
+      "description": "AI Tool Manager",
       "exports": [
         "init",
         "getAvailableTools",
@@ -3245,7 +3245,7 @@
     },
     "renderer/aiToolSelector": {
       "file": "src/renderer/aiToolSelector.js",
-      "description": "A",
+      "description": "AI Tool Selector Module",
       "exports": [
         "init",
         "getCurrentTool",
@@ -3305,7 +3305,7 @@
     },
     "main/claudeSessionsManager": {
       "file": "src/main/claudeSessionsManager.js",
-      "description": "C",
+      "description": "Claude Sessions Manager Module",
       "exports": [
         "init",
         "setupIPC",
@@ -3686,5 +3686,251 @@
       "useIPC": "For main ↔ renderer communication",
       "useGlobal": "For renderer ↔ renderer communication that would cause circular dependency"
     }
+  },
+  "intentIndex": {
+    "ai-tool": [
+      {
+        "module": "main/aiToolManager",
+        "file": "src/main/aiToolManager.js",
+        "description": "AI Tool Manager"
+      },
+      {
+        "module": "renderer/aiToolSelector",
+        "file": "src/renderer/aiToolSelector.js",
+        "description": "AI Tool Selector Module"
+      }
+    ],
+    "claude-sessions": [
+      {
+        "module": "main/claudeSessionsManager",
+        "file": "src/main/claudeSessionsManager.js",
+        "description": "Claude Sessions Manager Module"
+      }
+    ],
+    "claude-usage": [
+      {
+        "module": "main/claudeUsageManager",
+        "file": "src/main/claudeUsageManager.js",
+        "description": "Claude Usage Manager Module"
+      }
+    ],
+    "dialogs": [
+      {
+        "module": "main/dialogs",
+        "file": "src/main/dialogs.js",
+        "description": "Dialogs Module"
+      }
+    ],
+    "editor": [
+      {
+        "module": "main/editor",
+        "file": "src/main/editor.js",
+        "description": "File reading/writing for editor overlay"
+      },
+      {
+        "module": "renderer/editor",
+        "file": "src/renderer/editor.js",
+        "description": "File Editor Module"
+      }
+    ],
+    "file-editor": [
+      {
+        "module": "main/fileEditor",
+        "file": "src/main/fileEditor.js",
+        "description": "File Editor Module"
+      }
+    ],
+    "file-tree": [
+      {
+        "module": "main/fileTree",
+        "file": "src/main/fileTree.js",
+        "description": "File Tree Module"
+      },
+      {
+        "module": "renderer/fileTreeUI",
+        "file": "src/renderer/fileTreeUI.js",
+        "description": "File Tree UI Module"
+      }
+    ],
+    "frame-config": [
+      {
+        "module": "main/frameProject",
+        "file": "src/main/frameProject.js",
+        "description": "Frame Project Module"
+      },
+      {
+        "module": "shared/frameConstants",
+        "file": "src/shared/frameConstants.js",
+        "description": "Frame Constants"
+      },
+      {
+        "module": "shared/frameTemplates",
+        "file": "src/shared/frameTemplates.js",
+        "description": "Frame Templates"
+      }
+    ],
+    "git-branches": [
+      {
+        "module": "main/gitBranchesManager",
+        "file": "src/main/gitBranchesManager.js",
+        "description": "Git Branches Manager Module"
+      }
+    ],
+    "github": [
+      {
+        "module": "main/githubManager",
+        "file": "src/main/githubManager.js",
+        "description": "GitHub Manager Module"
+      },
+      {
+        "module": "renderer/githubPanel",
+        "file": "src/renderer/githubPanel.js",
+        "description": "GitHub Panel Module"
+      }
+    ],
+    "history": [
+      {
+        "module": "main/promptLogger",
+        "file": "src/main/promptLogger.js",
+        "description": "Prompt Logger Module"
+      },
+      {
+        "module": "renderer/historyPanel",
+        "file": "src/renderer/historyPanel.js",
+        "description": "History Panel Module"
+      }
+    ],
+    "index": [
+      {
+        "module": "main/index",
+        "file": "src/main/index.js",
+        "description": "Main Process Entry Point"
+      },
+      {
+        "module": "renderer/index",
+        "file": "src/renderer/index.js",
+        "description": "Renderer Entry Point"
+      }
+    ],
+    "ipc": [
+      {
+        "module": "shared/ipcChannels",
+        "file": "src/shared/ipcChannels.js",
+        "description": "IPC Channel Constants"
+      }
+    ],
+    "menu": [
+      {
+        "module": "main/menu",
+        "file": "src/main/menu.js",
+        "description": "Application Menu Module"
+      }
+    ],
+    "overview": [
+      {
+        "module": "main/overviewManager",
+        "file": "src/main/overviewManager.js",
+        "description": "Overview Manager Module"
+      },
+      {
+        "module": "renderer/overviewPanel",
+        "file": "src/renderer/overviewPanel.js",
+        "description": "Overview Panel Module"
+      }
+    ],
+    "plugins": [
+      {
+        "module": "main/pluginsManager",
+        "file": "src/main/pluginsManager.js",
+        "description": "Plugins Manager Module"
+      },
+      {
+        "module": "renderer/pluginsPanel",
+        "file": "src/renderer/pluginsPanel.js",
+        "description": "Plugins Panel Module"
+      }
+    ],
+    "sidebar": [
+      {
+        "module": "renderer/projectListUI",
+        "file": "src/renderer/projectListUI.js",
+        "description": "Project List UI Module"
+      },
+      {
+        "module": "renderer/sidebarResize",
+        "file": "src/renderer/sidebarResize.js",
+        "description": "Sidebar Resize Module"
+      }
+    ],
+    "state": [
+      {
+        "module": "renderer/state",
+        "file": "src/renderer/state.js",
+        "description": "Application State Module"
+      }
+    ],
+    "structure": [
+      {
+        "module": "renderer/structureMap",
+        "file": "src/renderer/structureMap.js",
+        "description": "Structure Map Module"
+      }
+    ],
+    "tasks": [
+      {
+        "module": "main/tasksManager",
+        "file": "src/main/tasksManager.js",
+        "description": "Tasks Manager Module"
+      },
+      {
+        "module": "renderer/tasksPanel",
+        "file": "src/renderer/tasksPanel.js",
+        "description": "Tasks Panel Module"
+      }
+    ],
+    "terminal": [
+      {
+        "module": "main/pty",
+        "file": "src/main/pty.js",
+        "description": "PTY Management Module"
+      },
+      {
+        "module": "main/ptyManager",
+        "file": "src/main/ptyManager.js",
+        "description": "PTY Manager Module"
+      },
+      {
+        "module": "renderer/multiTerminalUI",
+        "file": "src/renderer/multiTerminalUI.js",
+        "description": "Multi-Terminal UI Module"
+      },
+      {
+        "module": "renderer/terminal",
+        "file": "src/renderer/terminal.js",
+        "description": "Terminal UI Module"
+      },
+      {
+        "module": "renderer/terminalGrid",
+        "file": "src/renderer/terminalGrid.js",
+        "description": "Terminal Grid Module"
+      },
+      {
+        "module": "renderer/terminalManager",
+        "file": "src/renderer/terminalManager.js",
+        "description": "Terminal Manager Module"
+      },
+      {
+        "module": "renderer/terminalTabBar",
+        "file": "src/renderer/terminalTabBar.js",
+        "description": "Terminal Tab Bar Module"
+      }
+    ],
+    "workspace": [
+      {
+        "module": "main/workspace",
+        "file": "src/main/workspace.js",
+        "description": "Workspace Module"
+      }
+    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "dev": "npm run watch & electron .",
     "structure": "node scripts/update-structure.js",
     "structure:changed": "node scripts/update-structure.js --changed",
+    "find-module": "node scripts/find-module.js",
     "prepare": "git config core.hooksPath .githooks || true",
     "dist": "npm run build && electron-builder --mac --dir",
     "dist:mac": "npm run build && electron-builder --mac",

--- a/scripts/find-module.js
+++ b/scripts/find-module.js
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * Module Finder — Fast file lookup using STRUCTURE.json intentIndex
+ *
+ * Usage:
+ *   node scripts/find-module.js <keyword>      # Search by feature/concept
+ *   node scripts/find-module.js --list          # List all features
+ *
+ * Examples:
+ *   node scripts/find-module.js github
+ *   node scripts/find-module.js terminal
+ *   node scripts/find-module.js tasks
+ */
+
+const fs = require('fs');
+const path = require('path');
+
+const STRUCTURE_FILE = path.join(__dirname, '..', 'STRUCTURE.json');
+
+function loadStructure() {
+  try {
+    return JSON.parse(fs.readFileSync(STRUCTURE_FILE, 'utf-8'));
+  } catch (e) {
+    console.error('Error: Could not read STRUCTURE.json');
+    process.exit(1);
+  }
+}
+
+/**
+ * Search intentIndex for matching features
+ */
+function searchIntentIndex(structure, keyword) {
+  const index = structure.intentIndex;
+  if (!index) {
+    console.error('No intentIndex found in STRUCTURE.json. Run: npm run structure');
+    process.exit(1);
+  }
+
+  const kw = keyword.toLowerCase();
+  const results = [];
+
+  // 1. Exact match in intentIndex keys
+  for (const [feature, modules] of Object.entries(index)) {
+    if (feature === kw) {
+      results.push({ feature, modules, matchType: 'exact' });
+    }
+  }
+
+  // 2. Partial match in intentIndex keys
+  if (results.length === 0) {
+    for (const [feature, modules] of Object.entries(index)) {
+      if (feature.includes(kw) || kw.includes(feature)) {
+        results.push({ feature, modules, matchType: 'partial' });
+      }
+    }
+  }
+
+  // 3. Search in module descriptions, exports, IPC channels
+  if (results.length === 0) {
+    const matchedModules = [];
+    for (const [key, mod] of Object.entries(structure.modules)) {
+      const searchable = [
+        key,
+        mod.description || '',
+        ...(mod.exports || []),
+        ...(mod.ipc?.listens || []),
+        ...(mod.ipc?.emits || [])
+      ].join(' ').toLowerCase();
+
+      if (searchable.includes(kw)) {
+        matchedModules.push({
+          module: key,
+          file: mod.file,
+          description: mod.description || ''
+        });
+      }
+    }
+    if (matchedModules.length > 0) {
+      results.push({ feature: `search: "${keyword}"`, modules: matchedModules, matchType: 'deep' });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * List all features in intentIndex
+ */
+function listFeatures(structure) {
+  const index = structure.intentIndex;
+  if (!index) {
+    console.error('No intentIndex found. Run: npm run structure');
+    process.exit(1);
+  }
+
+  console.log('Available features:\n');
+  for (const [feature, modules] of Object.entries(index)) {
+    const files = modules.map(m => m.file).join(', ');
+    console.log(`  ${feature.padEnd(20)} → ${files}`);
+  }
+  console.log(`\nTotal: ${Object.keys(index).length} features, ${Object.values(index).flat().length} modules`);
+}
+
+/**
+ * Format and print results
+ */
+function printResults(results, keyword) {
+  if (results.length === 0) {
+    console.log(`No modules found for "${keyword}"`);
+    console.log('Try: node scripts/find-module.js --list');
+    return;
+  }
+
+  for (const result of results) {
+    console.log(`Feature: ${result.feature}`);
+    for (const mod of result.modules) {
+      const desc = mod.description ? ` — ${mod.description}` : '';
+      console.log(`  ${mod.file.padEnd(42)}${desc}`);
+    }
+
+    // Show related IPC channels
+    const structure = loadStructure();
+    const ipcChannels = [];
+    for (const mod of result.modules) {
+      const modInfo = structure.modules[mod.module];
+      if (modInfo?.ipc) {
+        ipcChannels.push(...(modInfo.ipc.listens || []), ...(modInfo.ipc.emits || []));
+      }
+    }
+    if (ipcChannels.length > 0) {
+      console.log(`  IPC: ${[...new Set(ipcChannels)].join(', ')}`);
+    }
+    console.log('');
+  }
+}
+
+// Main
+const args = process.argv.slice(2);
+
+if (args.length === 0) {
+  console.log('Usage: node scripts/find-module.js <keyword>');
+  console.log('       node scripts/find-module.js --list');
+  process.exit(0);
+}
+
+const structure = loadStructure();
+
+if (args[0] === '--list') {
+  listFeatures(structure);
+} else {
+  const keyword = args.join(' ');
+  const results = searchIntentIndex(structure, keyword);
+  printResults(results, keyword);
+}


### PR DESCRIPTION
## Summary
- Auto-generate `intentIndex` in STRUCTURE.json that groups 40 modules into 22 features by name pattern
- Add `scripts/find-module.js` CLI tool for fast file lookup (3-layer search: intentIndex → module names → descriptions/exports/IPC)
- Fix description extraction regex to capture full JSDoc line instead of single character
- Add agent instructions in AGENTS.md to use `find-module` before manual grep/glob

## Test plan
- [ ] `npm run structure` generates intentIndex without errors
- [ ] `node scripts/find-module.js github` returns githubManager + githubPanel
- [ ] `node scripts/find-module.js terminal` returns all 7 terminal-related files
- [ ] `node scripts/find-module.js --list` lists all 22 features
- [ ] Pre-commit hook still works (STRUCTURE.json auto-updates with intentIndex)
- [ ] Descriptions are full strings, not single characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)