### PR TITLE
feat: first-run welcome flow + boot loader splash

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Claude Code IDE - Module structure and IPC communication map",
-  "lastUpdated": "2026-04-26",
+  "lastUpdated": "2026-04-27",
   "architecture": {
     "type": "electron",
     "mainProcess": "src/main/index.js",
@@ -36,23 +36,24 @@
         "gitBranchesManager",
         "aiToolManager",
         "claudeSessionsManager",
-        "updateChecker"
+        "updateChecker",
+        "userSettings"
       ],
       "functions": {
         "createWindow": {
-          "line": 35,
+          "line": 36,
           "purpose": "Create main application window"
         },
         "setupAllIPC": {
-          "line": 86,
+          "line": 87,
           "purpose": "Setup all IPC handlers"
         },
         "init": {
-          "line": 115,
+          "line": 120,
           "purpose": "Initialize application"
         },
         "initModulesWithWindow": {
-          "line": 126,
+          "line": 134,
           "params": [
             "window"
           ],
@@ -61,6 +62,8 @@
       },
       "ipc": {
         "listens": [
+          "GET_USER_SETTING",
+          "SET_USER_SETTING",
           "TERMINAL_INPUT"
         ],
         "emits": []
@@ -767,26 +770,28 @@
         "commandRegistry",
         "commandPalette",
         "cheatSheet",
+        "welcomeOverlay",
+        "appLoader",
         "../package.json"
       ],
       "functions": {
         "init": {
-          "line": 27,
+          "line": 29,
           "purpose": "Initialize all modules"
         },
         "setupButtonHandlers": {
-          "line": 149,
+          "line": 156,
           "purpose": "Setup button click handlers"
         },
         "revealSidebarTab": {
-          "line": 256,
+          "line": 263,
           "params": [
             "tabName"
           ],
           "purpose": "commands so they don't try to focus an element inside a hidden container."
         },
         "registerCommands": {
-          "line": 274,
+          "line": 281,
           "purpose": "Command Palette and the global keyboard handler."
         }
       },
@@ -3755,6 +3760,133 @@
           ]
         }
       }
+    },
+    "main/userSettings": {
+      "file": "src/main/userSettings.js",
+      "description": "User Settings",
+      "exports": [
+        "init",
+        "get",
+        "set"
+      ],
+      "depends": [
+        "fs",
+        "path",
+        "electron"
+      ],
+      "functions": {
+        "init": {
+          "line": 21
+        },
+        "load": {
+          "line": 26
+        },
+        "get": {
+          "line": 40,
+          "params": [
+            "key"
+          ]
+        },
+        "set": {
+          "line": 44,
+          "params": [
+            "key",
+            "value"
+          ]
+        }
+      }
+    },
+    "renderer/appLoader": {
+      "file": "src/renderer/appLoader.js",
+      "description": "App Loader",
+      "exports": [
+        "init"
+      ],
+      "depends": [
+        "electron",
+        "shared/ipcChannels"
+      ],
+      "functions": {
+        "init": {
+          "line": 19
+        },
+        "hide": {
+          "line": 38
+        }
+      },
+      "ipc": {
+        "listens": [
+          "WORKSPACE_DATA"
+        ],
+        "emits": []
+      }
+    },
+    "renderer/welcomeOverlay": {
+      "file": "src/renderer/welcomeOverlay.js",
+      "description": "Welcome Overlay (Launch Greeting)",
+      "exports": [
+        "init",
+        "open",
+        "close",
+        "reopen"
+      ],
+      "depends": [
+        "electron",
+        "shared/ipcChannels",
+        "state"
+      ],
+      "functions": {
+        "init": {
+          "line": 23
+        },
+        "loadAITools": {
+          "line": 53
+        },
+        "maybeShowOnLaunch": {
+          "line": 64
+        },
+        "setupListeners": {
+          "line": 71
+        },
+        "persistDismissPreference": {
+          "line": 120
+        },
+        "renderToolOptions": {
+          "line": 128
+        },
+        "updateToolSelection": {
+          "line": 163
+        },
+        "open": {
+          "line": 174
+        },
+        "close": {
+          "line": 180
+        },
+        "reopen": {
+          "line": 194,
+          "purpose": "the checkbox state from a prior session would silently re-dismiss)."
+        },
+        "escapeHtml": {
+          "line": 202,
+          "params": [
+            "s"
+          ]
+        },
+        "escapeAttr": {
+          "line": 211,
+          "params": [
+            "s"
+          ]
+        }
+      },
+      "ipc": {
+        "listens": [
+          "WORKSPACE_DATA",
+          "AI_TOOL_CHANGED"
+        ],
+        "emits": []
+      }
     }
   },
   "ipcChannels": {
@@ -4241,6 +4373,16 @@
         "name": "update-available",
         "direction": "",
         "description": ""
+      },
+      "GET_USER_SETTING": {
+        "name": "get-user-setting",
+        "direction": "",
+        "description": ""
+      },
+      "SET_USER_SETTING": {
+        "name": "set-user-setting",
+        "direction": "",
+        "description": ""
       }
     }
   },
