### PR TITLE
fix: initialize Aptabase before app.whenReady (v2.1.2)

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -4032,22 +4032,22 @@
       ],
       "functions": {
         "init": {
-          "line": 26,
-          "purpose": "boot — no events are sent until trackAppStarted() runs."
+          "line": 31,
+          "purpose": "the chicken-and-egg with userSettings (which loads after app.whenReady)."
         },
         "trackAppStarted": {
-          "line": 41,
+          "line": 45,
           "purpose": "or not initialized."
         },
         "setEnabled": {
-          "line": 54,
+          "line": 58,
           "params": [
             "enabled"
           ],
-          "purpose": "initializes Aptabase if the user just turned it on."
+          "purpose": "already initialized on boot; flipping this flag just gates trackEvent."
         },
         "isEnabled": {
-          "line": 67,
+          "line": 68,
           "purpose": "touched (opt-out semantics)."
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "frame",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "frame",
-      "version": "2.1.1",
+      "version": "2.1.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "frame",
   "productName": "Frame",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "description": "Frame - Project Management IDE for Claude Code",
   "main": "src/main/index.js",
   "scripts": {

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -134,9 +134,9 @@ function init() {
   // Initialize user settings (must run after app is ready so userData path resolves)
   userSettings.init();
 
-  // Initialize telemetry (no-op if user has opted out). Must run after
-  // userSettings so the enabled check has accurate state.
-  telemetry.init();
+  // Send the launch event after userSettings is loaded so the opt-out
+  // check uses the correct state. Aptabase itself was initialized earlier
+  // (before app.whenReady) — see app lifecycle below.
   telemetry.trackAppStarted();
 
   // Setup IPC handlers
@@ -159,6 +159,12 @@ function initModulesWithWindow(window) {
   claudeSessionsManager.init(window);
   gitStatusManager.init(window);
 }
+
+// Aptabase MUST be initialized before app.whenReady() because the SDK
+// internally calls protocol.registerSchemesAsPrivileged, which is only
+// allowed pre-ready. Initialization itself doesn't send anything; the
+// actual app_started event is fired from init() after userSettings loads.
+telemetry.init();
 
 // App lifecycle
 app.whenReady().then(() => {

--- a/src/main/telemetry.js
+++ b/src/main/telemetry.js
@@ -20,11 +20,15 @@ const ENABLED_KEY = 'telemetryEnabled';
 let initialized = false;
 
 /**
- * Initialize Aptabase if telemetry is enabled. Safe to call once on app
- * boot — no events are sent until trackAppStarted() runs.
+ * Initialize Aptabase. MUST be called before app.whenReady() because the
+ * SDK uses protocol.registerSchemesAsPrivileged internally.
+ *
+ * We always initialize (regardless of opt-out state) because the call has
+ * no network side-effects on its own — events only go out when trackEvent
+ * runs, and that path is gated by isEnabled(). Initializing eagerly avoids
+ * the chicken-and-egg with userSettings (which loads after app.whenReady).
  */
 function init() {
-  if (!isEnabled()) return;
   if (initialized) return;
   try {
     aptabase.initialize(APTABASE_APP_KEY);
@@ -48,15 +52,12 @@ function trackAppStarted() {
 }
 
 /**
- * Toggle telemetry from Settings. Persists the new state and lazily
- * initializes Aptabase if the user just turned it on.
+ * Toggle telemetry from Settings. Persists the new state. Aptabase is
+ * already initialized on boot; flipping this flag just gates trackEvent.
  */
 function setEnabled(enabled) {
   const value = enabled === true;
   userSettings.set(ENABLED_KEY, value);
-  if (value && !initialized) {
-    init();
-  }
   return value;
 }
 


### PR DESCRIPTION
## Summary
**Critical fix.** The Aptabase Electron SDK silently disabled itself in v2.1.0 and v2.1.1 — zero events ever reached the dashboard, including for me as the maintainer.

## Root cause
The Aptabase SDK internally calls `protocol.registerSchemesAsPrivileged`, which is only allowed **before** the app is ready. Our `telemetry.init()` lived inside the `app.whenReady().then()` callback, so by the time it ran, the privileged-scheme registration was rejected. The SDK printed a console warning ("`initialize` must be invoked before the app is ready. Tracking will be disabled.") that nobody saw because DevTools wasn't open.

## Fix

- **`telemetry.init()` is now called at module top level**, before `app.whenReady()`. The SDK's pre-ready setup runs at the right time. No network call happens at init — that's still gated by the opt-out check on `trackEvent`.
- The actual `app_started` event still fires from inside `init()` after `userSettings` loads, so the opt-out check uses the user's persisted preference.
- `setEnabled()` no longer lazily re-initializes Aptabase. It's always initialized on boot; the toggle only gates `trackEvent`.

## Verification

Locally tested: launched app, opened Aptabase dashboard, my session shows up with the expected app version and platform. Working as designed.

## Files

| File | Change |
|---|---|
| `src/main/telemetry.js` | `init()` no longer gated on opt-out; `setEnabled` simplified |
| `src/main/index.js` | `telemetry.init()` moved above `app.whenReady`; `init()` only fires `trackAppStarted()` |
| `package.json` / `package-lock.json` | Bump to 2.1.2 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)