### PR TITLE
feat: spec-driven dev — Tasks subview + full-page Dashboard + resizable panel (Slice 2.1)

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Auto-generated module structure",
-  "lastUpdated": "2026-04-30",
+  "lastUpdated": "2026-05-01",
   "architecture": {},
   "modules": {
     "main/aiToolManager": {
@@ -1440,56 +1440,56 @@
       ],
       "functions": {
         "getSpecsRoot": {
-          "line": 39,
+          "line": 41,
           "params": [
             "projectPath"
           ],
           "purpose": "─── Path helpers ──────────────────────────────────────────"
         },
         "getSpecDir": {
-          "line": 43,
+          "line": 45,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "generateSlug": {
-          "line": 52,
+          "line": 54,
           "params": [
             "title"
           ],
           "purpose": "`-2`, `-3`, ... suffixes. See PROJECT_NOTES.md for the canonical rules."
         },
         "uniqueSlug": {
-          "line": 65,
+          "line": 67,
           "params": [
             "projectPath",
             "baseSlug"
           ]
         },
         "validateSpecStatus": {
-          "line": 78,
+          "line": 80,
           "params": [
             "obj"
           ],
           "purpose": "Returns null when valid, or a human-readable reason string."
         },
         "readFileSafe": {
-          "line": 97,
+          "line": 99,
           "params": [
             "p"
           ],
           "purpose": "─── Filesystem helpers ────────────────────────────────────"
         },
         "readStatus": {
-          "line": 106,
+          "line": 108,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "writeStatus": {
-          "line": 117,
+          "line": 119,
           "params": [
             "projectPath",
             "slug",
@@ -1497,14 +1497,14 @@
           ]
         },
         "listSpecs": {
-          "line": 125,
+          "line": 127,
           "params": [
             "projectPath"
           ],
           "purpose": "─── Public API ────────────────────────────────────────────"
         },
         "fileExists": {
-          "line": 164,
+          "line": 182,
           "params": [
             "projectPath",
             "slug",
@@ -1513,29 +1513,38 @@
           "purpose": "rely on that — defense in depth."
         },
         "derivePhase": {
-          "line": 168,
+          "line": 186,
           "params": [
             "projectPath",
             "slug",
-            "currentPhase"
+            "currentPhase",
+            "tasksDataOrNull"
+          ]
+        },
+        "collectSpecTasks": {
+          "line": 205,
+          "params": [
+            "slug",
+            "tasksData"
           ]
         },
         "reconcilePhase": {
-          "line": 178,
+          "line": 211,
           "params": [
             "projectPath",
-            "slug"
+            "slug",
+            "tasksDataOrNull"
           ]
         },
         "getDefaultTemplatePath": {
-          "line": 202,
+          "line": 235,
           "params": [
             "aiTool",
             "command"
           ]
         },
         "getOverrideTemplatePath": {
-          "line": 206,
+          "line": 239,
           "params": [
             "projectPath",
             "aiTool",
@@ -1543,7 +1552,7 @@
           ]
         },
         "loadCommandTemplate": {
-          "line": 210,
+          "line": 243,
           "params": [
             "projectPath",
             "aiTool",
@@ -1551,14 +1560,14 @@
           ]
         },
         "interpolate": {
-          "line": 216,
+          "line": 249,
           "params": [
             "template",
             "vars"
           ]
         },
         "getCommandPrompt": {
-          "line": 223,
+          "line": 256,
           "params": [
             "projectPath",
             "slug",
@@ -1567,7 +1576,7 @@
           ]
         },
         "buildSpecCommandFile": {
-          "line": 250,
+          "line": 283,
           "params": [
             "projectPath",
             "slug",
@@ -1576,47 +1585,47 @@
           ]
         },
         "parseTasksMarkdown": {
-          "line": 278,
+          "line": 311,
           "params": [
             "content"
           ]
         },
         "syncTasksFromMarkdown": {
-          "line": 291,
+          "line": 324,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "arraysEqual": {
-          "line": 371,
+          "line": 404,
           "params": [
             "a",
             "b"
           ]
         },
         "syncAllSpecTasks": {
-          "line": 378,
+          "line": 411,
           "params": [
             "projectPath"
           ]
         },
         "getSpec": {
-          "line": 395,
+          "line": 428,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "createSpec": {
-          "line": 408,
+          "line": 441,
           "params": [
             "projectPath",
             "opts"
           ]
         },
         "updateSpecStatus": {
-          "line": 444,
+          "line": 477,
           "params": [
             "projectPath",
             "slug",
@@ -1624,37 +1633,37 @@
           ]
         },
         "deleteSpec": {
-          "line": 462,
+          "line": 495,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "startWatching": {
-          "line": 475,
+          "line": 508,
           "params": [
             "projectPath"
           ],
           "purpose": "across all three platforms — if that ever changes, swap in a poller."
         },
         "stopWatching": {
-          "line": 500
+          "line": 550
         },
         "pushSpecData": {
-          "line": 512,
+          "line": 570,
           "params": [
             "projectPath"
           ]
         },
         "init": {
-          "line": 523,
+          "line": 581,
           "params": [
             "window"
           ],
           "purpose": "─── Init + IPC ────────────────────────────────────────────"
         },
         "setupIPC": {
-          "line": 527,
+          "line": 585,
           "params": [
             "ipcMain"
           ]
@@ -2840,6 +2849,8 @@
         "githubPanel",
         "promptsPanel",
         "specPanel",
+        "specPanelResize",
+        "specsDashboard",
         "state",
         "projectListUI",
         "editor",
@@ -2856,26 +2867,26 @@
       ],
       "functions": {
         "init": {
-          "line": 35,
+          "line": 37,
           "purpose": "Initialize all modules"
         },
         "setupButtonHandlers": {
-          "line": 181,
+          "line": 187,
           "purpose": "Setup button click handlers"
         },
         "setupUpdateDot": {
-          "line": 292,
+          "line": 298,
           "purpose": "→ About → \"Dismiss this version\"). Both click open Settings → About."
         },
         "revealSidebarTab": {
-          "line": 323,
+          "line": 329,
           "params": [
             "tabName"
           ],
           "purpose": "commands so they don't try to focus an element inside a hidden container."
         },
         "registerCommands": {
-          "line": 341,
+          "line": 347,
           "purpose": "Command Palette and the global keyboard handler."
         }
       },
@@ -3587,156 +3598,186 @@
         "hide",
         "toggle",
         "startWatchingForProject",
-        "stopWatching"
+        "stopWatching",
+        "showNewSpecPrompt"
       ],
       "depends": [
         "electron",
         "marked",
         "shared/ipcChannels",
-        "state"
+        "state",
+        "specsDashboard"
       ],
       "functions": {
         "init": {
-          "line": 29
+          "line": 30
         },
         "setupEventListeners": {
-          "line": 40
+          "line": 41
         },
         "setupIPCListeners": {
-          "line": 46
+          "line": 50
         },
         "show": {
-          "line": 58,
+          "line": 79,
           "purpose": "─── Visibility ─────────────────────────────────────"
         },
         "hide": {
-          "line": 66
+          "line": 87
         },
         "toggle": {
-          "line": 75,
+          "line": 96,
           "purpose": "instead of opening the panel — keeping the workflow opt-in."
         },
         "startWatchingForProject": {
-          "line": 93,
+          "line": 114,
           "params": [
             "projectPath"
           ],
           "purpose": "─── Watch lifecycle ────────────────────────────────"
         },
         "stopWatching": {
-          "line": 98
+          "line": 123
         },
         "renderList": {
-          "line": 104,
+          "line": 130,
           "purpose": "─── List view ──────────────────────────────────────"
         },
         "renderSpecRow": {
-          "line": 135,
+          "line": 161,
           "params": [
             "spec"
           ]
         },
         "openDetail": {
-          "line": 155,
+          "line": 181,
           "params": [
             "slug"
           ],
           "purpose": "─── Detail view ────────────────────────────────────"
         },
         "reloadDetail": {
-          "line": 161
+          "line": 187
         },
         "renderDetail": {
-          "line": 169
+          "line": 195
         },
         "nextActionForPhase": {
-          "line": 223,
+          "line": 250,
           "params": [
             "phase"
           ],
           "purpose": "AI tool is running) can produce the next artifact."
         },
         "renderNextActionBar": {
-          "line": 236,
+          "line": 263,
           "params": [
             "action"
           ]
         },
         "runSpecCommand": {
-          "line": 250,
+          "line": 277,
           "params": [
             "command"
           ]
         },
         "renderTabButton": {
-          "line": 279,
+          "line": 306,
           "params": [
             "tab",
             "label",
             "hasContent"
           ]
         },
+        "hasSpecTasks": {
+          "line": 312
+        },
+        "tasksTabLabel": {
+          "line": 318,
+          "params": [
+            "hasMarkdown"
+          ]
+        },
         "renderTabBody": {
-          "line": 285,
+          "line": 327,
           "params": [
             "tab"
           ]
         },
+        "renderTasksTabBody": {
+          "line": 340
+        },
+        "renderSpecTaskRow": {
+          "line": 380,
+          "params": [
+            "task"
+          ]
+        },
+        "attachTaskActionHandlers": {
+          "line": 429
+        },
+        "handleSpecTaskAction": {
+          "line": 442,
+          "params": [
+            "taskId",
+            "action"
+          ]
+        },
         "switchTab": {
-          "line": 292,
+          "line": 461,
           "params": [
             "tab"
           ]
         },
         "backToList": {
-          "line": 301
+          "line": 471
         },
         "showNewSpecPrompt": {
-          "line": 316,
+          "line": 486,
           "purpose": "`window.prompt` is blocked in Electron's renderer."
         },
         "parseTitleAndBody": {
-          "line": 404,
+          "line": 574,
           "params": [
             "raw"
           ],
           "purpose": "matter."
         },
         "deriveSlugPreview": {
-          "line": 418,
+          "line": 588,
           "params": [
             "title"
           ],
           "purpose": "can preview without a roundtrip. Keep in sync if the canonical changes."
         },
         "showSuggestionModal": {
-          "line": 436,
+          "line": 606,
           "params": [
             "projectPath"
           ],
           "purpose": "them turn it on or skip. Maximum friction: a one-time, dismissable modal."
         },
         "showInlineError": {
-          "line": 498,
+          "line": 668,
           "params": [
             "message"
           ]
         },
         "renderMarkdown": {
-          "line": 518,
+          "line": 688,
           "params": [
             "md"
           ],
           "purpose": "─── Helpers ────────────────────────────────────────"
         },
         "escapeHtml": {
-          "line": 528,
+          "line": 698,
           "params": [
             "s"
           ]
         },
         "relativeTime": {
-          "line": 538,
+          "line": 708,
           "params": [
             "iso"
           ]
@@ -3745,11 +3786,14 @@
       "ipc": {
         "listens": [
           "SPEC_DATA",
+          "TASKS_DATA",
           "TOGGLE_SPECS_PANEL"
         ],
         "emits": [
           "WATCH_SPECS",
-          "UNWATCH_SPECS"
+          "LOAD_TASKS",
+          "UNWATCH_SPECS",
+          "UPDATE_TASK"
         ]
       }
     },
@@ -4860,6 +4904,194 @@
       ],
       "depends": [],
       "functions": {}
+    },
+    "renderer/specsDashboard": {
+      "file": "src/renderer/specsDashboard.js",
+      "description": "Specs Dashboard Module",
+      "exports": [
+        "init",
+        "show",
+        "hide",
+        "toggle"
+      ],
+      "depends": [
+        "electron",
+        "marked",
+        "shared/ipcChannels",
+        "state",
+        "specPanel",
+        "taskInfoModal"
+      ],
+      "functions": {
+        "init": {
+          "line": 49
+        },
+        "setupIPCListeners": {
+          "line": 81
+        },
+        "show": {
+          "line": 107,
+          "purpose": "─── Visibility ──────────────────────────────────────────"
+        },
+        "hide": {
+          "line": 138
+        },
+        "toggle": {
+          "line": 145
+        },
+        "renderFilters": {
+          "line": 151,
+          "purpose": "─── Filters ─────────────────────────────────────────────"
+        },
+        "applyFilter": {
+          "line": 165,
+          "params": [
+            "specsList"
+          ]
+        },
+        "renderGrid": {
+          "line": 178,
+          "purpose": "─── Grid ────────────────────────────────────────────────"
+        },
+        "renderCard": {
+          "line": 206,
+          "params": [
+            "spec"
+          ]
+        },
+        "selectCard": {
+          "line": 237,
+          "params": [
+            "slug"
+          ],
+          "purpose": "─── Detail aside ───────────────────────────────────────"
+        },
+        "clearSelection": {
+          "line": 245
+        },
+        "reloadDetail": {
+          "line": 253
+        },
+        "renderDetailHeader": {
+          "line": 269
+        },
+        "tabBtn": {
+          "line": 303,
+          "params": [
+            "tab",
+            "label",
+            "hasContent"
+          ]
+        },
+        "renderDetailBody": {
+          "line": 309
+        },
+        "renderTasksTabBody": {
+          "line": 328
+        },
+        "renderSpecTaskRow": {
+          "line": 365,
+          "params": [
+            "task"
+          ]
+        },
+        "attachTaskActionHandlers": {
+          "line": 414
+        },
+        "handleSpecTaskAction": {
+          "line": 427,
+          "params": [
+            "taskId",
+            "action"
+          ]
+        },
+        "hasSpecTasks": {
+          "line": 438,
+          "purpose": "─── Helpers ────────────────────────────────────────────"
+        },
+        "tasksTabLabel": {
+          "line": 444,
+          "params": [
+            "hasMarkdown"
+          ]
+        },
+        "renderMarkdown": {
+          "line": 453,
+          "params": [
+            "md"
+          ]
+        },
+        "escapeHtml": {
+          "line": 458,
+          "params": [
+            "s"
+          ]
+        },
+        "relativeTime": {
+          "line": 464,
+          "params": [
+            "iso"
+          ]
+        },
+        "displayProjectName": {
+          "line": 475,
+          "params": [
+            "projectPath"
+          ]
+        }
+      },
+      "ipc": {
+        "listens": [
+          "SPEC_DATA",
+          "TASKS_DATA",
+          "TOGGLE_SPECS_DASHBOARD"
+        ],
+        "emits": [
+          "WATCH_SPECS",
+          "LOAD_TASKS",
+          "UPDATE_TASK"
+        ]
+      }
+    },
+    "renderer/specPanelResize": {
+      "file": "src/renderer/specPanelResize.js",
+      "description": "Specs Panel Resize Module",
+      "exports": [
+        "init",
+        "resetWidth",
+        "toggleWide"
+      ],
+      "depends": [],
+      "functions": {
+        "init": {
+          "line": 25
+        },
+        "onMouseDown": {
+          "line": 51,
+          "params": [
+            "e"
+          ]
+        },
+        "onMouseMove": {
+          "line": 60,
+          "params": [
+            "e"
+          ]
+        },
+        "onMouseUp": {
+          "line": 70
+        },
+        "resetWidth": {
+          "line": 79
+        },
+        "toggleWide": {
+          "line": 88,
+          "purpose": "preset wide width. Drag handle still works for fine-tuning."
+        },
+        "refreshToggleIcon": {
+          "line": 97
+        }
+      }
     }
   },
   "ipcChannels": {
@@ -5035,6 +5267,11 @@
       },
       "BUILD_SPEC_COMMAND_FILE": {
         "name": "build-spec-command-file",
+        "direction": "",
+        "description": ""
+      },
+      "TOGGLE_SPECS_DASHBOARD": {
+        "name": "toggle-specs-dashboard",
         "direction": "",
         "description": ""
       }
@@ -5649,6 +5886,20 @@
         "module": "renderer/specPanel",
         "file": "src/renderer/specPanel.js",
         "description": "Specs Panel Module"
+      }
+    ],
+    "spec-panel-resize": [
+      {
+        "module": "renderer/specPanelResize",
+        "file": "src/renderer/specPanelResize.js",
+        "description": "Specs Panel Resize Module"
+      }
+    ],
+    "specs-dashboard": [
+      {
+        "module": "renderer/specsDashboard",
+        "file": "src/renderer/specsDashboard.js",
+        "description": "Specs Dashboard Module"
       }
     ],
     "state": [

--- a/index.html
+++ b/index.html
@@ -218,6 +218,7 @@
 
     <!-- Specs Panel (spec-driven development, Slice 1) -->
     <div id="specs-panel">
+      <div id="specs-panel-resize-handle"></div>
       <div id="specs-header">
         <button id="specs-collapse-btn" title="Collapse panel">
           <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
@@ -226,6 +227,28 @@
         </button>
         <h3>Specs</h3>
         <div class="specs-header-actions">
+          <button id="specs-wide-toggle" tabindex="-1" title="Expand panel" aria-label="Expand panel">
+            <svg class="specs-wide-icon-expand" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="15 3 21 3 21 9"/>
+              <polyline points="9 21 3 21 3 15"/>
+              <line x1="21" y1="3" x2="14" y2="10"/>
+              <line x1="3" y1="21" x2="10" y2="14"/>
+            </svg>
+            <svg class="specs-wide-icon-compact" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <polyline points="4 14 10 14 10 20"/>
+              <polyline points="20 10 14 10 14 4"/>
+              <line x1="14" y1="10" x2="21" y2="3"/>
+              <line x1="3" y1="21" x2="10" y2="14"/>
+            </svg>
+          </button>
+          <button id="specs-dashboard-btn" tabindex="-1" title="Open spec dashboard">
+            <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <rect x="3" y="3" width="6" height="18" rx="1"/>
+              <rect x="11" y="3" width="6" height="12" rx="1"/>
+              <rect x="19" y="3" width="2" height="8" rx="1"/>
+            </svg>
+            Dashboard
+          </button>
           <button id="specs-new-btn" tabindex="-1" title="New Spec">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <line x1="12" y1="5" x2="12" y2="19"/>
@@ -788,6 +811,32 @@
               <span class="tasks-dashboard-detail-dates"></span>
             </div>
           </div>
+        </aside>
+      </div>
+    </div>
+
+    <!-- Specs Dashboard (full-page card grid view) -->
+    <div id="specs-dashboard" class="specs-dashboard">
+      <div class="specs-dashboard-header">
+        <div class="specs-dashboard-title">
+          <span class="specs-dashboard-mark">&#10022;</span>
+          <h2>Specs</h2>
+          <span id="specs-dashboard-project" class="specs-dashboard-project"></span>
+        </div>
+        <div class="specs-dashboard-actions">
+          <button id="specs-dashboard-new" class="btn btn-primary specs-dashboard-new" tabindex="-1">+ New Spec</button>
+          <button id="specs-dashboard-close" class="specs-dashboard-close" tabindex="-1" aria-label="Close dashboard">&#x2715;</button>
+        </div>
+      </div>
+      <div id="specs-dashboard-filters" class="specs-dashboard-filters"></div>
+      <div class="specs-dashboard-body">
+        <div id="specs-dashboard-grid" class="specs-dashboard-grid"></div>
+        <aside id="specs-dashboard-detail" class="specs-dashboard-detail">
+          <button class="specs-dashboard-detail-close" aria-label="Close detail">&#x2715;</button>
+          <div class="specs-dashboard-detail-empty">
+            <p>Select a spec to see its details, plan, and tasks.</p>
+          </div>
+          <div class="specs-dashboard-detail-content"></div>
         </aside>
       </div>
     </div>

--- a/src/main/specManager.js
+++ b/src/main/specManager.js
@@ -31,8 +31,10 @@ const SLUG_MAX_LEN = 48;
 
 let mainWindow = null;
 let activeWatcher = null;
+let activeTasksWatcher = null;
 let activeWatchedProject = null;
 let watchDebounce = null;
+let tasksWatchDebounce = null;
 
 // ─── Path helpers ──────────────────────────────────────────
 
@@ -132,21 +134,37 @@ function listSpecs(projectPath) {
     console.error('specManager: listSpecs readdir failed', err);
     return [];
   }
+
+  // Load tasks once so reconcilePhase can look at task statuses (the
+  // implementing → done transition is task-driven). Cheap on the order
+  // of dozens of specs; if this ever becomes a hot path we can cache.
+  let tasksData = null;
+  try {
+    tasksData = tasksManager.loadTasks(projectPath);
+  } catch (err) {
+    tasksData = null;
+  }
+
   const specs = [];
   for (const ent of entries) {
     if (!ent.isDirectory()) continue;
-    // Reconcile phase from filesystem state — catches the case where the AI
-    // wrote a plan.md / tasks.md but didn't (or couldn't) update status.json.
-    reconcilePhase(projectPath, ent.name);
+    // Reconcile phase from filesystem state + task statuses — catches the
+    // case where the AI wrote a plan.md / tasks.md but didn't (or couldn't)
+    // update status.json, and also flips to implementing/done as the user
+    // moves spec tasks through their lifecycle.
+    reconcilePhase(projectPath, ent.name, tasksData);
     const status = readStatus(projectPath, ent.name);
     if (!status) continue;
     if (validateSpecStatus(status)) continue; // silently skip malformed
+    const specTasks = collectSpecTasks(status.slug, tasksData);
+    const completedCount = specTasks.filter(t => t.status === 'completed').length;
     specs.push({
       slug: status.slug,
       title: status.title,
       phase: status.phase,
       ai_tool: status.ai_tool || null,
-      task_count: status.generated_task_ids.length,
+      task_count: specTasks.length || status.generated_task_ids.length,
+      completed_count: completedCount,
       created_at: status.created_at || null,
       updated_at: status.updated_at || null
     });
@@ -165,20 +183,35 @@ function fileExists(projectPath, slug, name) {
   return fs.existsSync(path.join(getSpecDir(projectPath, slug), name));
 }
 
-function derivePhase(projectPath, slug, currentPhase) {
-  // Once the user has manually moved into implementing / done, leave it
-  // alone — those phases are owned by the user, not the filesystem.
-  if (currentPhase === 'implementing' || currentPhase === 'done') return currentPhase;
+function derivePhase(projectPath, slug, currentPhase, tasksDataOrNull) {
+  // Once spec-derived tasks exist, their statuses drive the implementing →
+  // done transition. This overrides the file-based check so flipping a task
+  // back to pending automatically rewinds the phase too.
+  const specTasks = collectSpecTasks(slug, tasksDataOrNull);
+  if (specTasks.length > 0) {
+    const allCompleted = specTasks.every(t => t.status === 'completed');
+    const anyStarted = specTasks.some(t => t.status === 'in_progress' || t.status === 'completed');
+    if (allCompleted) return 'done';
+    if (anyStarted) return 'implementing';
+    // No started tasks → fall through to file-based check
+  }
+
   if (fileExists(projectPath, slug, TASKS_FILE)) return 'tasks_generated';
   if (fileExists(projectPath, slug, PLAN_FILE)) return 'planned';
   if (fileExists(projectPath, slug, SPEC_FILE)) return 'specified';
   return 'draft';
 }
 
-function reconcilePhase(projectPath, slug) {
+function collectSpecTasks(slug, tasksData) {
+  if (!tasksData || !Array.isArray(tasksData.tasks)) return [];
+  const prefix = `spec:${slug}:`;
+  return tasksData.tasks.filter(t => t && typeof t.source === 'string' && t.source.startsWith(prefix));
+}
+
+function reconcilePhase(projectPath, slug, tasksDataOrNull) {
   const status = readStatus(projectPath, slug);
   if (!status) return;
-  const newPhase = derivePhase(projectPath, slug, status.phase);
+  const newPhase = derivePhase(projectPath, slug, status.phase, tasksDataOrNull);
   if (newPhase === status.phase) return;
   const now = new Date().toISOString();
   writeStatus(projectPath, slug, {
@@ -493,6 +526,23 @@ function startWatching(projectPath) {
     console.error('specManager: fs.watch failed', err);
     return;
   }
+
+  // Also watch tasks.json — spec phase transitions to "implementing" /
+  // "done" are driven by spec-derived task statuses, so a status flip in
+  // the Tasks panel needs to refresh SPEC_DATA too. Independent watcher
+  // so we don't depend on tasksManager's internal pub/sub.
+  const tasksJsonPath = path.join(projectPath, 'tasks.json');
+  if (fs.existsSync(tasksJsonPath)) {
+    try {
+      activeTasksWatcher = fs.watch(tasksJsonPath, () => {
+        if (tasksWatchDebounce) clearTimeout(tasksWatchDebounce);
+        tasksWatchDebounce = setTimeout(() => pushSpecData(projectPath), WATCH_DEBOUNCE_MS);
+      });
+    } catch (err) {
+      console.error('specManager: tasks.json watch failed', err);
+    }
+  }
+
   // Initial snapshot so the panel paints something immediately
   pushSpecData(projectPath);
 }
@@ -502,10 +552,18 @@ function stopWatching() {
     try { activeWatcher.close(); } catch (err) { /* ignore */ }
   }
   activeWatcher = null;
+  if (activeTasksWatcher) {
+    try { activeTasksWatcher.close(); } catch (err) { /* ignore */ }
+  }
+  activeTasksWatcher = null;
   activeWatchedProject = null;
   if (watchDebounce) {
     clearTimeout(watchDebounce);
     watchDebounce = null;
+  }
+  if (tasksWatchDebounce) {
+    clearTimeout(tasksWatchDebounce);
+    tasksWatchDebounce = null;
   }
 }
 

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -16,6 +16,8 @@ const pluginsPanel = require('./pluginsPanel');
 const githubPanel = require('./githubPanel');
 const promptsPanel = require('./promptsPanel');
 const specPanel = require('./specPanel');
+const specPanelResize = require('./specPanelResize');
+const specsDashboard = require('./specsDashboard');
 const state = require('./state');
 const projectListUI = require('./projectListUI');
 const editor = require('./editor');
@@ -107,6 +109,10 @@ function init() {
 
   // Initialize specs panel (spec-driven development)
   specPanel.init();
+  specPanelResize.init();
+
+  // Initialize specs dashboard (full-page card grid, opened from panel header)
+  specsDashboard.init();
 
   // Initialize sidebar resize
   sidebarResize.init(() => {
@@ -438,6 +444,12 @@ function registerCommands() {
     category: 'Panel',
     shortcut: 'CmdOrCtrl+Shift+S',
     run: () => specPanel.toggle()
+  });
+  r({
+    id: 'panel.toggleSpecsDashboard',
+    title: 'Toggle Specs Dashboard',
+    category: 'Panel',
+    run: () => specsDashboard.toggle()
   });
   r({
     id: 'panel.togglePlugins',

--- a/src/renderer/specPanel.js
+++ b/src/renderer/specPanel.js
@@ -25,6 +25,7 @@ let specs = [];           // list cache from SPEC_DATA push
 let activeSlug = null;    // null = list view; slug = detail view
 let activeSpec = null;    // full payload for detail view
 let activeTab = 'spec';   // 'spec' | 'plan' | 'tasks'
+let allTasks = [];        // flat tasks.json cache (for filtering by spec source)
 
 function init() {
   panelEl = document.getElementById('specs-panel');
@@ -41,6 +42,9 @@ function setupEventListeners() {
   document.getElementById('specs-close')?.addEventListener('click', hide);
   document.getElementById('specs-collapse-btn')?.addEventListener('click', hide);
   document.getElementById('specs-new-btn')?.addEventListener('click', showNewSpecPrompt);
+  document.getElementById('specs-dashboard-btn')?.addEventListener('click', () => {
+    require('./specsDashboard').show();
+  });
 }
 
 function setupIPCListeners() {
@@ -48,6 +52,23 @@ function setupIPCListeners() {
     specs = incoming || [];
     if (activeSlug) reloadDetail();
     else renderList();
+  });
+
+  // Mirror the Tasks panel subscription so we can render an interactive
+  // task list inside the spec detail view (filtered to source: spec:<slug>:*).
+  // tasksManager broadcasts TASKS_DATA on every save/migration/external edit.
+  ipcRenderer.on(IPC.TASKS_DATA, (event, { tasks }) => {
+    if (tasks && Array.isArray(tasks.tasks)) {
+      allTasks = tasks.tasks;
+    } else {
+      allTasks = [];
+    }
+    // Re-render in detail view so the Tasks tab updates live
+    if (activeSlug && isVisible && activeTab === 'tasks') {
+      const body = contentEl?.querySelector('#spec-detail-body');
+      if (body) body.innerHTML = renderTabBody('tasks');
+      attachTaskActionHandlers();
+    }
   });
 
   ipcRenderer.on(IPC.TOGGLE_SPECS_PANEL, () => toggle());
@@ -93,10 +114,15 @@ async function toggle() {
 function startWatchingForProject(projectPath) {
   if (!projectPath) return;
   ipcRenderer.send(IPC.WATCH_SPECS, projectPath);
+  // Also kick a one-off LOAD_TASKS so the Tasks subview has data even
+  // before the user opens the standalone Tasks panel. Subsequent changes
+  // arrive via TASKS_DATA pushes.
+  ipcRenderer.send(IPC.LOAD_TASKS, projectPath);
 }
 
 function stopWatching() {
   ipcRenderer.send(IPC.UNWATCH_SPECS);
+  allTasks = [];
 }
 
 // ─── List view ──────────────────────────────────────
@@ -197,7 +223,7 @@ function renderDetail() {
       <div class="spec-detail-tabs">
         ${renderTabButton('spec', 'Spec', !!spec)}
         ${renderTabButton('plan', 'Plan', !!plan)}
-        ${renderTabButton('tasks', 'Tasks', !!tasks)}
+        ${renderTabButton('tasks', tasksTabLabel(!!tasks), !!tasks || hasSpecTasks())}
       </div>
       <div class="spec-detail-body" id="spec-detail-body">
         ${renderTabBody(activeTab)}
@@ -212,6 +238,7 @@ function renderDetail() {
   contentEl.querySelector('#spec-action-btn')?.addEventListener('click', () => {
     if (nextAction) runSpecCommand(nextAction.command);
   });
+  if (activeTab === 'tasks') attachTaskActionHandlers();
 }
 
 // ─── Next-action bar ────────────────────────────────
@@ -282,11 +309,153 @@ function renderTabButton(tab, label, hasContent) {
   return `<button class="spec-tab-btn ${active} ${empty}" data-tab="${tab}">${label}${hasContent ? '' : ' <span class="spec-tab-empty-dot">·</span>'}</button>`;
 }
 
+function hasSpecTasks() {
+  if (!activeSlug) return false;
+  const prefix = `spec:${activeSlug}:`;
+  return allTasks.some(t => t && typeof t.source === 'string' && t.source.startsWith(prefix));
+}
+
+function tasksTabLabel(hasMarkdown) {
+  if (!activeSlug) return 'Tasks';
+  const prefix = `spec:${activeSlug}:`;
+  const items = allTasks.filter(t => t && typeof t.source === 'string' && t.source.startsWith(prefix));
+  if (items.length === 0) return 'Tasks';
+  const completed = items.filter(t => t.status === 'completed').length;
+  return `Tasks <span class="spec-tab-count">${completed}/${items.length}</span>`;
+}
+
 function renderTabBody(tab) {
+  // The Tasks tab gets the interactive list view (Slice 2.1) — pulled
+  // from tasks.json with the spec source marker filter. Falls back to
+  // the raw tasks.md markdown if the import hasn't run yet (e.g., user
+  // is mid-/spec.tasks generation).
+  if (tab === 'tasks') return renderTasksTabBody();
+
   const md = activeSpec?.[tab];
   if (md) return renderMarkdown(md);
   const cmdMap = { spec: '/spec.new', plan: '/spec.plan', tasks: '/spec.tasks' };
   return `<div class="spec-empty-tab">No <code>${tab}.md</code> yet — run <code>${cmdMap[tab]}</code> from the terminal.</div>`;
+}
+
+function renderTasksTabBody() {
+  if (!activeSlug) return '';
+  const prefix = `spec:${activeSlug}:`;
+  const items = allTasks
+    .filter(t => t && typeof t.source === 'string' && t.source.startsWith(prefix))
+    // Stable order by the T<n> identifier suffix on `source`
+    .sort((a, b) => (a.source || '').localeCompare(b.source || '', undefined, { numeric: true }));
+
+  if (items.length === 0) {
+    if (activeSpec?.tasks) {
+      // tasks.md exists but nothing imported yet (user mid-flight or empty file)
+      return `
+        <div class="spec-empty-tab">
+          Waiting for <code>/spec.tasks</code> output to sync into tasks.json.
+          The raw <code>tasks.md</code> follows:
+        </div>
+        ${renderMarkdown(activeSpec.tasks)}
+      `;
+    }
+    return `<div class="spec-empty-tab">No tasks yet — run <code>/spec.tasks</code> from the terminal.</div>`;
+  }
+
+  const total = items.length;
+  const completed = items.filter(t => t.status === 'completed').length;
+  const inProgress = items.filter(t => t.status === 'in_progress').length;
+  const pct = Math.round((completed / total) * 100);
+
+  return `
+    <div class="spec-tasks-progress">
+      <div class="spec-tasks-progress-text">
+        <strong>${completed} / ${total}</strong> done${inProgress ? ` · ${inProgress} in progress` : ''}
+      </div>
+      <div class="spec-tasks-progress-bar"><div class="spec-tasks-progress-fill" style="width: ${pct}%"></div></div>
+    </div>
+    <div class="spec-tasks-list">
+      ${items.map(renderSpecTaskRow).join('')}
+    </div>
+  `;
+}
+
+function renderSpecTaskRow(task) {
+  const taskNum = (task.source || '').split(':').pop() || '—';
+  const isCompleted = task.status === 'completed';
+  const isInProgress = task.status === 'in_progress';
+  const isPending = task.status === 'pending';
+
+  const statusIcon = isCompleted
+    ? `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>`
+    : isInProgress
+      ? `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>`
+      : `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/></svg>`;
+
+  let actions = '';
+  if (isPending) {
+    actions = `
+      <button class="spec-task-action-btn" data-action="start" title="Start working">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3"/></svg>
+      </button>
+      <button class="spec-task-action-btn" data-action="complete" title="Mark complete">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>
+      </button>
+    `;
+  } else if (isInProgress) {
+    actions = `
+      <button class="spec-task-action-btn" data-action="complete" title="Mark complete">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>
+      </button>
+      <button class="spec-task-action-btn" data-action="pause" title="Move back to pending">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
+      </button>
+    `;
+  } else {
+    actions = `
+      <button class="spec-task-action-btn" data-action="reopen" title="Reopen">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/></svg>
+      </button>
+    `;
+  }
+
+  return `
+    <div class="spec-task-row status-${task.status}" data-task-id="${escapeHtml(task.id)}">
+      <span class="spec-task-status">${statusIcon}</span>
+      <span class="spec-task-num">${escapeHtml(taskNum)}</span>
+      <span class="spec-task-title">${escapeHtml(task.title)}</span>
+      <span class="spec-task-actions">${actions}</span>
+    </div>
+  `;
+}
+
+function attachTaskActionHandlers() {
+  if (!contentEl) return;
+  contentEl.querySelectorAll('.spec-task-row').forEach(row => {
+    const taskId = row.dataset.taskId;
+    row.querySelectorAll('.spec-task-action-btn').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        handleSpecTaskAction(taskId, btn.dataset.action);
+      });
+    });
+  });
+}
+
+function handleSpecTaskAction(taskId, action) {
+  const projectPath = state.getProjectPath();
+  if (!projectPath || !taskId) return;
+  const statusMap = {
+    start: 'in_progress',
+    complete: 'completed',
+    pause: 'pending',
+    reopen: 'pending'
+  };
+  const status = statusMap[action];
+  if (!status) return;
+  ipcRenderer.send(IPC.UPDATE_TASK, {
+    projectPath,
+    taskId,
+    updates: { status }
+  });
+  // tasksManager pushes TASKS_DATA back on save → our listener re-renders.
 }
 
 function switchTab(tab) {
@@ -296,6 +465,7 @@ function switchTab(tab) {
   });
   const body = contentEl.querySelector('#spec-detail-body');
   if (body) body.innerHTML = renderTabBody(tab);
+  if (tab === 'tasks') attachTaskActionHandlers();
 }
 
 function backToList() {
@@ -552,5 +722,6 @@ module.exports = {
   hide,
   toggle,
   startWatchingForProject,
-  stopWatching
+  stopWatching,
+  showNewSpecPrompt
 };

--- a/src/renderer/specPanelResize.js
+++ b/src/renderer/specPanelResize.js
@@ -1,0 +1,105 @@
+/**
+ * Specs Panel Resize Module
+ *
+ * Mirror of the sidebar resize pattern but for the right-anchored Specs
+ * panel. Drag the left edge of the panel to grow/shrink it. Width persists
+ * to localStorage so it survives reloads. Double-click resets to default.
+ */
+
+const STORAGE_KEY = 'specs-panel-width';
+const MIN_WIDTH = 360;
+const MAX_WIDTH = 1000;
+const DEFAULT_WIDTH = 420;
+const WIDE_WIDTH = 800;
+// Threshold for "is the panel currently in wide mode?" — anything ≥ this is
+// considered wide. Used to flip the toolbar button's intent.
+const WIDE_THRESHOLD = 600;
+
+let panelEl = null;
+let handleEl = null;
+let toggleBtnEl = null;
+let isResizing = false;
+let startX = 0;
+let startWidth = 0;
+
+function init() {
+  panelEl = document.getElementById('specs-panel');
+  handleEl = document.getElementById('specs-panel-resize-handle');
+  toggleBtnEl = document.getElementById('specs-wide-toggle');
+  if (!panelEl || !handleEl) return;
+
+  // Restore saved width
+  const saved = localStorage.getItem(STORAGE_KEY);
+  if (saved) {
+    const w = parseInt(saved, 10);
+    if (w >= MIN_WIDTH && w <= MAX_WIDTH) {
+      panelEl.style.width = `${w}px`;
+    }
+  }
+  refreshToggleIcon();
+
+  handleEl.addEventListener('mousedown', onMouseDown);
+  document.addEventListener('mousemove', onMouseMove);
+  document.addEventListener('mouseup', onMouseUp);
+  handleEl.addEventListener('dblclick', resetWidth);
+
+  if (toggleBtnEl) {
+    toggleBtnEl.addEventListener('click', toggleWide);
+  }
+}
+
+function onMouseDown(e) {
+  e.preventDefault();
+  isResizing = true;
+  startX = e.clientX;
+  startWidth = panelEl.offsetWidth;
+  handleEl.classList.add('dragging');
+  document.body.classList.add('sidebar-resizing'); // reuse the global cursor / no-select class
+}
+
+function onMouseMove(e) {
+  if (!isResizing) return;
+  // Panel is right-anchored: dragging the handle leftward grows the panel,
+  // so width grows by the negative of deltaX.
+  const deltaX = e.clientX - startX;
+  let newWidth = startWidth - deltaX;
+  newWidth = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, newWidth));
+  panelEl.style.width = `${newWidth}px`;
+}
+
+function onMouseUp() {
+  if (!isResizing) return;
+  isResizing = false;
+  handleEl.classList.remove('dragging');
+  document.body.classList.remove('sidebar-resizing');
+  localStorage.setItem(STORAGE_KEY, panelEl.offsetWidth.toString());
+  refreshToggleIcon();
+}
+
+function resetWidth() {
+  if (!panelEl) return;
+  panelEl.style.width = `${DEFAULT_WIDTH}px`;
+  localStorage.setItem(STORAGE_KEY, DEFAULT_WIDTH.toString());
+  refreshToggleIcon();
+}
+
+// One-tap expand / compact. Flips between the default narrow width and a
+// preset wide width. Drag handle still works for fine-tuning.
+function toggleWide() {
+  if (!panelEl) return;
+  const currentWidth = panelEl.offsetWidth;
+  const target = currentWidth >= WIDE_THRESHOLD ? DEFAULT_WIDTH : WIDE_WIDTH;
+  panelEl.style.width = `${target}px`;
+  localStorage.setItem(STORAGE_KEY, target.toString());
+  refreshToggleIcon();
+}
+
+function refreshToggleIcon() {
+  if (!toggleBtnEl || !panelEl) return;
+  const isWide = panelEl.offsetWidth >= WIDE_THRESHOLD;
+  toggleBtnEl.classList.toggle('is-wide', isWide);
+  toggleBtnEl.title = isWide ? 'Compact panel' : 'Expand panel';
+  toggleBtnEl.setAttribute('aria-label', toggleBtnEl.title);
+}
+
+module.exports = { init, resetWidth, toggleWide };

--- a/src/renderer/specsDashboard.js
+++ b/src/renderer/specsDashboard.js
@@ -1,0 +1,479 @@
+/**
+ * Specs Dashboard Module
+ *
+ * Full-page card grid view of all specs in the active project. Symmetric
+ * with the tasksDashboard (Cmd+Shift+D) — opened via the Dashboard button
+ * in the side Specs panel header.
+ *
+ * Layout: filterable grid on the left, sliding detail aside on the right.
+ * Cards show title + phase badge + progress bar + slug + AI tool + relative
+ * update time. Click a card → detail aside renders Spec / Plan / Tasks tabs
+ * with an interactive tasks list (status flips routed through UPDATE_TASK).
+ *
+ * State subscribes to the same SPEC_DATA + TASKS_DATA streams the side
+ * panel uses, so dashboard, side panel, and disk all stay in sync.
+ */
+
+const { ipcRenderer } = require('electron');
+const { marked } = require('marked');
+const { IPC } = require('../shared/ipcChannels');
+const state = require('./state');
+
+const FILTERS = [
+  { id: 'all',                 label: 'All' },
+  { id: 'active',              label: 'Active' },
+  { id: 'done',                label: 'Done' },
+  { id: 'phase:draft',         label: 'Draft' },
+  { id: 'phase:specified',     label: 'Specified' },
+  { id: 'phase:planned',       label: 'Planned' },
+  { id: 'phase:tasks_generated', label: 'Tasks Generated' },
+  { id: 'phase:implementing',  label: 'Implementing' }
+];
+
+let isVisible = false;
+let specs = [];
+let allTasks = [];
+let selectedSlug = null;
+let selectedSpec = null;   // full spec body (from GET_SPEC)
+let selectedTab = 'spec';
+let activeFilter = 'all';
+
+let dashboardEl = null;
+let projectLabelEl = null;
+let gridEl = null;
+let filtersEl = null;
+let detailEl = null;
+let detailEmptyEl = null;
+let detailContentEl = null;
+
+function init() {
+  dashboardEl = document.getElementById('specs-dashboard');
+  if (!dashboardEl) return;
+
+  projectLabelEl = document.getElementById('specs-dashboard-project');
+  gridEl = document.getElementById('specs-dashboard-grid');
+  filtersEl = document.getElementById('specs-dashboard-filters');
+  detailEl = document.getElementById('specs-dashboard-detail');
+  detailEmptyEl = detailEl.querySelector('.specs-dashboard-detail-empty');
+  detailContentEl = detailEl.querySelector('.specs-dashboard-detail-content');
+
+  // Header buttons
+  document.getElementById('specs-dashboard-close')?.addEventListener('click', hide);
+  document.getElementById('specs-dashboard-new')?.addEventListener('click', () => {
+    // Defer to side panel's modal — keeps the New Spec UX in one place
+    require('./specPanel').showNewSpecPrompt?.();
+  });
+  detailEl.querySelector('.specs-dashboard-detail-close')?.addEventListener('click', clearSelection);
+
+  renderFilters();
+  setupIPCListeners();
+
+  // Esc closes detail first, then dashboard
+  document.addEventListener('keydown', (e) => {
+    if (!isVisible) return;
+    if (e.key === 'Escape') {
+      if (selectedSlug) clearSelection();
+      else hide();
+    }
+  });
+}
+
+function setupIPCListeners() {
+  ipcRenderer.on(IPC.SPEC_DATA, (event, { specs: incoming }) => {
+    specs = incoming || [];
+    if (isVisible) {
+      renderGrid();
+      if (selectedSlug) reloadDetail();
+    }
+  });
+
+  ipcRenderer.on(IPC.TASKS_DATA, (event, { tasks }) => {
+    allTasks = (tasks && Array.isArray(tasks.tasks)) ? tasks.tasks : [];
+    if (isVisible) {
+      // Progress chips on cards depend on task state, so re-render the grid
+      renderGrid();
+      if (selectedSlug && selectedTab === 'tasks') {
+        renderDetailBody();
+        attachTaskActionHandlers();
+      }
+    }
+  });
+
+  ipcRenderer.on(IPC.TOGGLE_SPECS_DASHBOARD, () => toggle());
+}
+
+// ─── Visibility ──────────────────────────────────────────
+
+async function show() {
+  if (!dashboardEl) return;
+  const projectPath = state.getProjectPath();
+  if (!projectPath) {
+    require('./taskInfoModal').open?.({
+      title: 'No project selected',
+      message: 'Select a project from the sidebar to view its specs.'
+    });
+    return;
+  }
+  // The side panel and the dashboard show the same data — keeping both open
+  // overlaps z-indexes and confuses the layout. Force the side panel closed.
+  try { require('./specPanel').hide?.(); } catch {}
+
+  dashboardEl.classList.add('visible');
+  isVisible = true;
+  if (projectLabelEl) projectLabelEl.textContent = displayProjectName(projectPath);
+
+  // Fetch synchronously so the grid paints with real data on first frame
+  // instead of waiting for the watcher's debounced push. Watcher still runs
+  // for live updates afterward.
+  ipcRenderer.send(IPC.WATCH_SPECS, projectPath);
+  ipcRenderer.send(IPC.LOAD_TASKS, projectPath);
+  try {
+    specs = await ipcRenderer.invoke(IPC.LIST_SPECS, projectPath) || [];
+  } catch (err) {
+    specs = [];
+  }
+  renderGrid();
+}
+
+function hide() {
+  if (!dashboardEl) return;
+  dashboardEl.classList.remove('visible');
+  isVisible = false;
+  clearSelection();
+}
+
+function toggle() {
+  isVisible ? hide() : show();
+}
+
+// ─── Filters ─────────────────────────────────────────────
+
+function renderFilters() {
+  if (!filtersEl) return;
+  filtersEl.innerHTML = FILTERS.map(f => `
+    <button class="specs-dashboard-filter-btn ${activeFilter === f.id ? 'active' : ''}" data-filter="${f.id}">${f.label}</button>
+  `).join('');
+  filtersEl.querySelectorAll('.specs-dashboard-filter-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      activeFilter = btn.dataset.filter;
+      renderFilters();
+      renderGrid();
+    });
+  });
+}
+
+function applyFilter(specsList) {
+  if (activeFilter === 'all') return specsList;
+  if (activeFilter === 'active') return specsList.filter(s => s.phase !== 'done');
+  if (activeFilter === 'done') return specsList.filter(s => s.phase === 'done');
+  if (activeFilter.startsWith('phase:')) {
+    const target = activeFilter.slice('phase:'.length);
+    return specsList.filter(s => s.phase === target);
+  }
+  return specsList;
+}
+
+// ─── Grid ────────────────────────────────────────────────
+
+function renderGrid() {
+  if (!gridEl) return;
+  const filtered = applyFilter(specs);
+
+  if (filtered.length === 0) {
+    if (specs.length === 0) {
+      gridEl.innerHTML = `
+        <div class="specs-dashboard-empty">
+          <h3>No specs yet</h3>
+          <p>Define what you want to build with Spec-Driven Development.</p>
+          <button class="btn btn-primary" id="specs-dashboard-empty-new">+ New Spec</button>
+        </div>
+      `;
+      gridEl.querySelector('#specs-dashboard-empty-new')?.addEventListener('click', () => {
+        require('./specPanel').showNewSpecPrompt?.();
+      });
+    } else {
+      gridEl.innerHTML = `<div class="specs-dashboard-empty"><p>No specs match the active filter.</p></div>`;
+    }
+    return;
+  }
+
+  gridEl.innerHTML = filtered.map(renderCard).join('');
+  gridEl.querySelectorAll('.specs-card').forEach(card => {
+    card.addEventListener('click', () => selectCard(card.dataset.slug));
+  });
+}
+
+function renderCard(spec) {
+  const taskMatches = allTasks.filter(t => t && typeof t.source === 'string' && t.source.startsWith(`spec:${spec.slug}:`));
+  const total = taskMatches.length || spec.task_count || 0;
+  const done = taskMatches.filter(t => t.status === 'completed').length;
+  const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+  const phaseLabel = spec.phase.replace(/_/g, ' ');
+  const isSelected = spec.slug === selectedSlug ? 'selected' : '';
+
+  return `
+    <div class="specs-card ${isSelected}" data-slug="${escapeHtml(spec.slug)}">
+      <div class="specs-card-top">
+        <span class="spec-phase-badge phase-${spec.phase}">${phaseLabel}</span>
+        ${spec.ai_tool ? `<span class="specs-card-ai">${escapeHtml(spec.ai_tool)}</span>` : ''}
+      </div>
+      <div class="specs-card-title">${escapeHtml(spec.title)}</div>
+      <div class="specs-card-slug">${escapeHtml(spec.slug)}</div>
+      ${total > 0 ? `
+        <div class="specs-card-progress">
+          <div class="specs-card-progress-bar"><div class="specs-card-progress-fill" style="width: ${pct}%"></div></div>
+          <span class="specs-card-progress-text">${done} / ${total}</span>
+        </div>
+      ` : `<div class="specs-card-progress-empty">No tasks yet</div>`}
+      <div class="specs-card-foot">
+        <span class="specs-card-time">${relativeTime(spec.updated_at)}</span>
+      </div>
+    </div>
+  `;
+}
+
+// ─── Detail aside ───────────────────────────────────────
+
+async function selectCard(slug) {
+  selectedSlug = slug;
+  selectedTab = 'spec';
+  await reloadDetail();
+  // Re-render to mark the selected card
+  renderGrid();
+}
+
+function clearSelection() {
+  selectedSlug = null;
+  selectedSpec = null;
+  selectedTab = 'spec';
+  if (detailEl) detailEl.classList.remove('has-selection');
+  renderGrid();
+}
+
+async function reloadDetail() {
+  if (!selectedSlug) return;
+  const projectPath = state.getProjectPath();
+  if (!projectPath) return;
+  selectedSpec = await ipcRenderer.invoke(IPC.GET_SPEC, { projectPath, slug: selectedSlug });
+  if (!selectedSpec) {
+    // Spec was deleted out from under us
+    clearSelection();
+    return;
+  }
+  if (detailEl) detailEl.classList.add('has-selection');
+  renderDetailHeader();
+  renderDetailBody();
+  attachTaskActionHandlers();
+}
+
+function renderDetailHeader() {
+  if (!detailContentEl || !selectedSpec) return;
+  const { status, spec, plan, tasks } = selectedSpec;
+  const phaseLabel = status.phase.replace(/_/g, ' ');
+  const aiLabel = status.ai_tool || '';
+
+  detailContentEl.innerHTML = `
+    <div class="specs-dashboard-detail-head">
+      <div class="specs-dashboard-detail-meta">
+        <span class="specs-dashboard-detail-slug">${escapeHtml(status.slug)}</span>
+        ${aiLabel ? `<span class="specs-detail-ai">${escapeHtml(aiLabel)}</span>` : ''}
+      </div>
+      <h3 class="specs-dashboard-detail-title">${escapeHtml(status.title)}</h3>
+      <div class="specs-dashboard-detail-meta">
+        <span class="spec-phase-badge phase-${status.phase}">${phaseLabel}</span>
+      </div>
+      <div class="specs-dashboard-detail-tabs">
+        ${tabBtn('spec',  'Spec',  !!spec)}
+        ${tabBtn('plan',  'Plan',  !!plan)}
+        ${tabBtn('tasks', tasksTabLabel(!!tasks), !!tasks || hasSpecTasks())}
+      </div>
+    </div>
+    <div class="specs-dashboard-detail-body" id="specs-dashboard-detail-body"></div>
+  `;
+  detailContentEl.querySelectorAll('.spec-tab-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      selectedTab = btn.dataset.tab;
+      renderDetailHeader();
+      renderDetailBody();
+      attachTaskActionHandlers();
+    });
+  });
+}
+
+function tabBtn(tab, label, hasContent) {
+  const active = selectedTab === tab ? 'active' : '';
+  const empty = hasContent ? '' : 'empty';
+  return `<button class="spec-tab-btn ${active} ${empty}" data-tab="${tab}">${label}${hasContent ? '' : ' <span class="spec-tab-empty-dot">·</span>'}</button>`;
+}
+
+function renderDetailBody() {
+  if (!selectedSpec) return;
+  const body = detailContentEl.querySelector('#specs-dashboard-detail-body');
+  if (!body) return;
+
+  if (selectedTab === 'tasks') {
+    body.innerHTML = renderTasksTabBody();
+    return;
+  }
+
+  const md = selectedSpec[selectedTab];
+  if (md) {
+    body.innerHTML = renderMarkdown(md);
+  } else {
+    const cmdMap = { spec: '/spec.new', plan: '/spec.plan', tasks: '/spec.tasks' };
+    body.innerHTML = `<div class="spec-empty-tab">No <code>${selectedTab}.md</code> yet — run <code>${cmdMap[selectedTab]}</code> from the terminal.</div>`;
+  }
+}
+
+function renderTasksTabBody() {
+  if (!selectedSlug) return '';
+  const prefix = `spec:${selectedSlug}:`;
+  const items = allTasks
+    .filter(t => t && typeof t.source === 'string' && t.source.startsWith(prefix))
+    .sort((a, b) => (a.source || '').localeCompare(b.source || '', undefined, { numeric: true }));
+
+  if (items.length === 0) {
+    if (selectedSpec?.tasks) {
+      return `
+        <div class="spec-empty-tab">
+          Waiting for <code>/spec.tasks</code> output to sync into tasks.json.
+        </div>
+        ${renderMarkdown(selectedSpec.tasks)}
+      `;
+    }
+    return `<div class="spec-empty-tab">No tasks yet — run <code>/spec.tasks</code> from the terminal.</div>`;
+  }
+
+  const total = items.length;
+  const completed = items.filter(t => t.status === 'completed').length;
+  const inProgress = items.filter(t => t.status === 'in_progress').length;
+  const pct = Math.round((completed / total) * 100);
+
+  return `
+    <div class="spec-tasks-progress">
+      <div class="spec-tasks-progress-text">
+        <strong>${completed} / ${total}</strong> done${inProgress ? ` · ${inProgress} in progress` : ''}
+      </div>
+      <div class="spec-tasks-progress-bar"><div class="spec-tasks-progress-fill" style="width: ${pct}%"></div></div>
+    </div>
+    <div class="spec-tasks-list">
+      ${items.map(renderSpecTaskRow).join('')}
+    </div>
+  `;
+}
+
+function renderSpecTaskRow(task) {
+  const taskNum = (task.source || '').split(':').pop() || '—';
+  const isCompleted = task.status === 'completed';
+  const isInProgress = task.status === 'in_progress';
+  const isPending = task.status === 'pending';
+
+  const statusIcon = isCompleted
+    ? `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>`
+    : isInProgress
+      ? `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>`
+      : `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/></svg>`;
+
+  let actions = '';
+  if (isPending) {
+    actions = `
+      <button class="spec-task-action-btn" data-action="start" title="Start working">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor"><polygon points="5 3 19 12 5 21 5 3"/></svg>
+      </button>
+      <button class="spec-task-action-btn" data-action="complete" title="Mark complete">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>
+      </button>
+    `;
+  } else if (isInProgress) {
+    actions = `
+      <button class="spec-task-action-btn" data-action="complete" title="Mark complete">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>
+      </button>
+      <button class="spec-task-action-btn" data-action="pause" title="Move back to pending">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="currentColor"><rect x="6" y="4" width="4" height="16"/><rect x="14" y="4" width="4" height="16"/></svg>
+      </button>
+    `;
+  } else {
+    actions = `
+      <button class="spec-task-action-btn" data-action="reopen" title="Reopen">
+        <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M3 12a9 9 0 1 0 9-9 9.75 9.75 0 0 0-6.74 2.74L3 8"/><path d="M3 3v5h5"/></svg>
+      </button>
+    `;
+  }
+
+  return `
+    <div class="spec-task-row status-${task.status}" data-task-id="${escapeHtml(task.id)}">
+      <span class="spec-task-status">${statusIcon}</span>
+      <span class="spec-task-num">${escapeHtml(taskNum)}</span>
+      <span class="spec-task-title">${escapeHtml(task.title)}</span>
+      <span class="spec-task-actions">${actions}</span>
+    </div>
+  `;
+}
+
+function attachTaskActionHandlers() {
+  if (!detailContentEl) return;
+  detailContentEl.querySelectorAll('.spec-task-row').forEach(row => {
+    const taskId = row.dataset.taskId;
+    row.querySelectorAll('.spec-task-action-btn').forEach(btn => {
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        handleSpecTaskAction(taskId, btn.dataset.action);
+      });
+    });
+  });
+}
+
+function handleSpecTaskAction(taskId, action) {
+  const projectPath = state.getProjectPath();
+  if (!projectPath || !taskId) return;
+  const statusMap = { start: 'in_progress', complete: 'completed', pause: 'pending', reopen: 'pending' };
+  const status = statusMap[action];
+  if (!status) return;
+  ipcRenderer.send(IPC.UPDATE_TASK, { projectPath, taskId, updates: { status } });
+}
+
+// ─── Helpers ────────────────────────────────────────────
+
+function hasSpecTasks() {
+  if (!selectedSlug) return false;
+  const prefix = `spec:${selectedSlug}:`;
+  return allTasks.some(t => t && typeof t.source === 'string' && t.source.startsWith(prefix));
+}
+
+function tasksTabLabel(hasMarkdown) {
+  if (!selectedSlug) return 'Tasks';
+  const prefix = `spec:${selectedSlug}:`;
+  const items = allTasks.filter(t => t && typeof t.source === 'string' && t.source.startsWith(prefix));
+  if (items.length === 0) return 'Tasks';
+  const completed = items.filter(t => t.status === 'completed').length;
+  return `Tasks <span class="spec-tab-count">${completed}/${items.length}</span>`;
+}
+
+function renderMarkdown(md) {
+  if (!md) return '';
+  return marked.parse(md).replace(/<script/gi, '&lt;script').replace(/on\w+=/gi, 'data-safe-');
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, c => ({
+    '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;'
+  }[c]));
+}
+
+function relativeTime(iso) {
+  if (!iso) return '';
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return '';
+  const diff = Math.max(0, (Date.now() - t) / 1000);
+  if (diff < 60) return 'just now';
+  if (diff < 3600) return `${Math.floor(diff / 60)}m ago`;
+  if (diff < 86400) return `${Math.floor(diff / 3600)}h ago`;
+  return `${Math.floor(diff / 86400)}d ago`;
+}
+
+function displayProjectName(projectPath) {
+  return projectPath.split('/').pop() || projectPath.split('\\').pop() || projectPath;
+}
+
+module.exports = { init, show, hide, toggle };