@@ -4394,6 +4536,13 @@
         "module": "renderer/aiToolSelector",
         "file": "src/renderer/aiToolSelector.js",
         "description": "AI Tool Selector Module"
+      }
+    ],
+    "app-loader": [
+      {
+        "module": "renderer/appLoader",
+        "file": "src/renderer/appLoader.js",
+        "description": "App Loader"
       }
     ],
     "cheat-sheet": [
@@ -4661,6 +4810,20 @@
         "module": "main/updateChecker",
         "file": "src/main/updateChecker.js",
         "description": "Update Checker Module"
+      }
+    ],
+    "user-settings": [
+      {
+        "module": "main/userSettings",
+        "file": "src/main/userSettings.js",
+        "description": "User Settings"
+      }
+    ],
+    "welcome-overlay": [
+      {
+        "module": "renderer/welcomeOverlay",
+        "file": "src/renderer/welcomeOverlay.js",
+        "description": "Welcome Overlay (Launch Greeting)"
       }
     ],
     "workspace": [

--- a/index.html
+++ b/index.html
@@ -11,6 +11,12 @@
   <link rel="stylesheet" href="src/renderer/styles/main.css">
 </head>
 <body>
+  <!-- App Loader (boot splash, hidden once workspace data arrives) -->
+  <div id="app-loader" class="app-loader">
+    <div class="app-loader-mark">&#10022;</div>
+    <div class="app-loader-text">Loading workspace…</div>
+  </div>
+
   <!-- Sidebar -->
   <div id="sidebar">
     <div id="sidebar-resize-handle"></div>
@@ -299,6 +305,65 @@
         <div class="cheat-sheet-footer">
           <span>Press <kbd>Esc</kbd> to close</span>
           <span>Open the Command Palette to run an action</span>
+        </div>
+      </div>
+    </div>
+
+    <!-- Welcome Overlay (First-run Onboarding) -->
+    <div id="welcome-overlay" class="welcome-overlay">
+      <div class="welcome-card" role="dialog" aria-label="Welcome to Frame">
+        <div class="welcome-header">
+          <div class="welcome-mark">&#10022;</div>
+          <h2 class="welcome-title">Welcome to Frame</h2>
+          <p class="welcome-subtitle">
+            The terminal-first IDE for agentic development. One standard for every
+            project, every AI tool. Context that survives sessions.
+          </p>
+        </div>
+
+        <div class="welcome-section">
+          <h4 class="welcome-section-title">Get started</h4>
+          <div class="welcome-actions">
+            <button id="welcome-open-folder" class="welcome-action">
+              <span class="welcome-action-icon">&#128193;</span>
+              <span class="welcome-action-text">
+                <span class="welcome-action-title">Open Project Folder</span>
+                <span class="welcome-action-desc">Pick an existing folder on your machine</span>
+              </span>
+            </button>
+            <button id="welcome-create-project" class="welcome-action">
+              <span class="welcome-action-icon">&#10010;</span>
+              <span class="welcome-action-text">
+                <span class="welcome-action-title">Create New Project</span>
+                <span class="welcome-action-desc">Start a fresh Frame project from scratch</span>
+              </span>
+            </button>
+            <button id="welcome-clone-github" class="welcome-action">
+              <span class="welcome-action-icon">&#8623;</span>
+              <span class="welcome-action-text">
+                <span class="welcome-action-title">Clone from GitHub</span>
+                <span class="welcome-action-desc">Pull a repo and open it as a project</span>
+              </span>
+            </button>
+          </div>
+        </div>
+
+        <div class="welcome-section">
+          <h4 class="welcome-section-title">Default AI tool</h4>
+          <div id="welcome-tool-options" class="welcome-tool-options"></div>
+        </div>
+
+        <div class="welcome-tip">
+          Tip: press <kbd>⌘⇧K</kbd> any time to see all keyboard shortcuts.
+        </div>
+
+        <div class="welcome-footer">
+          <label class="welcome-dont-show-label">
+            <input type="checkbox" id="welcome-dont-show" />
+            <span>Don&rsquo;t show this again</span>
+          </label>
+          <button id="welcome-close" class="welcome-close-btn">Close</button>
+          <button id="welcome-skip" class="welcome-skip">Skip for now</button>
         </div>
       </div>
     </div>

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -26,6 +26,7 @@ const gitBranchesManager = require('./gitBranchesManager');
 const aiToolManager = require('./aiToolManager');
 const claudeSessionsManager = require('./claudeSessionsManager');
 const updateChecker = require('./updateChecker');
+const userSettings = require('./userSettings');
 
 let mainWindow = null;
 
@@ -102,6 +103,10 @@ function setupAllIPC() {
   claudeSessionsManager.setupIPC(ipcMain);
   updateChecker.setupIPC();
 
+  // User settings (renderer-side preferences persisted to userData JSON)
+  ipcMain.handle(IPC.GET_USER_SETTING, (event, key) => userSettings.get(key));
+  ipcMain.handle(IPC.SET_USER_SETTING, (event, key, value) => userSettings.set(key, value));
+
   // Terminal input handler (needs prompt logger integration)
   ipcMain.on(IPC.TERMINAL_INPUT, (event, data) => {
     pty.writeToPTY(data);
@@ -115,6 +120,9 @@ function setupAllIPC() {
 function init() {
   // Initialize prompt logger with app paths
   promptLogger.init(app);
+
+  // Initialize user settings (must run after app is ready so userData path resolves)
+  userSettings.init();
 
   // Setup IPC handlers
   setupAllIPC();

--- a/src/main/userSettings.js
+++ b/src/main/userSettings.js
@@ -1,0 +1,59 @@
+/**
+ * User Settings
+ *
+ * Generic key-value store for renderer-side user preferences that need to
+ * persist across launches. Backed by user-settings.json under the app's
+ * userData directory.
+ *
+ * Used instead of localStorage because Electron's renderer localStorage
+ * has been observed to lose state across launches in dev mode (likely
+ * tied to userData path resolution timing). This main-process JSON is
+ * the same pattern aiToolManager / workspace already use.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const { app } = require('electron');
+
+let settingsPath = null;
+let cache = {};
+
+function init() {
+  settingsPath = path.join(app.getPath('userData'), 'user-settings.json');
+  load();
+}
+
+function load() {
+  try {
+    if (fs.existsSync(settingsPath)) {
+      const raw = fs.readFileSync(settingsPath, 'utf-8');
+      cache = JSON.parse(raw) || {};
+    } else {
+      cache = {};
+    }
+  } catch (err) {
+    console.error('userSettings: failed to load', err);
+    cache = {};
+  }
+}
+
+function get(key) {
+  return Object.prototype.hasOwnProperty.call(cache, key) ? cache[key] : null;
+}
+
+function set(key, value) {
+  if (value === null || value === undefined) {
+    delete cache[key];
+  } else {
+    cache[key] = value;
+  }
+  try {
+    fs.writeFileSync(settingsPath, JSON.stringify(cache, null, 2), 'utf-8');
+    return true;
+  } catch (err) {
+    console.error('userSettings: failed to write', err);
+    return false;
+  }
+}
+
+module.exports = { init, get, set };

--- a/src/renderer/appLoader.js
+++ b/src/renderer/appLoader.js
@@ -1,0 +1,49 @@
+/**
+ * App Loader
+ *
+ * Full-screen splash shown on boot until the first WORKSPACE_DATA arrives
+ * (or a safety timeout fires). Avoids the brief flash of empty sidebar /
+ * unmounted terminal that users see while the main process loads workspace
+ * state.
+ */
+
+const { ipcRenderer } = require('electron');
+const { IPC } = require('../shared/ipcChannels');
+
+const FAILSAFE_MS = 10000;
+const FADE_MS = 280;
+
+let loaderEl = null;
+let firstDataArrived = false;
+
+function init() {
+  loaderEl = document.getElementById('app-loader');
+  if (!loaderEl) return;
+
+  // Hide as soon as workspace data arrives the first time. Registered before
+  // welcomeOverlay's listener so the loader fades out before the welcome
+  // modal can open behind it.
+  ipcRenderer.on(IPC.WORKSPACE_DATA, () => {
+    if (firstDataArrived) return;
+    firstDataArrived = true;
+    hide();
+  });
+
+  // Failsafe — never trap the user behind the loader if something fails.
+  setTimeout(() => {
+    if (!firstDataArrived) hide();
+  }, FAILSAFE_MS);
+}
+
+function hide() {
+  if (!loaderEl) return;
+  loaderEl.classList.add('app-loader-hidden');
+  setTimeout(() => {
+    if (loaderEl && loaderEl.parentNode) {
+      loaderEl.parentNode.removeChild(loaderEl);
+    }
+    loaderEl = null;
+  }, FADE_MS);
+}
+
+module.exports = { init };

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -20,6 +20,8 @@ const aiToolSelector = require('./aiToolSelector');
 const commandRegistry = require('./commandRegistry');
 const commandPalette = require('./commandPalette');
 const cheatSheet = require('./cheatSheet');
+const welcomeOverlay = require('./welcomeOverlay');
+const appLoader = require('./appLoader');
 
 /**
  * Initialize all modules
@@ -132,8 +134,13 @@ function init() {
   setupButtonHandlers();
 
   // Initialize command palette + cheat sheet, register all commands, then bind keyboard
+  // App loader registers its WORKSPACE_DATA listener first so it fades out
+  // before welcomeOverlay's listener can open the welcome modal.
+  appLoader.init();
+
   commandPalette.init();
   cheatSheet.init();
+  welcomeOverlay.init();
   registerCommands();
   commandRegistry.bindKeyboard();
 
@@ -297,6 +304,12 @@ function registerCommands() {
     category: 'Help',
     shortcut: 'CmdOrCtrl+Shift+K',
     run: () => cheatSheet.toggle()
+  });
+  r({
+    id: 'help.welcome',
+    title: 'Show Welcome Screen',
+    category: 'Help',
+    run: () => welcomeOverlay.reopen()
   });
 
   // ---------- Sidebar / Panels ----------

--- a/src/renderer/styles/components/app-loader.css
+++ b/src/renderer/styles/components/app-loader.css
@@ -1,0 +1,45 @@
+/* App Loader (boot splash) */
+
+.app-loader {
+  position: fixed;
+  inset: 0;
+  z-index: 100000;
+  background: var(--bg-deep);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-direction: column;
+  gap: 18px;
+  transition: opacity 0.28s ease-out;
+}
+
+.app-loader.app-loader-hidden {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.app-loader-mark {
+  font-size: 48px;
+  color: var(--accent-primary);
+  line-height: 1;
+  animation: app-loader-pulse 1.6s ease-in-out infinite;
+  text-shadow: 0 0 24px var(--accent-glow);
+}
+
+.app-loader-text {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+@keyframes app-loader-pulse {
+  0%, 100% {
+    opacity: 0.55;
+    transform: scale(0.92);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1);
+  }
+}

--- a/src/renderer/styles/components/welcome-overlay.css
+++ b/src/renderer/styles/components/welcome-overlay.css
@@ -1,0 +1,322 @@
+/* Welcome Overlay (First-run Onboarding) */
+
+.welcome-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.55);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  z-index: 10001;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+}
+
+.welcome-overlay.visible {
+  display: flex;
+  animation: welcome-fade 0.2s ease-out;
+}
+
+@keyframes welcome-fade {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+.welcome-card {
+  width: min(560px, 100%);
+  max-height: 90vh;
+  overflow-y: auto;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-strong);
+  border-radius: 14px;
+  box-shadow: 0 30px 80px rgba(0, 0, 0, 0.55);
+  padding: 36px 36px 28px;
+  animation: welcome-rise 0.22s ease-out;
+}
+
+@keyframes welcome-rise {
+  from { opacity: 0; transform: translateY(12px) scale(0.98); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+
+.welcome-header {
+  text-align: center;
+  margin-bottom: 22px;
+}
+
+.welcome-mark {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  background: var(--accent-subtle);
+  color: var(--accent-primary);
+  font-size: 22px;
+  margin-bottom: 14px;
+}
+
+.welcome-title {
+  font-size: 22px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0 0 8px;
+  letter-spacing: -0.01em;
+}
+
+.welcome-subtitle {
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--text-secondary);
+  margin: 0;
+  max-width: 420px;
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.welcome-section {
+  margin-top: 22px;
+}
+
+.welcome-section-title {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-tertiary);
+  margin: 0 0 10px;
+}
+
+.welcome-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.welcome-action {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  width: 100%;
+  padding: 12px 14px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-default);
+  border-radius: 8px;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s, transform 0.08s;
+}
+
+.welcome-action:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+}
+
+.welcome-action:active {
+  transform: scale(0.99);
+}
+
+.welcome-action-icon {
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 16px;
+  color: var(--accent-primary);
+  flex-shrink: 0;
+}
+
+.welcome-action-text {
+  flex: 1;
+  min-width: 0;
+}
+
+.welcome-action-title {
+  display: block;
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.welcome-action-desc {
+  display: block;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  margin-top: 2px;
+}
+
+.welcome-tool-options {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 8px;
+}
+
+.welcome-tool-option {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 10px 12px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-default);
+  border-radius: 7px;
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--text-primary);
+  transition: background 0.12s, border-color 0.12s;
+  user-select: none;
+}
+
+.welcome-tool-option:hover {
+  background: var(--bg-hover);
+}
+
+.welcome-tool-option.selected {
+  border-color: var(--accent-primary);
+  background: var(--accent-subtle);
+  color: var(--accent-primary);
+}
+
+.welcome-tool-option input[type="radio"] {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.welcome-tool-name {
+  font-weight: 500;
+}
+
+.welcome-tool-empty {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  padding: 10px 12px;
+}
+
+.welcome-tip {
+  margin-top: 22px;
+  padding: 10px 12px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  border-radius: 7px;
+  font-size: 11px;
+  color: var(--text-secondary);
+  text-align: center;
+}
+
+.welcome-tip kbd {
+  font-family: 'JetBrains Mono', monospace;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: 4px;
+  padding: 1px 6px;
+  font-size: 10px;
+  color: var(--text-primary);
+}
+
+.welcome-footer {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.welcome-footer .welcome-dont-show-label {
+  justify-self: start;
+}
+
+.welcome-footer .welcome-close-btn {
+  justify-self: center;
+}
+
+.welcome-footer .welcome-skip {
+  justify-self: end;
+}
+
+.welcome-close-btn {
+  background: var(--accent-primary);
+  color: var(--bg-secondary);
+  border: 1px solid var(--accent-primary);
+  border-radius: 7px;
+  padding: 8px 24px;
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.12s, transform 0.08s;
+}
+
+.welcome-close-btn:hover {
+  background: var(--accent-secondary);
+  border-color: var(--accent-secondary);
+}
+
+.welcome-close-btn:active {
+  transform: scale(0.98);
+}
+
+.welcome-dont-show-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  user-select: none;
+  transition: color 0.12s;
+}
+
+.welcome-dont-show-label:hover {
+  color: var(--text-secondary);
+}
+
+.welcome-dont-show-label input[type="checkbox"] {
+  appearance: none;
+  -webkit-appearance: none;
+  width: 14px;
+  height: 14px;
+  border: 1px solid var(--border-strong);
+  border-radius: 3px;
+  background: var(--bg-tertiary);
+  cursor: pointer;
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  flex-shrink: 0;
+  transition: background 0.12s, border-color 0.12s;
+}
+
+.welcome-dont-show-label input[type="checkbox"]:checked {
+  background: var(--accent-primary);
+  border-color: var(--accent-primary);
+}
+
+.welcome-dont-show-label input[type="checkbox"]:checked::after {
+  content: '';
+  width: 4px;
+  height: 8px;
+  border: solid var(--bg-secondary);
+  border-width: 0 2px 2px 0;
+  transform: rotate(45deg) translate(-1px, -1px);
+}
+
+.welcome-skip {
+  background: none;
+  border: none;
+  color: var(--text-tertiary);
+  font-size: 12px;
+  font-family: inherit;
+  cursor: pointer;
+  padding: 6px 10px;
+  transition: color 0.12s;
+}
+
+.welcome-skip:hover {
+  color: var(--text-secondary);
+}

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -25,3 +25,9 @@
 
 /* 7. Cheat Sheet */
 @import 'components/cheat-sheet.css';
+
+/* 8. Welcome Overlay */
+@import 'components/welcome-overlay.css';
+
+/* 9. App Loader (boot splash) */
+@import 'components/app-loader.css';

--- a/src/renderer/welcomeOverlay.js
+++ b/src/renderer/welcomeOverlay.js
@@ -1,0 +1,215 @@
+/**
+ * Welcome Overlay (Launch Greeting)
+ *
+ * Single-screen welcome shown on every launch unless the user explicitly
+ * opts out via the "Don't show this again" checkbox. Pitches the value
+ * prop, lets them pick a default AI tool, and routes to the existing
+ * project-creation actions.
+ */
+
+const { ipcRenderer } = require('electron');
+const { IPC } = require('../shared/ipcChannels');
+const state = require('./state');
+
+const DISMISSED_KEY = 'onboardingDismissed';
+
+let overlayEl = null;
+let dontShowEl = null;
+let isOpen = false;
+let launchTriggerFired = false;
+let availableTools = {};
+let activeToolId = null;
+
+function init() {
+  overlayEl = document.getElementById('welcome-overlay');
+  dontShowEl = document.getElementById('welcome-dont-show');
+  if (!overlayEl) {
+    console.error('Welcome overlay element not found');
+    return;
+  }
+
+  loadAITools();
+  setupListeners();
+
+  // Trigger on launch — wait for workspace data so we don't race with the
+  // initial sidebar render, but otherwise show regardless of project count.
+  ipcRenderer.on(IPC.WORKSPACE_DATA, () => {
+    if (launchTriggerFired) return;
+    launchTriggerFired = true;
+    maybeShowOnLaunch().catch((err) =>
+      console.error('Welcome: launch trigger failed', err)
+    );
+  });
+
+  // Keep selected tool in sync if changed elsewhere
+  ipcRenderer.on(IPC.AI_TOOL_CHANGED, (event, tool) => {
+    if (tool && tool.id) {
+      activeToolId = tool.id;
+      updateToolSelection();
+    }
+  });
+}
+
+async function loadAITools() {
+  try {
+    const config = await ipcRenderer.invoke(IPC.GET_AI_TOOL_CONFIG);
+    availableTools = config.availableTools || {};
+    activeToolId = config.activeTool ? config.activeTool.id : null;
+    renderToolOptions();
+  } catch (e) {
+    console.error('Welcome: failed to load AI tool config', e);
+  }
+}
+
+async function maybeShowOnLaunch() {
+  const dismissed = await ipcRenderer.invoke(IPC.GET_USER_SETTING, DISMISSED_KEY);
+  if (dismissed !== true) {
+    open();
+  }
+}
+
+function setupListeners() {
+  document
+    .getElementById('welcome-open-folder')
+    .addEventListener('click', () => {
+      close();
+      state.selectProjectFolder();
+    });
+
+  document
+    .getElementById('welcome-create-project')
+    .addEventListener('click', () => {
+      close();
+      state.createNewProject();
+    });
+
+  document
+    .getElementById('welcome-clone-github')
+    .addEventListener('click', () => {
+      close();
+      const cloneBtn = document.getElementById('btn-clone-github');
+      if (cloneBtn) cloneBtn.click();
+    });
+
+  document.getElementById('welcome-close').addEventListener('click', () => {
+    close();
+  });
+
+  document.getElementById('welcome-skip').addEventListener('click', () => {
+    close();
+  });
+
+  // Persist checkbox state immediately on change so Cmd+Q while the modal
+  // is still open also captures the user's preference.
+  if (dontShowEl) {
+    dontShowEl.addEventListener('change', persistDismissPreference);
+  }
+
+  overlayEl.addEventListener('mousedown', (e) => {
+    if (e.target === overlayEl) close();
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (isOpen && e.key === 'Escape') {
+      e.preventDefault();
+      close();
+    }
+  });
+}
+
+function persistDismissPreference() {
+  if (!dontShowEl) return;
+  const value = dontShowEl.checked ? true : null;
+  ipcRenderer
+    .invoke(IPC.SET_USER_SETTING, DISMISSED_KEY, value)
+    .catch((err) => console.error('Welcome: failed to persist setting', err));
+}
+
+function renderToolOptions() {
+  const container = document.getElementById('welcome-tool-options');
+  if (!container) return;
+
+  const tools = Object.values(availableTools);
+  if (tools.length === 0) {
+    container.innerHTML =
+      '<div class="welcome-tool-empty">No AI tools detected.</div>';
+    return;
+  }
+
+  container.innerHTML = tools
+    .map((tool) => {
+      const checked = tool.id === activeToolId;
+      return `
+      <label class="welcome-tool-option ${checked ? 'selected' : ''}" data-tool-id="${escapeAttr(tool.id)}">
+        <input type="radio" name="welcome-tool" value="${escapeAttr(tool.id)}" ${checked ? 'checked' : ''}>
+        <span class="welcome-tool-name">${escapeHtml(tool.name)}</span>
+      </label>
+    `;
+    })
+    .join('');
+
+  container.querySelectorAll('.welcome-tool-option').forEach((el) => {
+    el.addEventListener('change', async () => {
+      const toolId = el.dataset.toolId;
+      const success = await ipcRenderer.invoke(IPC.SET_AI_TOOL, toolId);
+      if (success) {
+        activeToolId = toolId;
+        updateToolSelection();
+      }
+    });
+  });
+}
+
+function updateToolSelection() {
+  const container = document.getElementById('welcome-tool-options');
+  if (!container) return;
+  container.querySelectorAll('.welcome-tool-option').forEach((el) => {
+    const isActive = el.dataset.toolId === activeToolId;
+    el.classList.toggle('selected', isActive);
+    const radio = el.querySelector('input[type="radio"]');
+    if (radio) radio.checked = isActive;
+  });
+}
+
+function open() {
+  if (isOpen) return;
+  isOpen = true;
+  overlayEl.classList.add('visible');
+}
+
+function close() {
+  if (!isOpen) return;
+  isOpen = false;
+  // Persist whatever the checkbox state currently is (idempotent with the
+  // change handler, kept here for paths that don't go through change).
+  persistDismissPreference();
+  overlayEl.classList.remove('visible');
+}
+
+/**
+ * Reopen welcome from Command Palette. Resets the dismissed flag so the
+ * user can see the modal again from the same session forward (otherwise
+ * the checkbox state from a prior session would silently re-dismiss).
+ */
+function reopen() {
+  ipcRenderer
+    .invoke(IPC.SET_USER_SETTING, DISMISSED_KEY, null)
+    .catch((err) => console.error('Welcome: failed to reset setting', err));
+  if (dontShowEl) dontShowEl.checked = false;
+  open();
+}
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function escapeAttr(s) {
+  return escapeHtml(s);
+}
+
+module.exports = { init, open, close, reopen };

--- a/src/shared/ipcChannels.js
+++ b/src/shared/ipcChannels.js
@@ -118,7 +118,11 @@ const IPC = {
   GET_AI_TOOL_CONFIG: 'get-ai-tool-config',
   AI_TOOL_CONFIG_DATA: 'ai-tool-config-data',
   SET_AI_TOOL: 'set-ai-tool',
-  AI_TOOL_CHANGED: 'ai-tool-changed'
+  AI_TOOL_CHANGED: 'ai-tool-changed',
+
+  // User Settings (renderer-side preferences persisted to userData JSON)
+  GET_USER_SETTING: 'get-user-setting',
+  SET_USER_SETTING: 'set-user-setting'
 };
 
 module.exports = { IPC };

--- a/tasks.json
+++ b/tasks.json
@@ -165,21 +165,6 @@
         "completedAt": null
       },
       {
-        "id": "task-prod-onboarding",
-        "title": "First-run onboarding flow",
-        "description": "Guided welcome experience for users opening Frame for the first time: explain core concepts (terminal-first, Frame project standard, AI selector), select first project, optionally initialize Frame docs, pick AI tool. Replaces the current cold 'Select Project Folder' empty screen. Files: new welcomeOverlay.js in renderer, first-run flag in main settings.",
-        "userRequest": "User said: çok güzel öneriler, bence hepsini tasks.json a ekleyelim — 2026-04-26 product audit.",
-        "acceptanceCriteria": "On first launch, welcome flow appears; user can finish in <60s; flag is persisted so it never appears again unless reset; reachable later via Help menu.",
-        "notes": "Should set tone of voice for the whole product — also a chance to land Frame's 'why' message.",
-        "status": "pending",
-        "priority": "high",
-        "category": "feature",
-        "context": "Session 2026-04-26 - Frame product readiness audit",
-        "createdAt": "2026-04-26T12:00:00Z",
-        "updatedAt": "2026-04-26T12:00:00Z",
-        "completedAt": null
-      },
-      {
         "id": "task-prod-keybinding-remap",
         "title": "Custom keybinding remap UI",
         "description": "Allow users to remap any registered shortcut from a Settings > Keybindings screen. Persist to a keybindings.json. Conflict detection. Builds on the central action registry from Command Palette.",
@@ -501,6 +486,36 @@
       }
     ],
     "completed": [
+      {
+        "id": "task-prod-onboarding",
+        "title": "First-run welcome flow with persistent dismiss",
+        "description": "Single-screen welcome modal shown on every launch unless user opts out via 'Don't show this again' checkbox. Pitches Frame's value prop (terminal-first, AI-native), offers three primary actions (Open Folder / Create New / Clone GitHub), embeds AI tool radio picker synced with sidebar via SET_AI_TOOL IPC, has Close primary button + Skip secondary. Reachable later via Command Palette (help.welcome). Persistence moved from localStorage to userData JSON via new userSettings module + IPC channels because Electron renderer localStorage didn't survive launches in dev. Checkbox state persists immediately on change so Cmd+Q while modal open is still captured.",
+        "userRequest": "User said: first-run welcome flow u entegre etmeliyiz bence, önemli bir ux iyileştirmesi olur — followed by: ben modali çok beğendim. ilk açılışta her zaman açılsın. dont show this again seçeneği koyalım — followed by: belki bir de close diye bi buton da koyalım modalin alt orta kısmına.",
+        "acceptanceCriteria": "Modal opens on every launch by default; AI tool radio cards in sync with sidebar selector; checkbox state persisted instantly to userData JSON; Close / Skip / Esc / outside-click all dismiss; Cmd+Q while open still saves; reachable via Command Palette > Show Welcome Screen with flag reset.",
+        "notes": "Discovered and fixed an Electron localStorage persistence quirk during testing — switched to a generic userSettings IPC pattern that mirrors aiToolManager's userData JSON approach. New IPC channels GET_USER_SETTING / SET_USER_SETTING are reusable for future renderer-side preferences (telemetry consent, theme, etc.).",
+        "status": "completed",
+        "priority": "high",
+        "category": "feature",
+        "context": "Session 2026-04-26 / 2026-04-27 - Frame product readiness audit",
+        "createdAt": "2026-04-26T12:00:00Z",
+        "updatedAt": "2026-04-27T17:00:00Z",
+        "completedAt": "2026-04-27T17:00:00Z"
+      },
+      {
+        "id": "task-prod-app-loader",
+        "title": "App boot loader splash",
+        "description": "Full-screen centered loader shown on app boot until the first WORKSPACE_DATA IPC arrives (or a 10s failsafe). Pulsing brand mark (sparkle ✦) + 'Loading workspace…' caption, fades out with CSS transition then removes itself from DOM. Avoids the brief flash of empty sidebar / unmounted terminal users with many projects experience during initial workspace load. Listener registered before welcomeOverlay's so the loader fades out before the welcome modal can appear behind it.",
+        "userRequest": "User said: bir ilk açılışta mesela benim artık bir sürü projem olduğu için bir kaç saniye projelerin dolmasını bekliyorum. acaba bu bekleme zamanı için bir loading animasyonu gibi bişey ekleyebilir miyiz? — followed by: sidebarda değil aslında, tam ortada görmek istiyorum.",
+        "acceptanceCriteria": "Loader visible on boot covering the whole window; fades out within ~280ms once workspace data arrives; never traps user (10s failsafe); welcome modal opens cleanly behind it.",
+        "notes": "Initially tried a sidebar skeleton placeholder, but user preferred a centered full-screen approach. Z-index 100000 layers above all panels; failsafe handles the unlikely case where WORKSPACE_DATA never arrives.",
+        "status": "completed",
+        "priority": "medium",
+        "category": "feature",
+        "context": "Session 2026-04-27 - Welcome flow polish",
+        "createdAt": "2026-04-27T16:00:00Z",
+        "updatedAt": "2026-04-27T17:00:00Z",
+        "completedAt": "2026-04-27T17:00:00Z"
+      },
       {
         "id": "task-prod-shortcuts-cheatsheet",
         "title": "In-app keyboard shortcut cheat sheet",


### PR DESCRIPTION
## Summary
Two related onboarding / polish features shipping together:

1. **First-run welcome flow** — Modal shown on every launch unless user opts out via "Don't show this again" checkbox. Pitches Frame's value prop, offers Open/Create/Clone actions, embeds AI tool picker.
2. **Boot loader splash** — Full-screen centered loader with pulsing brand mark, fades out once workspace data arrives. Removes the empty-sidebar flash on launch.

Plus a new generic `userSettings` IPC pattern that future renderer-side preferences (telemetry consent, theme, etc.) can reuse.

## Welcome flow

- Modal opens on every launch by default; "Don't show this again" persists immediately on checkbox change (so Cmd+Q while open still saves)
- Three primary actions: Open Folder / Create New Project / Clone from GitHub — each calls existing `state.*` flows
- AI tool radio picker (Claude / Codex / Gemini, populated from `GET_AI_TOOL_CONFIG`) is two-way synced with sidebar dropdown via `SET_AI_TOOL` and `AI_TOOL_CHANGED`
- Footer: checkbox left, **Close** primary button center, "Skip for now" secondary right
- Reachable later via Command Palette: `Show Welcome Screen` (id `help.welcome`) — resets the dismiss flag so it can be seen again

### Persistence rewrite
Originally used `localStorage`, but in dev mode Electron's renderer localStorage didn't survive across launches (verified via DevTools diagnostic). Migrated to:

- New `src/main/userSettings.js` — generic key/value store backed by `userData/user-settings.json`, mirroring the existing `aiToolManager` pattern
- New IPC channels `GET_USER_SETTING` / `SET_USER_SETTING`
- Welcome overlay reads/writes via `ipcRenderer.invoke` instead of localStorage

This is reusable for any future renderer-side preference.

## Boot loader splash

- Full-screen `position: fixed` overlay with z-index above all panels
- Pulsing Frame sparkle (`✦`) + "Loading workspace…" caption
- Listens for first `WORKSPACE_DATA` IPC, then fades out (CSS transition) and removes itself from DOM
- Listener registered **before** welcomeOverlay's so loader fades out before the welcome modal opens behind it
- 10s failsafe prevents the user from ever being trapped behind the loader

## Files

| File | Change |
|---|---|
| `src/main/userSettings.js` | new — generic key/value store |
| `src/main/index.js` | userSettings init + IPC handlers |
| `src/shared/ipcChannels.js` | `GET_USER_SETTING`, `SET_USER_SETTING` |
| `src/renderer/welcomeOverlay.js` | new — welcome modal logic |
| `src/renderer/appLoader.js` | new — boot splash logic |
| `src/renderer/styles/components/welcome-overlay.css` | new |
| `src/renderer/styles/components/app-loader.css` | new |
| `src/renderer/styles/main.css` | imports for new CSS files |
| `src/renderer/index.js` | wire-up + `help.welcome` Command Palette entry |
| `index.html` | welcome modal + loader markup |

## Test plan

### macOS (verified locally)
- [x] Boot loader visible on launch, fades out within ~280ms once workspace loads
- [x] Welcome modal opens after loader fade
- [x] AI tool radio sync with sidebar selector (both directions)
- [x] Open Folder / Create / Clone GitHub buttons trigger correct flows
- [x] Checkbox state persists immediately to `userData/user-settings.json`
- [x] Close / Skip / Esc / outside-click all dismiss the modal
- [x] After dismiss, modal does NOT open on next launch
- [x] Command Palette `Show Welcome Screen` reopens modal and resets the flag

### Windows
- [ ] Smoke test — loader and welcome modal render correctly, `Cmd+Shift+P > Show Welcome Screen` works, `userData/user-settings.json` written to expected path
