### PR TITLE
fix: XSS in markdown preview + plugin install command

### DIFF
--- a/src/renderer/editor.js
+++ b/src/renderer/editor.js
@@ -125,7 +125,7 @@ function checkModified() {
 function togglePreview() {
   isPreviewMode = !isPreviewMode;
   if (isPreviewMode) {
-    editorPreview.innerHTML = marked.parse(editorTextarea.value);
+    editorPreview.innerHTML = marked.parse(editorTextarea.value).replace(/<script/gi, '&lt;script').replace(/on\w+=/gi, 'data-safe-');
     editorPreview.style.display = '';
     editorTextarea.style.display = 'none';
     editorPreviewBtn.textContent = 'Edit';
@@ -218,7 +218,7 @@ function setupIPC() {
       const isMd = result.extension.toLowerCase() === 'md';
       if (isMd) {
         isPreviewMode = true;
-        editorPreview.innerHTML = marked.parse(result.content);
+        editorPreview.innerHTML = marked.parse(result.content).replace(/<script/gi, '&lt;script').replace(/on\w+=/gi, 'data-safe-');
         editorPreview.style.display = '';
         editorTextarea.style.display = 'none';
         editorPreviewBtn.textContent = 'Edit';

--- a/src/renderer/pluginsPanel.js
+++ b/src/renderer/pluginsPanel.js
@@ -390,7 +390,7 @@ async function togglePlugin(pluginId) {
  * Install plugin via terminal command
  */
 function installPlugin(pluginName) {
-  const command = `claude plugin install ${pluginName}`;
+  const command = `/plugin install ${pluginName}`;
 
   // Send command to terminal
   if (typeof window.terminalSendCommand === 'function') {


### PR DESCRIPTION
Two fixes: (1) XSS in markdown preview - sanitize marked.parse output before innerHTML (2) Plugin install command - use slash command syntax instead of CLI syntax. Resolves frame issues 17 and 3.