### PR TITLE
feat: git status integration (file tree decoration)

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -37,23 +37,24 @@
         "aiToolManager",
         "claudeSessionsManager",
         "updateChecker",
-        "userSettings"
+        "userSettings",
+        "gitStatusManager"
       ],
       "functions": {
         "createWindow": {
-          "line": 36,
+          "line": 37,
           "purpose": "Create main application window"
         },
         "setupAllIPC": {
-          "line": 87,
+          "line": 88,
           "purpose": "Setup all IPC handlers"
         },
         "init": {
-          "line": 120,
+          "line": 124,
           "purpose": "Initialize application"
         },
         "initModulesWithWindow": {
-          "line": 134,
+          "line": 138,
           "params": [
             "window"
           ],
@@ -912,7 +913,7 @@
       ],
       "functions": {
         "init": {
-          "line": 27,
+          "line": 41,
           "params": [
             "elementId",
             "getProjectPath"
@@ -920,21 +921,21 @@
           "purpose": "Initialize file tree UI"
         },
         "setProjectPathGetter": {
-          "line": 43,
+          "line": 57,
           "params": [
             "getter"
           ],
           "purpose": "Set project path getter"
         },
         "setOnFileClick": {
-          "line": 50,
+          "line": 64,
           "params": [
             "callback"
           ],
           "purpose": "Set file click callback"
         },
         "renderFileTree": {
-          "line": 57,
+          "line": 71,
           "params": [
             "files",
             "parentElement",
@@ -943,67 +944,67 @@
           "purpose": "Render file tree recursively"
         },
         "clearFileTree": {
-          "line": 148,
+          "line": 162,
           "purpose": "Clear file tree"
         },
         "refreshFileTree": {
-          "line": 157,
+          "line": 174,
           "params": [
             "projectPath"
           ],
           "purpose": "Refresh file tree"
         },
         "loadFileTree": {
-          "line": 167,
+          "line": 184,
           "params": [
             "projectPath"
           ],
           "purpose": "Load file tree for path"
         },
         "setupIPC": {
-          "line": 174,
+          "line": 192,
           "purpose": "Setup IPC listeners"
         },
         "focus": {
-          "line": 186,
+          "line": 213,
           "purpose": "Focus file tree for keyboard navigation"
         },
         "getVisibleItems": {
-          "line": 216,
+          "line": 243,
           "purpose": "inside collapsed folders."
         },
         "handleKeydown": {
-          "line": 225,
+          "line": 252,
           "params": [
             "e"
           ],
           "purpose": "Handle keyboard navigation in file tree"
         },
         "blur": {
-          "line": 287,
+          "line": 314,
           "purpose": "Blur/unfocus file tree"
         },
         "setupSearch": {
-          "line": 297
+          "line": 324
         },
         "applyFilter": {
-          "line": 325,
+          "line": 352,
           "params": [
             "query"
           ]
         },
         "filterWrapper": {
-          "line": 338,
+          "line": 365,
           "params": [
             "wrapper",
             "query"
           ]
         },
         "setupContextMenu": {
-          "line": 374
+          "line": 401
         },
         "showContextMenu": {
-          "line": 398,
+          "line": 425,
           "params": [
             "x",
             "y",
@@ -1011,22 +1012,29 @@
           ]
         },
         "hideContextMenu": {
-          "line": 415
+          "line": 442
         },
         "handleContextMenuAction": {
-          "line": 421,
+          "line": 448,
           "params": [
             "action"
           ]
+        },
+        "applyGitStatusDecoration": {
+          "line": 465,
+          "purpose": "via a simple second pass."
         }
       },
       "ipc": {
         "listens": [
-          "FILE_TREE_DATA"
+          "FILE_TREE_DATA",
+          "GIT_STATUS_DATA"
         ],
         "emits": [
+          "UNWATCH_GIT_STATUS",
           "LOAD_FILE_TREE",
-          "LOAD_FILE_TREE"
+          "LOAD_FILE_TREE",
+          "WATCH_GIT_STATUS"
         ]
       }
     },
@@ -3923,6 +3931,74 @@
         ],
         "emits": []
       }