--- a/src/renderer/styles/components/panels.css
+++ b/src/renderer/styles/components/panels.css
@@ -4423,6 +4423,43 @@
   pointer-events: none;
 }
 
+#specs-panel-resize-handle {
+  position: absolute;
+  top: 0;
+  left: -3px;
+  width: 6px;
+  height: 100%;
+  cursor: col-resize;
+  z-index: 100;
+  background: transparent;
+  transition: background var(--transition-fast);
+}
+
+#specs-panel-resize-handle:hover,
+#specs-panel-resize-handle.dragging {
+  background: var(--accent-primary);
+}
+
+#specs-panel-resize-handle::before {
+  content: '';
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: 2px;
+  height: 40px;
+  background: var(--border-default);
+  border-radius: 1px;
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+#specs-panel-resize-handle:hover::before,
+#specs-panel-resize-handle.dragging::before {
+  opacity: 1;
+  background: var(--accent-primary);
+}
+
 #specs-panel:not(.visible) {
   transform: translateX(100%);
   opacity: 0;
@@ -4503,6 +4540,58 @@
   background: var(--accent-primary);
   color: var(--bg-deep);
 }
+
+#specs-dashboard-btn {
+  background: transparent;
+  border: 1px solid var(--border-default);
+  color: var(--text-secondary);
+  padding: var(--space-xs) var(--space-sm);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  transition: all var(--transition-fast);
+}
+
+#specs-dashboard-btn:hover {
+  background: var(--accent-subtle);
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+}
+
+#specs-wide-toggle {
+  background: transparent;
+  border: 1px solid var(--border-default);
+  color: var(--text-secondary);
+  padding: var(--space-xs);
+  border-radius: var(--radius-sm);
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition-fast);
+}
+
+#specs-wide-toggle:hover {
+  background: var(--accent-subtle);
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+}
+
+#specs-wide-toggle.is-wide {
+  background: var(--accent-subtle);
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+}
+
+#specs-wide-toggle .specs-wide-icon-compact { display: none; }
+#specs-wide-toggle.is-wide .specs-wide-icon-expand { display: none; }
+#specs-wide-toggle.is-wide .specs-wide-icon-compact { display: block; }
 
 #specs-close {
   background: transparent;
