### PR TITLE
feat: Add spotlight tour and hover tooltip for Initialize Frame button

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Claude Code IDE - Module structure and IPC communication map",
-  "lastUpdated": "2026-02-19",
+  "lastUpdated": "2026-02-26",
   "architecture": {
     "type": "electron",
     "mainProcess": "src/main/index.js",
@@ -1037,100 +1037,112 @@
       ],
       "functions": {
         "init": {
-          "line": 25,
+          "line": 27,
           "params": [
             "elements"
           ],
           "purpose": "Initialize state module"
         },
         "getProjectPath": {
-          "line": 38,
+          "line": 41,
           "purpose": "Get current project path"
         },
         "setMultiTerminalUI": {
-          "line": 45,
+          "line": 48,
           "params": [
             "ui"
           ],
           "purpose": "Set MultiTerminalUI reference for terminal session management"
         },
         "setProjectPath": {
-          "line": 52,
+          "line": 55,
           "params": [
             "path"
           ],
           "purpose": "Set project path and switch terminal session"
         },
         "onProjectChange": {
-          "line": 77,
+          "line": 80,
           "params": [
             "callback"
           ],
           "purpose": "Register callback for project change"
         },
         "getIsFrameProject": {
-          "line": 84,
+          "line": 87,
           "purpose": "Get Frame project status"
         },
         "setIsFrameProject": {
-          "line": 91,
+          "line": 94,
           "params": [
             "isFrame"
           ],
           "purpose": "Set Frame project status"
         },
         "onFrameStatusChange": {
-          "line": 102,
+          "line": 105,
           "params": [
             "callback"
           ],
           "purpose": "Register callback for Frame status change"
         },
         "onFrameInitialized": {
-          "line": 109,
+          "line": 112,
           "params": [
             "callback"
           ],
           "purpose": "Register callback for Frame project initialized"
         },
         "updateFrameUI": {
-          "line": 116,
+          "line": 119,
           "purpose": "Update Frame-related UI"
         },
         "initializeAsFrameProject": {
-          "line": 130,
+          "line": 134,
           "purpose": "Initialize current project as Frame project"
         },
         "showInitializeFrameModal": {
-          "line": 139,
+          "line": 143,
           "purpose": "Show custom initialize Frame modal"
         },
         "hideInitializeFrameModal": {
-          "line": 149,
+          "line": 153,
           "purpose": "Hide initialize Frame modal"
         },
         "handleInitializeFrame": {
-          "line": 159,
+          "line": 163,
           "purpose": "Handle initialize Frame confirmation"
         },
         "setupInitFrameModalListeners": {
-          "line": 174,
+          "line": 178,
           "purpose": "Setup initialize Frame modal listeners"
         },
+        "showInitSpotlight": {
+          "line": 204,
+          "purpose": "Show spotlight tour for the initialize button (first time only)"
+        },
+        "dismissSpotlight": {
+          "line": 242,
+          "purpose": "Dismiss spotlight and mark as seen"
+        },
+        "setupSpotlightListeners": {
+          "line": 253,
+          "purpose": "Setup spotlight tour listeners"
+        },
         "updateProjectUI": {
-          "line": 200,
+          "line": 295,
           "purpose": "Update project UI elements"
         },
         "selectProjectFolder": {
-          "line": 233,
+          "line": 328,
           "purpose": "Request folder selection"
         },
         "createNewProject": {
-          "line": 240,
+          "line": 335,
           "purpose": "Request new project creation"
         },
         "setupIPC": {
-          "line": 247,
+          "line": 342,
           "purpose": "Setup IPC listeners"
         }
       },

--- a/index.html
+++ b/index.html
@@ -38,7 +38,30 @@
             <option value="codex">Codex</option>
           </select>
         </div>
-        <button id="btn-initialize-frame" class="btn btn-secondary" tabindex="-1" style="display: none;">Initialize as Frame Project</button>
+        <div class="init-frame-wrapper">
+          <button id="btn-initialize-frame" class="btn btn-frame-init" tabindex="-1" style="display: none;">Initialize as Frame Project</button>
+        </div>
+
+    <!-- Hover tooltip for Initialize Frame button (fixed position, escapes overflow) -->
+    <div id="init-frame-tooltip" class="init-frame-tooltip">
+      <div class="spotlight-card-header">
+        <span class="spotlight-icon">&#10022;</span>
+        <h4>Initialize as Frame Project</h4>
+      </div>
+      <p class="spotlight-card-body">
+        Frame standardizes your project for AI-assisted development.
+        This creates configuration files that help AI tools understand
+        your project structure, preserve context between sessions,
+        and track decisions.
+      </p>
+      <div class="spotlight-card-files">
+        <span>AGENTS.md</span>
+        <span>STRUCTURE.json</span>
+        <span>PROJECT_NOTES.md</span>
+        <span>tasks.json</span>
+        <span>+ more</span>
+      </div>
+    </div>
       </div>
 
       <!-- Projects Section -->
@@ -211,6 +234,30 @@
       </div>
       <div id="github-content">
         <!-- GitHub content will be populated here -->
