### PR TITLE
feat: sidebar footer update banner (v2.1.1)

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -793,18 +793,18 @@
           "purpose": "Setup button click handlers"
         },
         "setupUpdateDot": {
-          "line": 270,
-          "purpose": "existing terminal tab bell which opens the GitHub release page directly."
+          "line": 272,
+          "purpose": "→ About → \"Dismiss this version\"). Both click open Settings → About."
         },
         "revealSidebarTab": {
-          "line": 293,
+          "line": 303,
           "params": [
             "tabName"
           ],
           "purpose": "commands so they don't try to focus an element inside a hidden container."
         },
         "registerCommands": {
-          "line": 311,
+          "line": 321,
           "purpose": "Command Palette and the global keyboard handler."
         }
       },
@@ -4102,22 +4102,22 @@
           "line": 209
         },
         "formatRelative": {
-          "line": 214,
+          "line": 216,
           "params": [
             "date"
           ]
         },
         "syncToggleFromSettings": {
-          "line": 225
+          "line": 227
         },
         "open": {
-          "line": 232
+          "line": 234
         },
         "close": {
-          "line": 239
+          "line": 241
         },
         "toggle": {
-          "line": 246
+          "line": 248
         }
       },
       "ipc": {

--- a/index.html
+++ b/index.html
@@ -141,6 +141,22 @@
         <!-- File tree will be populated here -->
       </div>
     </div>
+
+    <!-- Update Available Banner (sidebar footer) -->
+    <button
+      type="button"
+      id="sidebar-update-banner"
+      class="sidebar-update-banner"
+      style="display:none;"
+      aria-label="Update available, click to view details"
+    >
+      <span class="sidebar-update-banner-icon">&uarr;</span>
+      <span class="sidebar-update-banner-text">
+        <span class="sidebar-update-banner-title">New version available</span>
+        <span class="sidebar-update-banner-version" id="sidebar-update-banner-version">v0.0.0</span>
+      </span>
+      <span class="sidebar-update-banner-arrow">&rarr;</span>
+    </button>
   </div>
 
   <!-- Main Content Area -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frame",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frame",
-      "version": "2.1.0",
+      "version": "2.1.1",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frame",
   "productName": "Frame",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Frame - Project Management IDE for Claude Code",
   "main": "src/main/index.js",
   "scripts": {

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -262,14 +262,17 @@ function setupButtonHandlers() {
 }
 
 /**
- * Show a small notification dot in the sidebar header when an update is
- * available. Hidden when the user has dismissed the same version. Click
- * opens Settings — sidebar dot routes to About details, complementing the
- * existing terminal tab bell which opens the GitHub release page directly.
+ * Show update indicators when a new version is available:
+ * - Small pulsing dot in the sidebar header (peripheral signal)
+ * - Sidebar footer banner with version + arrow (primary, click-to-act signal)
+ *
+ * Both are hidden when the user has dismissed that same version (Settings
+ * → About → "Dismiss this version"). Both click open Settings → About.
  */
 function setupUpdateDot() {
   const dot = document.getElementById('update-dot');
-  if (!dot) return;
+  const banner = document.getElementById('sidebar-update-banner');
+  const bannerVersionEl = document.getElementById('sidebar-update-banner-version');
 
   ipcRenderer.on(IPC.UPDATE_AVAILABLE, async (event, info) => {
     if (!info || !info.latestVersion) return;
@@ -278,12 +281,19 @@ function setupUpdateDot() {
       'dismissedUpdateVersion'
     );
     if (dismissed === info.latestVersion) return;
-    dot.style.display = '';
+    if (dot) dot.style.display = '';
+    if (banner) {
+      if (bannerVersionEl) bannerVersionEl.textContent = `v${info.latestVersion}`;
+      banner.style.display = '';
+    }
   });
 
-  dot.addEventListener('click', () => {
-    settingsModal.open();
-  });
+  if (dot) {
+    dot.addEventListener('click', () => settingsModal.open());
+  }
+  if (banner) {
+    banner.addEventListener('click', () => settingsModal.open());
+  }
 }
 
 /**

--- a/src/renderer/settingsModal.js
+++ b/src/renderer/settingsModal.js
@@ -209,6 +209,8 @@ function hideUpdateBanner() {
 function hideSidebarDot() {
   const dot = document.getElementById('update-dot');
   if (dot) dot.style.display = 'none';
+  const banner = document.getElementById('sidebar-update-banner');
+  if (banner) banner.style.display = 'none';
 }
 
 function formatRelative(date) {

--- a/src/renderer/styles/layout.css
+++ b/src/renderer/styles/layout.css
@@ -120,6 +120,80 @@ body.sidebar-resizing * {
   50% { opacity: 0.45; }
 }
 
+/* Update banner — sidebar footer card, primary signal when an update is available */
+.sidebar-update-banner {
+  flex-shrink: 0;
+  margin-top: var(--space-md);
+  padding: 10px 12px;
+  background: var(--accent-subtle);
+  border: 1px solid var(--accent-primary);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-family: inherit;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  text-align: left;
+  width: 100%;
+  box-sizing: border-box;
+  transition: background 0.14s, border-color 0.14s, transform 0.08s;
+  animation: sidebar-update-pulse 2.6s ease-in-out infinite;
+}
+
+.sidebar-update-banner:hover {
+  background: var(--accent-glow);
+  border-color: var(--accent-secondary);
+}
+
+.sidebar-update-banner:active {
+  transform: scale(0.98);
+}
+
+.sidebar-update-banner-icon {
+  font-size: 14px;
+  color: var(--accent-primary);
+  font-weight: 700;
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+.sidebar-update-banner-text {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  overflow: hidden;
+}
+
+.sidebar-update-banner-title {
+  font-size: 12px;
+  color: var(--accent-primary);
+  font-weight: 500;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.sidebar-update-banner-version {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.sidebar-update-banner-arrow {
+  font-size: 14px;
+  color: var(--accent-primary);
+  flex-shrink: 0;
+  line-height: 1;
+}
+
+@keyframes sidebar-update-pulse {
+  0%, 100% { box-shadow: 0 0 0 0 var(--accent-glow); }
+  50% { box-shadow: 0 0 14px 2px var(--accent-glow); }
+}
+
 #sidebar-header::before {
   content: '';
   width: 8px;


### PR DESCRIPTION
## Summary
The sidebar header dot was too subtle — users barely notice there's an update available. Add a more explicit **"New version available"** card pinned to the bottom of the sidebar.

## What changed

- **Sidebar footer card** — pulsing accent-colored, up-arrow icon, title, version string (e.g. `v2.1.1`), arrow affordance
- **Click opens Settings → About** (same target as the existing header dot)
- **Hidden when dismissed** — shares the `dismissedUpdateVersion` flag with the dot
- **Dismissing in Settings hides both** — single "Dismiss this version" action clears both indicators
- **Header dot stays** as peripheral signal; banner is the primary click-to-act signal at different visual weight

Verified locally by temporarily downgrading `package.json` to 2.0.5, running `npm start`, and observing both indicators light up against the live v2.1.0 release.

## Files

| File | Change |
|---|---|
| `index.html` | Banner markup at the bottom of `#sidebar` |
| `src/renderer/styles/layout.css` | Banner styles + glow pulse keyframes |
| `src/renderer/index.js` | `setupUpdateDot` extended to also manage banner |
| `src/renderer/settingsModal.js` | `hideSidebarDot` now hides banner too |
| `package.json` / `package-lock.json` | Bump to 2.1.1 |

## Test plan
- [x] Banner appears in sidebar footer when an update is available
- [x] Click opens Settings → About
- [x] Subtle pulsing glow (every 2.6s) — visible but not distracting
- [x] Hover state: background fills with `accent-glow`
- [x] Dismissing in Settings hides both dot and banner
- [x] Banner version string shows the latest version, not the current one
- [ ] Windows: banner renders correctly with platform-correct fonts

🤖 Generated with [Claude Code](https://claude.com/claude-code)