@@ -4845,6 +4934,148 @@
   font-size: 11px;
 }
 
+/* Spec detail Tasks tab — interactive list (Slice 2.1) */
+.spec-tab-count {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-tertiary);
+  margin-left: 4px;
+}
+
+.spec-tab-btn.active .spec-tab-count {
+  color: var(--accent-primary);
+}
+
+.spec-tasks-progress {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--bg-tertiary);
+  border-radius: var(--radius-sm);
+  margin-bottom: var(--space-sm);
+}
+
+.spec-tasks-progress-text {
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+
+.spec-tasks-progress-text strong {
+  color: var(--accent-primary);
+  font-weight: 600;
+}
+
+.spec-tasks-progress-bar {
+  height: 4px;
+  background: var(--bg-hover);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.spec-tasks-progress-fill {
+  height: 100%;
+  background: var(--accent-primary);
+  border-radius: 2px;
+  transition: width var(--transition-normal);
+}
+
+.spec-tasks-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.spec-task-row {
+  display: grid;
+  grid-template-columns: 18px 28px 1fr auto;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.spec-task-row:hover {
+  background: var(--bg-elevated);
+  border-color: var(--border-default);
+}
+
+.spec-task-row.status-completed {
+  opacity: 0.6;
+}
+
+.spec-task-row.status-in_progress {
+  border-left: 2px solid var(--accent-primary);
+}
+
+.spec-task-status {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-tertiary);
+}
+
+.spec-task-row.status-in_progress .spec-task-status {
+  color: var(--accent-primary);
+}
+
+.spec-task-row.status-completed .spec-task-status {
+  color: var(--success);
+}
+
+.spec-task-num {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-muted);
+  font-weight: 600;
+}
+
+.spec-task-title {
+  color: var(--text-primary);
+  font-weight: 500;
+  line-height: 1.4;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.spec-task-row.status-completed .spec-task-title {
+  text-decoration: line-through;
+  color: var(--text-tertiary);
+}
+
+.spec-task-actions {
+  display: flex;
+  gap: 2px;
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.spec-task-row:hover .spec-task-actions {
+  opacity: 1;
+}
+
+.spec-task-action-btn {
+  background: transparent;
+  border: none;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  padding: 4px 6px;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition-fast);
+}
+
+.spec-task-action-btn:hover {
+  background: var(--accent-subtle);
+  color: var(--accent-primary);
+}
+
 /* Spec "New Spec" modal — temporary stub for Slice 1, replaced by /spec.new flow in 1.7 */
 .spec-modal-overlay {
   position: fixed;
@@ -5043,5 +5274,440 @@
   font-family: var(--font-mono);
   font-size: 10px;
   color: var(--text-secondary);
+}
+
+/* ──────────────────────────────────────────────────────
+   Specs Dashboard — full-page card grid (Slice 2.1)
+   Opened via the Dashboard button in the Specs panel
+   header. Symmetric with the Tasks Dashboard.
+   ────────────────────────────────────────────────────── */
+
+.specs-dashboard {
+  position: fixed;
+  inset: 0;
+  background: var(--bg-deep);
+  z-index: 9000;
+  display: none;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.specs-dashboard.visible {
+  display: flex;
+}
+
+.specs-dashboard-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-lg) var(--space-xl);
+  border-bottom: 1px solid var(--border-subtle);
+  background: linear-gradient(180deg, var(--bg-secondary) 0%, var(--bg-primary) 100%);
+}
+
+.specs-dashboard-title {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+}
+
+.specs-dashboard-mark {
+  font-size: 18px;
+  color: var(--accent-primary);
+}
+
+.specs-dashboard-title h2 {
+  font-size: 18px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  letter-spacing: -0.3px;
+}
+
+.specs-dashboard-project {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-tertiary);
+  background: var(--bg-tertiary);
+  padding: 3px 8px;
+  border-radius: var(--radius-sm);
+}
+
+.specs-dashboard-actions {
+  display: flex;
+  gap: var(--space-sm);
+  align-items: center;
+}
+
+.specs-dashboard-new {
+  font-size: 12px;
+}
+
+.specs-dashboard-close {
+  background: transparent;
+  border: none;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  font-size: 18px;
+  width: 32px;
+  height: 32px;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.specs-dashboard-close:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.specs-dashboard-filters {
+  display: flex;
+  gap: var(--space-xs);
+  flex-wrap: wrap;
+  padding: var(--space-md) var(--space-xl);
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-primary);
+}
+
+.specs-dashboard-filter-btn {
+  background: transparent;
+  border: 1px solid var(--border-subtle);
+  color: var(--text-tertiary);
+  padding: 4px 10px;
+  border-radius: 14px;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.specs-dashboard-filter-btn:hover {
+  color: var(--text-secondary);
+  border-color: var(--border-default);
+}
+
+.specs-dashboard-filter-btn.active {
+  background: var(--accent-subtle);
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+}
+
+.specs-dashboard-body {
+  flex: 1;
+  position: relative;
+  overflow: hidden;
+}
+
+.specs-dashboard-grid {
+  height: 100%;
+  padding: var(--space-xl);
+  padding-right: var(--space-xl);
+  overflow-y: auto;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--space-md);
+  align-content: start;
+  transition: padding-right var(--transition-normal);
+}
+
+.specs-dashboard-detail.has-selection ~ .specs-dashboard-grid,
+.specs-dashboard-body:has(.specs-dashboard-detail.has-selection) .specs-dashboard-grid {
+  padding-right: calc(480px + var(--space-xl));
+}
+
+.specs-card {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.specs-card:hover {
+  border-color: var(--accent-primary);
+  background: var(--bg-elevated);
+  transform: translateY(-1px);
+}
+
+.specs-card.selected {
+  border-color: var(--accent-primary);
+  background: var(--accent-subtle);
+  box-shadow: 0 0 0 1px var(--accent-primary);
+}
+
+.specs-card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-sm);
+}
+
+.specs-card-ai {
+  font-family: var(--font-mono);
+  font-size: 9px;
+  color: var(--text-tertiary);
+  background: var(--bg-hover);
+  padding: 2px 5px;
+  border-radius: 3px;
+}
+
+.specs-card-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  line-height: 1.35;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.specs-card-slug {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-muted);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.specs-card-progress {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  margin-top: var(--space-xs);
+}
+
+.specs-card-progress-bar {
+  flex: 1;
+  height: 4px;
+  background: var(--bg-hover);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.specs-card-progress-fill {
+  height: 100%;
+  background: var(--accent-primary);
+  border-radius: 2px;
+  transition: width var(--transition-normal);
+}
+
+.specs-card-progress-text {
+  font-size: 10px;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  min-width: 38px;
+  text-align: right;
+}
+
+.specs-card-progress-empty {
+  font-size: 10px;
+  color: var(--text-muted);
+  font-style: italic;
+}
+
+.specs-card-foot {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.specs-card-time {
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.specs-dashboard-empty {
+  grid-column: 1 / -1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-2xl);
+  color: var(--text-tertiary);
+  text-align: center;
+}
+
+.specs-dashboard-empty h3 {
+  font-size: 16px;
+  color: var(--text-secondary);
+  margin: 0 0 var(--space-sm);
+}
+
+.specs-dashboard-empty p {
+  font-size: 13px;
+  color: var(--text-tertiary);
+  margin: 0 0 var(--space-lg);
+  max-width: 400px;
+}
+
+/* Detail aside — slides in over the right side of the grid when a card
+   is selected. Absolute positioning (vs. flex sibling) avoids width-
+   transition flicker and ensures the aside is always above the grid. */
+.specs-dashboard-detail {
+  display: none;
+  position: absolute;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: 480px;
+  max-width: 90%;
+  background: var(--bg-secondary);
+  border-left: 1px solid var(--border-subtle);
+  flex-direction: column;
+  overflow: hidden;
+  z-index: 2;
+  box-shadow: -8px 0 24px rgba(0, 0, 0, 0.25);
+}
+
+.specs-dashboard-detail.has-selection {
+  display: flex;
+}
+
+.specs-dashboard-detail-close {
+  position: absolute;
+  top: var(--space-md);
+  right: var(--space-md);
+  background: transparent;
+  border: none;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  font-size: 14px;
+  width: 26px;
+  height: 26px;
+  border-radius: var(--radius-sm);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1;
+}
+
+.specs-dashboard-detail-close:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.specs-dashboard-detail-empty {
+  display: flex;
+  flex: 1;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-xl);
+  color: var(--text-muted);
+  font-size: 12px;
+  font-style: italic;
+}
+
+.specs-dashboard-detail.has-selection .specs-dashboard-detail-empty {
+  display: none;
+}
+
+.specs-dashboard-detail-content {
+  display: none;
+  flex: 1;
+  overflow-y: auto;
+  padding: var(--space-xl);
+}
+
+.specs-dashboard-detail.has-selection .specs-dashboard-detail-content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+.specs-dashboard-detail-head {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+  border-bottom: 1px solid var(--border-subtle);
+  padding-bottom: var(--space-md);
+}
+
+.specs-dashboard-detail-meta {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  flex-wrap: wrap;
+}
+
+.specs-dashboard-detail-slug {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-muted);
+}
+
+.specs-dashboard-detail-title {
+  font-size: 16px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin: 0;
+  line-height: 1.35;
+  letter-spacing: -0.2px;
+}
+
+.specs-dashboard-detail-tabs {
+  display: flex;
+  gap: var(--space-xs);
+  margin-top: var(--space-sm);
+}
+
+.specs-dashboard-detail-body {
+  font-size: 12px;
+  color: var(--text-secondary);
+  line-height: 1.6;
+}
+
+.specs-dashboard-detail-body h1,
+.specs-dashboard-detail-body h2,
+.specs-dashboard-detail-body h3 {
+  color: var(--text-primary);
+  margin-top: var(--space-md);
+  margin-bottom: var(--space-sm);
+}
+
+.specs-dashboard-detail-body h1 { font-size: 16px; }
+.specs-dashboard-detail-body h2 { font-size: 14px; }
+.specs-dashboard-detail-body h3 { font-size: 13px; }
+
+.specs-dashboard-detail-body code {
+  font-family: var(--font-mono);
+  background: var(--bg-tertiary);
+  padding: 1px 4px;
+  border-radius: 3px;
+  font-size: 11px;
+}
+
+.specs-dashboard-detail-body pre {
+  background: var(--bg-tertiary);
+  padding: var(--space-md);
+  border-radius: var(--radius-sm);
+  overflow-x: auto;
+}
+
+.specs-dashboard-detail-body ul,
+.specs-dashboard-detail-body ol {
+  padding-left: var(--space-lg);
+}
+
+.specs-dashboard-detail-body li {
+  margin-bottom: var(--space-xs);
+}
+
+@media (max-width: 900px) {
+  .specs-dashboard-detail.has-selection {
+    width: 100%;
+  }
+  .specs-dashboard-detail.has-selection ~ .specs-dashboard-grid,
+  .specs-dashboard-body:has(.specs-dashboard-detail.has-selection) .specs-dashboard-grid {
+    display: none;
+  }
 }
 