+    },
+    "main/gitStatusManager": {
+      "file": "src/main/gitStatusManager.js",
+      "description": "Git Status Manager",
+      "exports": [
+        "init",
+        "setupIPC"
+      ],
+      "depends": [
+        "child_process",
+        "shared/ipcChannels"
+      ],
+      "functions": {
+        "init": {
+          "line": 23,
+          "params": [
+            "window"
+          ]
+        },
+        "setupIPC": {
+          "line": 27,
+          "params": [
+            "ipcMain"
+          ]
+        },
+        "startWatching": {
+          "line": 37,
+          "params": [
+            "projectPath"
+          ]
+        },
+        "stopWatching": {
+          "line": 48
+        },
+        "pushStatus": {
+          "line": 55
+        },
+        "readGitStatus": {
+          "line": 73,
+          "params": [
+            "projectPath"
+          ]
+        },
+        "parsePorcelainV1": {
+          "line": 94,
+          "params": [
+            "stdout"
+          ],
+          "purpose": "Format: \"XY <path>\\0\" with renamed/copied entries adding \"<oldpath>\\0\" after."
+        },
+        "classify": {
+          "line": 131,
+          "params": [
+            "index",
+            "worktree"
+          ],
+          "purpose": "Order matters: conflicts and stages take precedence over modifications."
+        }
+      },
+      "ipc": {
+        "listens": [
+          "WATCH_GIT_STATUS",
+          "UNWATCH_GIT_STATUS"
+        ],
+        "emits": [
+          "GIT_STATUS_DATA"
+        ]
+      }
     }
   },
   "ipcChannels": {
@@ -4419,6 +4495,21 @@
         "name": "set-user-setting",
         "direction": "",
         "description": ""
+      },
+      "WATCH_GIT_STATUS": {
+        "name": "watch-git-status",
+        "direction": "",
+        "description": ""
+      },
+      "UNWATCH_GIT_STATUS": {
+        "name": "unwatch-git-status",
+        "direction": "",
+        "description": ""
+      },
+      "GIT_STATUS_DATA": {
+        "name": "git-status-data",
+        "direction": "",
+        "description": ""
       }
     }
   },
@@ -4676,6 +4767,13 @@
         "module": "main/gitBranchesManager",
         "file": "src/main/gitBranchesManager.js",
         "description": "Git Branches Manager Module"