+      </div>
+    </div>
+
+    <!-- Spotlight Tour: Initialize Frame -->
+    <div id="spotlight-overlay" class="spotlight-overlay">
+      <div id="spotlight-card" class="spotlight-card">
+        <div class="spotlight-card-header">
+          <span class="spotlight-icon">&#10022;</span>
+          <h4>Initialize as Frame Project</h4>
+        </div>
+        <p class="spotlight-card-body">
+          Frame standardizes your project for AI-assisted development.
+          This creates configuration files that help AI tools understand
+          your project structure, preserve context between sessions,
+          and track decisions.
+        </p>
+        <div class="spotlight-card-files">
+          <span>AGENTS.md</span>
+          <span>STRUCTURE.json</span>
+          <span>PROJECT_NOTES.md</span>
+          <span>tasks.json</span>
+          <span>+ more</span>
+        </div>
+        <button id="spotlight-dismiss" class="spotlight-card-btn">Got it</button>
       </div>
     </div>
 

--- a/src/renderer/styles/components/panels.css
+++ b/src/renderer/styles/components/panels.css
@@ -3986,3 +3986,122 @@
   cursor: pointer;
 }
 
+/* ==================== SPOTLIGHT TOUR ==================== */
+.spotlight-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  z-index: 900;
+  display: none;
+  pointer-events: none;
+}
+
+.spotlight-overlay.visible {
+  display: block;
+  pointer-events: auto;
+  animation: spotlightFadeIn 0.3s ease-out;
+}
+
+.spotlight-backdrop {
+  position: absolute;
+  border-radius: var(--radius-md);
+  box-shadow: 0 0 0 9999px rgba(0, 0, 0, 0.7);
+  pointer-events: none;
+  z-index: 1;
+}
+
+.spotlight-card {
+  position: absolute;
+  width: 300px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-lg);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  z-index: 2;
+  opacity: 0;
+  transform: translateX(-8px);
+}
+
+.spotlight-overlay.visible .spotlight-card {
+  animation: spotlightCardIn 0.3s ease-out 0.15s forwards;
+}
+
+.spotlight-card-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-bottom: var(--space-md);
+}
+
+.spotlight-icon {
+  color: var(--accent-primary);
+  font-size: 16px;
+}
+
+.spotlight-card-header h4 {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+  letter-spacing: -0.2px;
+}
+
+.spotlight-card-body {
+  margin: 0 0 var(--space-md) 0;
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+}
+
+.spotlight-card-files {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-bottom: var(--space-lg);
+}
+
+.spotlight-card-files span {
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+  padding: 3px 8px;
+  background: var(--accent-subtle);
+  color: var(--accent-primary);
+  border-radius: var(--radius-sm);
+}
+
+.spotlight-card-btn {
+  width: 100%;
+  padding: 8px 0;
+  background: var(--accent-primary);
+  color: var(--bg-deep);
+  border: none;
+  border-radius: var(--radius-md);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: opacity var(--transition-fast);
+}
+
+.spotlight-card-btn:hover {
+  opacity: 0.9;
+}
+
+@keyframes spotlightFadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes spotlightCardIn {
+  from {
+    opacity: 0;
+    transform: translateX(-8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+

--- a/src/renderer/styles/layout.css
+++ b/src/renderer/styles/layout.css
@@ -324,11 +324,42 @@ body.sidebar-resizing * {
   font-style: italic;
 }
 
-#btn-initialize-frame {
+.init-frame-wrapper {
+  position: relative;
   margin-top: var(--space-xl);
   padding-top: var(--space-lg);
   border-top: 1px dashed var(--border-default);
+}
+
+#btn-initialize-frame {
   width: 100%;
+  background: var(--accent-primary);
+  color: var(--bg-deep);
+  border-color: var(--accent-primary);
+  font-weight: 600;
+}
+
+#btn-initialize-frame:hover {
+  opacity: 0.9;
+}
+
+/* Hover tooltip (fixed position to escape sidebar overflow) */
+.init-frame-tooltip {
+  display: none;
+  position: fixed;
+  width: 280px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-lg);
+  padding: var(--space-lg);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+  z-index: 100;
+  pointer-events: none;
+}
+
+.init-frame-tooltip.visible {
+  display: block;
+  animation: spotlightCardIn 0.2s ease-out forwards;
 }
 
 /* ==================== MAIN CONTENT ==================== */


### PR DESCRIPTION
## Summary
- **Spotlight overlay**: Automatically appears the first time the "Initialize as Frame Project" button is shown. Darkened background with a cutout highlight around the button, and an explanatory card with file badges. Dismissible via "Got it" button, backdrop click, or Escape key. Shows only once per user (localStorage).
- **Button styling**: Changed from secondary to accent-primary background with black text to make it stand out visually.
- **Hover tooltip**: Hovering over the button shows the same info card (fixed-position to escape sidebar overflow).

## Changed files
- `index.html` — Spotlight overlay HTML + hover tooltip HTML
- `src/renderer/styles/components/panels.css` — Spotlight CSS (overlay, backdrop cutout, card, animations)
- `src/renderer/styles/layout.css` — Button accent styling + fixed-position tooltip
- `src/renderer/state.js` — Spotlight trigger/dismiss logic, hover tooltip positioning

## Test plan
- [ ] Select a non-Frame project → spotlight overlay appears automatically (first time only)
- [ ] Background is darkened, button highlighted with rounded cutout
- [ ] Card appears to the right with title, description, file badges
- [ ] "Got it" button, backdrop click, and Escape key all dismiss the spotlight
- [ ] After dismissal, selecting another non-Frame project → spotlight does NOT reappear
- [ ] Hover over the button → info tooltip appears to the right
- [ ] Initialize button click → existing modal flow works unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)