--- a/src/shared/ipcChannels.js
+++ b/src/shared/ipcChannels.js
@@ -147,6 +147,7 @@ const IPC = {
   UNWATCH_SPECS: 'unwatch-specs',
   SPEC_DATA: 'spec-data',
   TOGGLE_SPECS_PANEL: 'toggle-specs-panel',
+  TOGGLE_SPECS_DASHBOARD: 'toggle-specs-dashboard',
   GET_SPEC_PROMPT: 'get-spec-prompt',
   BUILD_SPEC_COMMAND_FILE: 'build-spec-command-file',
 

--- a/tasks.json
+++ b/tasks.json
@@ -7,7 +7,7 @@
   },
   "project": "Frame",
   "version": "2.0",
-  "lastUpdated": "2026-04-30T00:00:00Z",
+  "lastUpdated": "2026-04-30T15:56:06.717Z",
   "taskSchema": {
     "_comment": "This schema shows the expected structure for each task",
     "id": "unique-id (task-xxx format)",
@@ -852,10 +852,75 @@
       "createdAt": "2026-04-29T00:00:00Z",
       "updatedAt": "2026-04-29T00:00:00Z",
       "completedAt": "2026-04-29T00:00:00Z"
+    },
+    {
+      "id": "task-spec-agentlar-iin-roller-tanmlamay-dnyorum-aklmdaki-f-T01",
+      "title": "Add `src/templates/roles/AGENTS.md` starter template with Purpose / Steps / Commands / Notes sections and an inline behavior protocol covering session-start read, first-run capture, follow-up delta-only mode, and capture-only-with-approval.",
+      "description": "",
+      "source": "spec:agentlar-iin-roller-tanmlamay-dnyorum-aklmdaki-f:T01",
+      "status": "pending",
+      "priority": "medium",
+      "category": "feature",
+      "context": "From spec: agentlar-iin-roller-tanmlamay-dnyorum-aklmdaki-f",
+      "createdAt": "2026-04-30T15:56:06.716Z",
+      "updatedAt": "2026-04-30T15:56:06.716Z",
+      "completedAt": null
+    },
+    {
+      "id": "task-spec-agentlar-iin-roller-tanmlamay-dnyorum-aklmdaki-f-T02",
+      "title": "Add `scripts/create-role.js` CLI that validates a kebab-case role name, creates `roles/<name>/`, copies the template into `AGENTS.md`, and creates a `CLAUDE.md → AGENTS.md` symlink; refuse if `roles/<name>/` already exists.",
+      "description": "",
+      "source": "spec:agentlar-iin-roller-tanmlamay-dnyorum-aklmdaki-f:T02",
+      "status": "pending",
+      "priority": "medium",
+      "category": "feature",
+      "context": "From spec: agentlar-iin-roller-tanmlamay-dnyorum-aklmdaki-f",
+      "createdAt": "2026-04-30T15:56:06.716Z",
+      "updatedAt": "2026-04-30T15:56:06.716Z",
+      "completedAt": null
+    },
+    {
+      "id": "task-spec-agentlar-iin-roller-tanmlamay-dnyorum-aklmdaki-f-T03",
+      "title": "Wire `\"role:new\": \"node scripts/create-role.js\"` into the `scripts` block of `package.json`.",
+      "description": "",
+      "source": "spec:agentlar-iin-roller-tanmlamay-dnyorum-aklmdaki-f:T03",
+      "status": "pending",
+      "priority": "medium",
+      "category": "feature",
+      "context": "From spec: agentlar-iin-roller-tanmlamay-dnyorum-aklmdaki-f",
+      "createdAt": "2026-04-30T15:56:06.716Z",
+      "updatedAt": "2026-04-30T15:56:06.716Z",
+      "completedAt": null
+    },
+    {
+      "id": "task-spec-agentlar-iin-roller-tanmlamay-dnyorum-aklmdaki-f-T04",
+      "title": "Add a \"Roles\" section to the project root `AGENTS.md` covering when to create a role, the `npm run role:new <name>` command, the per-role protocol summary, and the capture-with-approval rule; cross-reference that specs/tasks remain for product work.",
+      "description": "",
+      "source": "spec:agentlar-iin-roller-tanmlamay-dnyorum-aklmdaki-f:T04",
+      "status": "pending",
+      "priority": "medium",
+      "category": "feature",
+      "context": "From spec: agentlar-iin-roller-tanmlamay-dnyorum-aklmdaki-f",
+      "createdAt": "2026-04-30T15:56:06.716Z",
+      "updatedAt": "2026-04-30T15:56:06.716Z",
+      "completedAt": null
+    },
+    {
+      "id": "task-spec-agentlar-iin-roller-tanmlamay-dnyorum-aklmdaki-f-T05",
+      "title": "Run `npm run structure` to refresh `STRUCTURE.json` so the new template and CLI land in the intentIndex.",
+      "description": "",
+      "source": "spec:agentlar-iin-roller-tanmlamay-dnyorum-aklmdaki-f:T05",
+      "status": "pending",
+      "priority": "medium",
+      "category": "feature",
+      "context": "From spec: agentlar-iin-roller-tanmlamay-dnyorum-aklmdaki-f",
+      "createdAt": "2026-04-30T15:56:06.716Z",
+      "updatedAt": "2026-04-30T15:56:06.716Z",
+      "completedAt": null
     }
   ],
   "metadata": {
-    "totalCreated": 51,
+    "totalCreated": 56,
     "totalCompleted": 16
   },
   "categories": {


### PR DESCRIPTION
## Summary

Three additions on top of Slice 1, all surfaced through the Specs panel that already shipped.

**Interactive Tasks subview (side panel)**
The Tasks tab now renders the live \`tasks.json\` subset filtered by \`source: spec:<slug>:*\` as an interactive list — hover-revealed Start / Complete / Pause / Reopen actions, status icons, progress bar, X/Y count in the tab label.

**Phase auto-advance from task statuses**
\`specManager.derivePhase\` now consults \`tasks.json\`: any spec task in_progress or completed → \`implementing\`; all completed → \`done\`. Reopen rewinds. A second \`fs.watch\` on \`tasks.json\` makes status flips from the standalone Tasks panel propagate to the spec view.

**Full-page Specs Dashboard**
New \`src/renderer/specsDashboard.js\`. Card grid, filter chips (All / Active / Done / per-phase), 480px detail aside that slides in over the right side with the same Spec / Plan / Tasks tab structure. Symmetric with the Tasks Dashboard. Opens from a button in the panel header; closes via ✕ or Esc.

**Resizable side panel + one-tap expand**
Drag handle on the panel's left edge (360–1000px, double-click resets to 420). Plus an Expand/Compact toggle button in the header for one-tap 420 ↔ 800 — useful when reading detailed plan.md.

New IPC: \`TOGGLE_SPECS_DASHBOARD\`. \`specPanel.showNewSpecPrompt\` is exported so the dashboard's "+ New Spec" reuses the same flow.

## Test plan

- [ ] Specs panel → Tasks tab shows interactive list (instead of raw markdown) when tasks have synced
- [ ] Hover a task row → action buttons appear; clicking Start / Complete / Pause / Reopen flips status, panel auto-refreshes
- [ ] Tab label updates: \`Tasks 2/5\` style count
- [ ] Start any task → spec phase badge becomes \`implementing\`; complete all → \`done\`; reopen one → rewinds to \`implementing\`
- [ ] Flip a spec-derived task's status from the standalone Tasks panel → spec phase reflects change without manual refresh
- [ ] Specs panel header: Dashboard button opens the full-page grid; side panel auto-closes
- [ ] Filter chips work; cards show progress bar, AI tool, relative time
- [ ] Click a card → detail aside slides in (480px), Spec/Plan/Tasks tabs work, action buttons functional in dashboard too
- [ ] Esc closes detail first, then dashboard
- [ ] Drag the spec panel's left edge → width persists across reload
- [ ] Click Expand/Compact toggle → panel jumps 420 ↔ 800; icon flips and tints accent in wide state

🤖 Generated with [Claude Code](https://claude.com/claude-code)