+      }
+    ],
+    "git-status": [
+      {
+        "module": "main/gitStatusManager",
+        "file": "src/main/gitStatusManager.js",
+        "description": "Git Status Manager"
       }
     ],
     "github": [

--- a/src/main/gitStatusManager.js
+++ b/src/main/gitStatusManager.js
@@ -1,0 +1,159 @@
+/**
+ * Git Status Manager
+ *
+ * Polls `git status --porcelain=v1 -z` for the active project on a fixed
+ * interval and pushes the parsed result to the renderer for file-tree
+ * decoration.
+ *
+ * Diff viewer / staged-files panel / stage-discard actions are intentionally
+ * out of scope here — those are separate features.
+ */
+
+const { execFile } = require('child_process');
+const { IPC } = require('../shared/ipcChannels');
+
+const POLL_INTERVAL_MS = 5000;
+const MAX_BUFFER = 10 * 1024 * 1024;
+
+let mainWindow = null;
+let pollTimer = null;
+let currentProjectPath = null;
+let lastSerialized = null; // de-dupe identical pushes
+
+function init(window) {
+  mainWindow = window;
+}
+
+function setupIPC(ipcMain) {
+  ipcMain.on(IPC.WATCH_GIT_STATUS, (event, projectPath) => {
+    startWatching(projectPath);
+  });
+
+  ipcMain.on(IPC.UNWATCH_GIT_STATUS, () => {
+    stopWatching();
+  });
+}
+
+function startWatching(projectPath) {
+  stopWatching();
+  currentProjectPath = projectPath;
+  if (!projectPath) return;
+
+  // Initial fetch (don't wait the full interval before showing decorations)
+  pushStatus();
+
+  pollTimer = setInterval(pushStatus, POLL_INTERVAL_MS);
+}
+
+function stopWatching() {
+  if (pollTimer) clearInterval(pollTimer);
+  pollTimer = null;
+  currentProjectPath = null;
+  lastSerialized = null;
+}
+
+async function pushStatus() {
+  const projectPath = currentProjectPath;
+  if (!projectPath || !mainWindow || mainWindow.isDestroyed()) return;
+
+  const result = await readGitStatus(projectPath);
+
+  // Skip if status is identical to the last push (avoids needless renderer work)
+  const serialized = JSON.stringify(result);
+  if (serialized === lastSerialized) return;
+  lastSerialized = serialized;
+
+  mainWindow.webContents.send(IPC.GIT_STATUS_DATA, {
+    projectPath,
+    isRepo: result.isRepo,
+    files: result.files
+  });
+}
+
+function readGitStatus(projectPath) {
+  return new Promise((resolve) => {
+    execFile(
+      'git',
+      ['status', '--porcelain=v1', '-z', '--untracked-files=all'],
+      { cwd: projectPath, maxBuffer: MAX_BUFFER },
+      (err, stdout) => {
+        if (err) {
+          resolve({ isRepo: false, files: {} });
+          return;
+        }
+        resolve({ isRepo: true, files: parsePorcelainV1(stdout) });
+      }
+    );
+  });
+}
+
+/**
+ * Parse `git status --porcelain=v1 -z` output.
+ * Format: "XY <path>\0" with renamed/copied entries adding "<oldpath>\0" after.
+ */
+function parsePorcelainV1(stdout) {
+  const files = {};
+  if (!stdout) return files;
+
+  const entries = stdout.split('\0');
+  let i = 0;
+  while (i < entries.length) {
+    const entry = entries[i];
+    if (!entry || entry.length < 3) {
+      i++;
+      continue;
+    }
+    const indexStatus = entry[0];
+    const worktreeStatus = entry[1];
+    const filename = entry.substring(3);
+
+    files[filename] = {
+      index: indexStatus,
+      worktree: worktreeStatus,
+      classification: classify(indexStatus, worktreeStatus)
+    };
+
+    // Renamed (R) and copied (C) entries are followed by the original name.
+    if (indexStatus === 'R' || indexStatus === 'C') {
+      i += 2;
+    } else {
+      i++;
+    }
+  }
+
+  return files;
+}
+
+/**
+ * Reduce two-character status to a single classification useful for UI styling.
+ * Order matters: conflicts and stages take precedence over modifications.
+ */
+function classify(index, worktree) {
+  if (index === '?' && worktree === '?') return 'untracked';
+  if (index === '!' && worktree === '!') return 'ignored';
+
+  // Conflicts: any U marker, or AA/DD per git status docs
+  if (
+    index === 'U' ||
+    worktree === 'U' ||
+    (index === 'A' && worktree === 'A') ||
+    (index === 'D' && worktree === 'D')
+  ) {
+    return 'conflict';
+  }
+
+  // Index has changes (staged) — check first because staged additions matter
+  if (index === 'A') return 'added';
+  if (index === 'R') return 'renamed';
+  if (index === 'D' && worktree !== 'D') return 'deleted';
+
+  // Worktree-only deletion
+  if (worktree === 'D') return 'deleted';
+
+  // Anything else with M is modified
+  if (index === 'M' || worktree === 'M') return 'modified';
+
+  return 'modified';
+}
+
+module.exports = { init, setupIPC };

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -27,6 +27,7 @@ const aiToolManager = require('./aiToolManager');
 const claudeSessionsManager = require('./claudeSessionsManager');
 const updateChecker = require('./updateChecker');
 const userSettings = require('./userSettings');
+const gitStatusManager = require('./gitStatusManager');
 
 let mainWindow = null;
 
@@ -107,6 +108,9 @@ function setupAllIPC() {
   ipcMain.handle(IPC.GET_USER_SETTING, (event, key) => userSettings.get(key));
   ipcMain.handle(IPC.SET_USER_SETTING, (event, key, value) => userSettings.set(key, value));
 
+  // Git status (file tree decoration polling)
+  gitStatusManager.setupIPC(ipcMain);
+
   // Terminal input handler (needs prompt logger integration)
   ipcMain.on(IPC.TERMINAL_INPUT, (event, data) => {
     pty.writeToPTY(data);
@@ -142,6 +146,7 @@ function initModulesWithWindow(window) {
   overviewManager.init(window);
   gitBranchesManager.init(window);
   claudeSessionsManager.init(window);
+  gitStatusManager.init(window);
 }
 
 // App lifecycle

--- a/src/renderer/fileTreeUI.js
+++ b/src/renderer/fileTreeUI.js
@@ -21,6 +21,20 @@ let currentQuery = '';
 let contextMenuEl = null;
 let contextMenuPath = null;
 
+// Git status decoration cache (relative path -> classification)
+let gitStatusFiles = {};
+let gitStatusProjectPath = null;
+const GIT_STATUS_CLASSES = [
+  'git-modified',
+  'git-added',
+  'git-untracked',
+  'git-deleted',
+  'git-renamed',
+  'git-conflict',
+  'git-ignored',
+  'git-has-changes'
+];
+
 /**
  * Initialize file tree UI
  */
@@ -149,6 +163,9 @@ function clearFileTree() {
   if (fileTreeElement) {
     fileTreeElement.innerHTML = '';
   }
+  gitStatusFiles = {};
+  gitStatusProjectPath = null;
+  ipcRenderer.send(IPC.UNWATCH_GIT_STATUS);
 }
 
 /**
@@ -166,6 +183,7 @@ function refreshFileTree(projectPath) {
  */
 function loadFileTree(projectPath) {
   ipcRenderer.send(IPC.LOAD_FILE_TREE, projectPath);
+  ipcRenderer.send(IPC.WATCH_GIT_STATUS, projectPath);
 }
 
 /**
@@ -177,6 +195,15 @@ function setupIPC() {
     renderFileTree(files, fileTreeElement);
     // Re-apply any active search filter to the new tree
     if (currentQuery) applyFilter(currentQuery);
+    // Re-apply git decoration to the new tree
+    applyGitStatusDecoration();
+  });
+
+  ipcRenderer.on(IPC.GIT_STATUS_DATA, (event, payload) => {
+    if (!payload) return;
+    gitStatusProjectPath = payload.projectPath;
+    gitStatusFiles = payload.isRepo ? (payload.files || {}) : {};
+    applyGitStatusDecoration();
   });
 }
 
@@ -426,6 +453,59 @@ function handleContextMenuAction(action) {
       console.error('Failed to copy filepath', e);
     }
   }
+}
+
+/* ──────────────────────── Git status decoration ──────────────────────── */
+
+/**
+ * Walk every rendered .file-item and apply the git status class matching its
+ * path in the cached status map. Then roll changes up to ancestor folders
+ * via a simple second pass.
+ */
+function applyGitStatusDecoration() {
+  if (!fileTreeElement) return;
+
+  const items = fileTreeElement.querySelectorAll('.file-item');
+  // First pass: clear old classes and apply file-level classification
+  items.forEach((item) => {
+    GIT_STATUS_CLASSES.forEach((cls) => item.classList.remove(cls));
+  });
+
+  if (!gitStatusProjectPath || Object.keys(gitStatusFiles).length === 0) {
+    return;
+  }
+
+  const projectPrefix = gitStatusProjectPath.endsWith('/')
+    ? gitStatusProjectPath
+    : gitStatusProjectPath + '/';
+
+  items.forEach((item) => {
+    if (item.classList.contains('folder')) return;
+    const abs = item.dataset.path;
+    if (!abs || !abs.startsWith(projectPrefix)) return;
+    const rel = abs.substring(projectPrefix.length);
+    const entry = gitStatusFiles[rel];
+    if (!entry) return;
+    const cls = `git-${entry.classification}`;
+    if (GIT_STATUS_CLASSES.includes(cls)) {
+      item.classList.add(cls);
+    }
+  });
+
+  // Second pass: roll up changes to ancestor folder items.
+  const changedItems = fileTreeElement.querySelectorAll(
+    '.file-item.git-modified, .file-item.git-added, .file-item.git-untracked, .file-item.git-deleted, .file-item.git-renamed, .file-item.git-conflict'
+  );
+  changedItems.forEach((item) => {
+    let parent = item.parentElement; // wrapper
+    while (parent && parent !== fileTreeElement) {
+      if (parent.classList && parent.classList.contains('file-wrapper')) {
+        const folderItem = parent.querySelector(':scope > .file-item.folder');
+        if (folderItem) folderItem.classList.add('git-has-changes');
+      }
+      parent = parent.parentElement;
+    }
+  });
 }
 
 module.exports = {

--- a/src/renderer/styles/components/file-tree.css
+++ b/src/renderer/styles/components/file-tree.css
@@ -103,3 +103,66 @@
   outline: none;
   background: var(--accent-subtle);
 }
+
+/* ───────── Git status decoration ───────── */
+
+/* Color tokens — reused for both file-item and inherited folder rollup */
+.file-item.git-modified .file-icon + span {
+  color: #d4a85e; /* warm amber — modified */
+}
+
+.file-item.git-added .file-icon + span {
+  color: #6fbf73; /* green — staged add */
+}
+
+.file-item.git-untracked .file-icon + span {
+  color: #5a9c6e; /* muted green — new untracked */
+}
+
+.file-item.git-deleted .file-icon + span {
+  color: #c97070; /* dim red — deleted */
+  text-decoration: line-through;
+  text-decoration-color: rgba(201, 112, 112, 0.5);
+}
+
+.file-item.git-renamed .file-icon + span {
+  color: #7da9d4; /* blue — renamed */
+}
+
+.file-item.git-conflict .file-icon + span {
+  color: #e26565; /* strong red — conflict */
+  font-weight: 600;
+}
+
+/* Folder rollup — softer hint that something changed inside */
+.file-item.folder.git-has-changes > .folder-arrow,
+.file-item.folder.git-has-changes > .file-icon,
+.file-item.folder.git-has-changes > span:last-child {
+  color: #d4a85e;
+}
+
+/* Light theme overrides — slightly darker so contrast survives */
+body.light-theme .file-item.git-modified .file-icon + span,
+body.theme-light .file-item.git-modified .file-icon + span {
+  color: #b07820;
+}
+body.light-theme .file-item.git-untracked .file-icon + span,
+body.theme-light .file-item.git-untracked .file-icon + span {
+  color: #2f7a4a;
+}
+body.light-theme .file-item.git-added .file-icon + span,
+body.theme-light .file-item.git-added .file-icon + span {
+  color: #2a8d3a;
+}
+body.light-theme .file-item.git-deleted .file-icon + span,
+body.theme-light .file-item.git-deleted .file-icon + span {
+  color: #a23b3b;
+}
+body.light-theme .file-item.git-conflict .file-icon + span,
+body.theme-light .file-item.git-conflict .file-icon + span {
+  color: #b62a2a;
+}
+body.light-theme .file-item.folder.git-has-changes > span:last-child,
+body.theme-light .file-item.folder.git-has-changes > span:last-child {
+  color: #b07820;
+}

--- a/src/shared/ipcChannels.js
+++ b/src/shared/ipcChannels.js
@@ -122,7 +122,12 @@ const IPC = {
 
   // User Settings (renderer-side preferences persisted to userData JSON)
   GET_USER_SETTING: 'get-user-setting',
-  SET_USER_SETTING: 'set-user-setting'
+  SET_USER_SETTING: 'set-user-setting',
+
+  // Git Status (file tree decoration)
+  WATCH_GIT_STATUS: 'watch-git-status',
+  UNWATCH_GIT_STATUS: 'unwatch-git-status',
+  GIT_STATUS_DATA: 'git-status-data'
 };
 
 module.exports = { IPC };

--- a/tasks.json
+++ b/tasks.json
@@ -39,18 +39,6 @@
         "completedAt": null
       },
       {
-        "id": "task-m2",
-        "title": "Git status integration",
-        "description": "Show git status, diff in the UI",
-        "status": "pending",
-        "priority": "high",
-        "category": "feature",
-        "context": "todos.json - mediumTerm",
-        "createdAt": "2026-01-21T00:00:00Z",
-        "updatedAt": "2026-01-24T16:30:00Z",
-        "completedAt": null
-      },
-      {
         "id": "task-m6",
         "title": "Claude Code chat sidebar",
         "description": "Dedicated UI for Claude Code interactions",
@@ -486,6 +474,21 @@
       }
     ],
     "completed": [
+      {
+        "id": "task-m2",
+        "title": "Git status integration (file tree decoration)",
+        "description": "v1: decorate the sidebar file tree with git status colors. New gitStatusManager (main) runs `git status --porcelain=v1 -z` for the active project on a 5s poll, parses output, pushes to renderer via GIT_STATUS_DATA. Renderer maps each file's relative path to a status classification (modified / added / untracked / deleted / renamed / conflict / ignored) and applies a CSS class to the .file-item. Folders containing any changed descendant get a 'git-has-changes' rollup class. Diff viewer, staged-files panel, and stage/discard actions are explicitly out of scope for v1 — they are v2.",
+        "userRequest": "User said: task m2 çok eklenmesi gerekli bir özellik ya, istersen onları da ekleyelim — 2026-04-28.",
+        "acceptanceCriteria": "File tree shows colored decorations matching git status; folder rollup works; status refreshes every ~5s; non-git projects render unchanged; switching projects updates the watch target.",
+        "notes": "Polling chosen over fs.watch for v1 simplicity. Diff viewer + Changes panel deferred to v2. Visual style is colored text only (VSCode pattern), no badges, to keep tree clean. Identical pushes are de-duplicated to avoid renderer churn.",
+        "status": "completed",
+        "priority": "high",
+        "category": "feature",
+        "context": "Session 2026-04-28 - Git status integration v1",
+        "createdAt": "2026-01-21T00:00:00Z",
+        "updatedAt": "2026-04-28T13:00:00Z",
+        "completedAt": "2026-04-28T13:00:00Z"
+      },
       {
         "id": "task-filetree-search",
         "title": "Filter input in file tree (substring match)",


### PR DESCRIPTION
## Summary
v1 of `task-m2` — surface git state visually in the sidebar file tree so users don't have to keep typing `git status` in the terminal.

**v1 scope:** colored decorations on file/folder names. **Out of scope (v2):** diff viewer, dedicated "Changes" panel, stage/discard actions.

## How it works

**Backend (`src/main/gitStatusManager.js`, new):**
- Runs `git status --porcelain=v1 -z --untracked-files=all` against the active project every **5 seconds**
- Parses two-character `XY` output into a single classification per file: `modified`, `added`, `untracked`, `deleted`, `renamed`, `conflict`, `ignored`
- De-duplicates identical pushes (`JSON.stringify` compare) so renderer doesn't churn when nothing changed
- Non-git projects gracefully resolve to `{ isRepo: false, files: {} }` → no decoration applied
- IPC: `WATCH_GIT_STATUS(projectPath)` / `UNWATCH_GIT_STATUS()` / `GIT_STATUS_DATA` push

**Renderer (`src/renderer/fileTreeUI.js`):**
- Subscribes to `GIT_STATUS_DATA`, caches latest map
- `applyGitStatusDecoration()` runs on every status push and after every tree render — looks up each file's relative path in the cache and applies a `git-<classification>` class
- Folder rollup: a second pass walks ancestors of every changed file and adds `git-has-changes` so users see activity at a glance even with the folder collapsed
- `loadFileTree` starts the watcher, `clearFileTree` stops it

## Visual style

Colored text only (VSCode pattern), no badge letters — keeps the tree uncluttered.

| Status | Dark theme | Light theme |
|---|---|---|
| Modified | Amber | Darker amber |
| Staged add | Green | Darker green |
| Untracked | Muted green | Forest green |
| Deleted | Dim red + strikethrough | Darker red + strikethrough |
| Renamed | Blue | (inherits dark style) |
| Conflict | Bold red | Bold red |
| Folder rollup | Amber (folder name) | Darker amber |

## Files

| File | Change |
|---|---|
| `src/main/gitStatusManager.js` | new — polling, parse, push |
| `src/main/index.js` | init + IPC bind |
| `src/shared/ipcChannels.js` | `WATCH_GIT_STATUS`, `UNWATCH_GIT_STATUS`, `GIT_STATUS_DATA` |
| `src/renderer/fileTreeUI.js` | listener, `applyGitStatusDecoration`, folder rollup, watch lifecycle |
| `src/renderer/styles/components/file-tree.css` | git status color rules (dark + light) |

## Test plan

### macOS (verified locally)
- [x] Modified files show amber in the tree
- [x] Containing folders show amber name (rollup)
- [x] `git add <file>` → file turns green within ~5s
- [x] `git checkout <file>` → decoration clears
- [x] Touch a new file → appears as untracked green within ~5s
- [x] Non-git project → no decorations, no errors
- [x] Switching projects updates the watch target

### Windows
- [ ] Smoke — `git` resolves on PATH, decorations appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)