### PR TITLE
feat: spec-driven dev — /spec.implement loop, outcome capture, naming polish

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1424,6 +1424,7 @@
         "getSpec",
         "createSpec",
         "updateSpecStatus",
+        "renameSpec",
         "deleteSpec",
         "derivePhase",
         "getCommandPrompt",
@@ -1440,56 +1441,56 @@
       ],
       "functions": {
         "getSpecsRoot": {
-          "line": 41,
+          "line": 42,
           "params": [
             "projectPath"
           ],
           "purpose": "─── Path helpers ──────────────────────────────────────────"
         },
         "getSpecDir": {
-          "line": 45,
+          "line": 46,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "generateSlug": {
-          "line": 54,
+          "line": 55,
           "params": [
             "title"
           ],
           "purpose": "`-2`, `-3`, ... suffixes. See PROJECT_NOTES.md for the canonical rules."
         },
         "uniqueSlug": {
-          "line": 67,
+          "line": 68,
           "params": [
             "projectPath",
             "baseSlug"
           ]
         },
         "validateSpecStatus": {
-          "line": 80,
+          "line": 81,
           "params": [
             "obj"
           ],
           "purpose": "Returns null when valid, or a human-readable reason string."
         },
         "readFileSafe": {
-          "line": 99,
+          "line": 100,
           "params": [
             "p"
           ],
           "purpose": "─── Filesystem helpers ────────────────────────────────────"
         },
         "readStatus": {
-          "line": 108,
+          "line": 109,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "writeStatus": {
-          "line": 119,
+          "line": 120,
           "params": [
             "projectPath",
             "slug",
@@ -1497,14 +1498,14 @@
           ]
         },
         "listSpecs": {
-          "line": 127,
+          "line": 128,
           "params": [
             "projectPath"
           ],
           "purpose": "─── Public API ────────────────────────────────────────────"
         },
         "fileExists": {
-          "line": 182,
+          "line": 183,
           "params": [
             "projectPath",
             "slug",
@@ -1513,7 +1514,7 @@
           "purpose": "rely on that — defense in depth."
         },
         "derivePhase": {
-          "line": 186,
+          "line": 187,
           "params": [
             "projectPath",
             "slug",
@@ -1522,14 +1523,14 @@
           ]
         },
         "collectSpecTasks": {
-          "line": 205,
+          "line": 206,
           "params": [
             "slug",
             "tasksData"
           ]
         },
         "reconcilePhase": {
-          "line": 211,
+          "line": 212,
           "params": [
             "projectPath",
             "slug",
@@ -1537,14 +1538,14 @@
           ]
         },
         "getDefaultTemplatePath": {
-          "line": 235,
+          "line": 236,
           "params": [
             "aiTool",
             "command"
           ]
         },
         "getOverrideTemplatePath": {
-          "line": 239,
+          "line": 240,
           "params": [
             "projectPath",
             "aiTool",
@@ -1552,7 +1553,7 @@
           ]
         },
         "loadCommandTemplate": {
-          "line": 243,
+          "line": 244,
           "params": [
             "projectPath",
             "aiTool",
@@ -1560,14 +1561,14 @@
           ]
         },
         "interpolate": {
-          "line": 249,
+          "line": 250,
           "params": [
             "template",
             "vars"
           ]
         },
         "getCommandPrompt": {
-          "line": 256,
+          "line": 257,
           "params": [
             "projectPath",
             "slug",
@@ -1576,7 +1577,7 @@
           ]
         },
         "buildSpecCommandFile": {
-          "line": 283,
+          "line": 284,
           "params": [
             "projectPath",
             "slug",
@@ -1585,47 +1586,47 @@
           ]
         },
         "parseTasksMarkdown": {
-          "line": 311,
+          "line": 312,
           "params": [
             "content"
           ]
         },
         "syncTasksFromMarkdown": {
-          "line": 324,
+          "line": 325,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "arraysEqual": {
-          "line": 404,
+          "line": 405,
           "params": [
             "a",
             "b"
           ]
         },
         "syncAllSpecTasks": {
-          "line": 411,
+          "line": 412,
           "params": [
             "projectPath"
           ]
         },
         "getSpec": {
-          "line": 428,
+          "line": 429,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "createSpec": {
-          "line": 441,
+          "line": 443,
           "params": [
             "projectPath",
             "opts"
           ]
         },
         "updateSpecStatus": {
-          "line": 477,
+          "line": 479,
           "params": [
             "projectPath",
             "slug",
@@ -1633,37 +1634,46 @@
           ]
         },
         "deleteSpec": {
-          "line": 495,
+          "line": 497,
           "params": [
             "projectPath",
             "slug"
           ]
         },
+        "renameSpec": {
+          "line": 514,
+          "params": [
+            "projectPath",
+            "oldSlug",
+            "opts"
+          ],
+          "purpose": "Returns { success: true, slug, status } on success, { error } on failure."
+        },
         "startWatching": {
-          "line": 508,
+          "line": 621,
           "params": [
             "projectPath"
           ],
           "purpose": "across all three platforms — if that ever changes, swap in a poller."
         },
         "stopWatching": {
-          "line": 550
+          "line": 663
         },
         "pushSpecData": {
-          "line": 570,
+          "line": 683,
           "params": [
             "projectPath"
           ]
         },
         "init": {
-          "line": 581,
+          "line": 694,
           "params": [
             "window"
           ],
           "purpose": "─── Init + IPC ────────────────────────────────────────────"
         },
         "setupIPC": {
-          "line": 585,
+          "line": 698,
           "params": [
             "ipcMain"
           ]
@@ -1675,12 +1685,14 @@
           "GET_SPEC",
           "CREATE_SPEC",
           "UPDATE_SPEC_STATUS",
+          "RENAME_SPEC",
           "GET_SPEC_PROMPT",
           "BUILD_SPEC_COMMAND_FILE",
           "WATCH_SPECS",
           "UNWATCH_SPECS"
         ],
         "emits": [
+          "TASKS_DATA",
           "TASKS_DATA",
           "SPEC_DATA"
         ]
@@ -3599,7 +3611,8 @@
         "toggle",
         "startWatchingForProject",
         "stopWatching",
-        "showNewSpecPrompt"
+        "showNewSpecPrompt",
+        "showRenameModal"
       ],
       "depends": [
         "electron",
@@ -3663,26 +3676,26 @@
           "line": 195
         },
         "nextActionForPhase": {
-          "line": 250,
+          "line": 260,
           "params": [
             "phase"
           ],
           "purpose": "AI tool is running) can produce the next artifact."
         },
         "renderNextActionBar": {
-          "line": 263,
+          "line": 276,
           "params": [
             "action"
           ]
         },
         "runSpecCommand": {
-          "line": 277,
+          "line": 290,
           "params": [
             "command"
           ]
         },
         "renderTabButton": {
-          "line": 306,
+          "line": 319,
           "params": [
             "tab",
             "label",
@@ -3690,94 +3703,94 @@
           ]
         },
         "hasSpecTasks": {
-          "line": 312
+          "line": 325
         },
         "tasksTabLabel": {
-          "line": 318,
+          "line": 331,
           "params": [
             "hasMarkdown"
           ]
         },
         "renderTabBody": {
-          "line": 327,
+          "line": 340,
           "params": [
             "tab"
           ]
         },
         "renderTasksTabBody": {
-          "line": 340
+          "line": 356
         },
         "renderSpecTaskRow": {
-          "line": 380,
+          "line": 396,
           "params": [
             "task"
           ]
         },
         "attachTaskActionHandlers": {
-          "line": 429
+          "line": 445
         },
         "handleSpecTaskAction": {
-          "line": 442,
+          "line": 458,
           "params": [
             "taskId",
             "action"
           ]
         },
         "switchTab": {
-          "line": 461,
+          "line": 477,
           "params": [
             "tab"
           ]
         },
         "backToList": {
-          "line": 471
+          "line": 487
         },
         "showNewSpecPrompt": {
-          "line": 486,
+          "line": 502,
           "purpose": "`window.prompt` is blocked in Electron's renderer."
         },
-        "parseTitleAndBody": {
-          "line": 574,
-          "params": [
-            "raw"
-          ],
-          "purpose": "matter."
-        },
         "deriveSlugPreview": {
-          "line": 588,
+          "line": 604,
           "params": [
             "title"
           ],
           "purpose": "can preview without a roundtrip. Keep in sync if the canonical changes."
         },
         "showSuggestionModal": {
-          "line": 606,
+          "line": 622,
           "params": [
             "projectPath"
           ],
           "purpose": "them turn it on or skip. Maximum friction: a one-time, dismissable modal."
         },
+        "showRenameModal": {
+          "line": 689,
+          "params": [
+            "status"
+          ],
+          "purpose": "status.json — all atomic from the user's perspective."
+        },
         "showInlineError": {
-          "line": 668,
+          "line": 782,
           "params": [
             "message"
           ]
         },
         "renderMarkdown": {
-          "line": 688,
+          "line": 802,
           "params": [
             "md"
           ],
           "purpose": "─── Helpers ────────────────────────────────────────"
         },
         "escapeHtml": {
-          "line": 698,
+          "line": 812,
           "params": [
             "s"
           ]
         },
         "relativeTime": {
-          "line": 708,
+          "line": 822,
           "params": [
             "iso"
           ]
@@ -4975,8 +4988,26 @@
         "renderDetailHeader": {
           "line": 269
         },
+        "nextActionForPhase": {
+          "line": 340,
+          "params": [
+            "phase"
+          ]
+        },
+        "renderNextActionBar": {
+          "line": 356,
+          "params": [
+            "action"
+          ]
+        },
+        "runSpecCommand": {
+          "line": 370,
+          "params": [
+            "command"
+          ]
+        },
         "tabBtn": {
-          "line": 303,
+          "line": 389,
           "params": [
             "tab",
             "label",
@@ -4984,57 +5015,57 @@
           ]
         },
         "renderDetailBody": {
-          "line": 309
+          "line": 395
         },
         "renderTasksTabBody": {
-          "line": 328
+          "line": 416
         },
         "renderSpecTaskRow": {
-          "line": 365,
+          "line": 453,
           "params": [
             "task"
           ]
         },
         "attachTaskActionHandlers": {
-          "line": 414
+          "line": 502
         },
         "handleSpecTaskAction": {
-          "line": 427,
+          "line": 515,
           "params": [
             "taskId",
             "action"
           ]
         },
         "hasSpecTasks": {
-          "line": 438,
+          "line": 526,
           "purpose": "─── Helpers ────────────────────────────────────────────"
         },
         "tasksTabLabel": {
-          "line": 444,
+          "line": 532,
           "params": [
             "hasMarkdown"
           ]
         },
         "renderMarkdown": {
-          "line": 453,
+          "line": 541,
           "params": [
             "md"
           ]
         },
         "escapeHtml": {
-          "line": 458,
+          "line": 546,
           "params": [
             "s"
           ]
         },
         "relativeTime": {
-          "line": 464,
+          "line": 552,
           "params": [
             "iso"
           ]
         },
         "displayProjectName": {
-          "line": 475,
+          "line": 563,
           "params": [
             "projectPath"
           ]
@@ -5044,7 +5075,8 @@
         "listens": [
           "SPEC_DATA",
           "TASKS_DATA",
-          "TOGGLE_SPECS_DASHBOARD"
+          "TOGGLE_SPECS_DASHBOARD",
+          "SPEC_DATA"
         ],
         "emits": [
           "WATCH_SPECS",
@@ -5272,6 +5304,11 @@
       },
       "TOGGLE_SPECS_DASHBOARD": {
         "name": "toggle-specs-dashboard",
+        "direction": "",
+        "description": ""
+      },
+      "RENAME_SPEC": {
+        "name": "rename-spec",
         "direction": "",
         "description": ""
       }

--- a/src/main/specManager.js
+++ b/src/main/specManager.js
@@ -22,6 +22,7 @@ const STATUS_FILE = 'status.json';
 const SPEC_FILE = 'spec.md';
 const PLAN_FILE = 'plan.md';
 const TASKS_FILE = 'tasks.md';
+const OUTCOME_FILE = 'outcome.md';
 
 const PHASES = ['draft', 'specified', 'planned', 'tasks_generated', 'implementing', 'done'];
 const AI_TOOLS = ['claude-code', 'codex', 'gemini'];
@@ -230,7 +231,7 @@ function reconcilePhase(projectPath, slug, tasksDataOrNull) {
 // are substituted via a simple regex — no expression evaluation.
 
 const FRAME_TEMPLATES_DIR = path.join(__dirname, '..', 'templates');
-const SUPPORTED_COMMANDS = ['spec.new', 'spec.plan', 'spec.tasks'];
+const SUPPORTED_COMMANDS = ['spec.new', 'spec.plan', 'spec.tasks', 'spec.implement'];
 
 function getDefaultTemplatePath(aiTool, command) {
   return path.join(FRAME_TEMPLATES_DIR, 'commands', aiTool, `${command}.md`);
@@ -434,7 +435,8 @@ function getSpec(projectPath, slug) {
     status,
     spec: readFileSafe(path.join(dir, SPEC_FILE)),
     plan: readFileSafe(path.join(dir, PLAN_FILE)),
-    tasks: readFileSafe(path.join(dir, TASKS_FILE))
+    tasks: readFileSafe(path.join(dir, TASKS_FILE)),
+    outcome: readFileSafe(path.join(dir, OUTCOME_FILE))
   };
 }
 
@@ -497,6 +499,117 @@ function deleteSpec(projectPath, slug) {
   if (!fs.existsSync(dir)) return false;
   fs.rmSync(dir, { recursive: true, force: true });
   return true;
+}
+
+// Rename a spec: moves the folder, updates status.json's slug field, and
+// rewrites every spec-derived task's `source` marker in tasks.json so the
+// linkage is preserved. Optionally also updates the display title.
+//
+// Validation rules for the new slug:
+//   - kebab-case [a-z0-9-]+, no leading/trailing hyphens, no double hyphens
+//   - max length SLUG_MAX_LEN
+//   - must not collide with another spec in the project
+//
+// Returns { success: true, slug, status } on success, { error } on failure.
+function renameSpec(projectPath, oldSlug, opts) {
+  const next = opts || {};
+  const wantSlug = next.slug != null;
+  const wantTitle = next.title != null && typeof next.title === 'string';
+
+  if (!wantSlug && !wantTitle) return { error: 'nothing to rename' };
+
+  // Resolve current spec
+  const oldDir = getSpecDir(projectPath, oldSlug);
+  if (!fs.existsSync(oldDir)) return { error: 'spec not found' };
+  const status = readStatus(projectPath, oldSlug);
+  if (!status) return { error: 'status.json missing' };
+
+  let newSlug = oldSlug;
+  let folderRenamed = false;
+
+  if (wantSlug) {
+    const candidate = String(next.slug).trim();
+    const slugRe = /^[a-z0-9]+(?:-[a-z0-9]+)*$/;
+    if (!candidate || !slugRe.test(candidate)) {
+      return { error: 'invalid slug — use kebab-case (a-z, 0-9, single hyphens)' };
+    }
+    if (candidate.length > SLUG_MAX_LEN) {
+      return { error: `slug too long (max ${SLUG_MAX_LEN} chars)` };
+    }
+    if (candidate !== oldSlug) {
+      const collidingDir = getSpecDir(projectPath, candidate);
+      if (fs.existsSync(collidingDir)) return { error: 'slug already in use' };
+
+      // Move folder first; if anything fails after this, we still have data
+      try {
+        fs.renameSync(oldDir, collidingDir);
+        folderRenamed = true;
+        newSlug = candidate;
+      } catch (err) {
+        return { error: 'could not rename folder: ' + err.message };
+      }
+    }
+  }
+
+  const now = new Date().toISOString();
+  const newStatus = {
+    ...status,
+    slug: newSlug,
+    title: wantTitle ? String(next.title).trim() || status.title : status.title,
+    updated_at: now
+  };
+  writeStatus(projectPath, newSlug, newStatus);
+
+  // Update every spec-derived task's source marker if the slug changed.
+  // Keep going even if this fails — folder rename is the canonical change.
+  if (folderRenamed) {
+    try {
+      const tasksData = tasksManager.loadTasks(projectPath);
+      if (tasksData && Array.isArray(tasksData.tasks)) {
+        const oldPrefix = `spec:${oldSlug}:`;
+        const newPrefix = `spec:${newSlug}:`;
+        const oldIdPrefix = `task-spec-${oldSlug}-`;
+        const newIdPrefix = `task-spec-${newSlug}-`;
+        let touched = 0;
+        for (const task of tasksData.tasks) {
+          if (task && typeof task.source === 'string' && task.source.startsWith(oldPrefix)) {
+            task.source = newPrefix + task.source.slice(oldPrefix.length);
+            // Also rewrite the deterministic id so it stays in sync
+            if (task.id && task.id.startsWith(oldIdPrefix)) {
+              task.id = newIdPrefix + task.id.slice(oldIdPrefix.length);
+            }
+            // Keep context field readable too
+            if (task.context === `From spec: ${oldSlug}`) {
+              task.context = `From spec: ${newSlug}`;
+            }
+            task.updatedAt = now;
+            touched++;
+          }
+        }
+        if (touched > 0) {
+          tasksManager.saveTasks(projectPath, tasksData);
+          if (mainWindow && !mainWindow.isDestroyed()) {
+            mainWindow.webContents.send(IPC.TASKS_DATA, { projectPath, tasks: tasksData });
+          }
+        }
+
+        // Also update generated_task_ids in status.json so back-references stay valid
+        if (Array.isArray(newStatus.generated_task_ids) && newStatus.generated_task_ids.length > 0) {
+          newStatus.generated_task_ids = newStatus.generated_task_ids.map(id =>
+            id.startsWith(oldIdPrefix) ? newIdPrefix + id.slice(oldIdPrefix.length) : id
+          );
+          writeStatus(projectPath, newSlug, newStatus);
+        }
+      }
+    } catch (err) {
+      console.error('specManager: tasks.json source-marker update failed', err);
+    }
+  }
+
+  // Trigger a fresh SPEC_DATA push so the panel reflects the new slug
+  pushSpecData(projectPath);
+
+  return { success: true, slug: newSlug, status: newStatus };
 }
 
 // ─── Watcher ───────────────────────────────────────────────
@@ -595,6 +708,9 @@ function setupIPC(ipcMain) {
   ipcMain.handle(IPC.UPDATE_SPEC_STATUS, (event, { projectPath, slug, partial }) =>
     updateSpecStatus(projectPath, slug, partial)
   );
+  ipcMain.handle(IPC.RENAME_SPEC, (event, { projectPath, oldSlug, opts }) =>
+    renameSpec(projectPath, oldSlug, opts)
+  );
   ipcMain.handle(IPC.GET_SPEC_PROMPT, (event, { projectPath, slug, command, aiTool }) =>
     getCommandPrompt(projectPath, slug, command, aiTool)
   );
@@ -619,6 +735,7 @@ module.exports = {
   getSpec,
   createSpec,
   updateSpecStatus,
+  renameSpec,
   deleteSpec,
   derivePhase,
   getCommandPrompt,

--- a/src/renderer/specPanel.js
+++ b/src/renderer/specPanel.js
@@ -198,7 +198,7 @@ function renderDetail() {
     contentEl.innerHTML = '<div class="specs-empty"><p>Spec not found.</p></div>';
     return;
   }
-  const { status, spec, plan, tasks } = activeSpec;
+  const { status, spec, plan, tasks, outcome } = activeSpec;
   const phaseLabel = status.phase.replace(/_/g, ' ');
   const aiLabel = status.ai_tool || '';
   const nextAction = nextActionForPhase(status.phase);
@@ -211,6 +211,12 @@ function renderDetail() {
           Back
         </button>
         <span class="spec-detail-slug">${escapeHtml(status.slug)}</span>
+        <button class="spec-rename-btn" id="spec-rename-btn" title="Rename spec" aria-label="Rename spec">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+          </svg>
+        </button>
       </div>
       <div class="spec-detail-header">
         <h3 class="spec-detail-title">${escapeHtml(status.title)}</h3>
@@ -224,6 +230,7 @@ function renderDetail() {
         ${renderTabButton('spec', 'Spec', !!spec)}
         ${renderTabButton('plan', 'Plan', !!plan)}
         ${renderTabButton('tasks', tasksTabLabel(!!tasks), !!tasks || hasSpecTasks())}
+        ${renderTabButton('outcome', 'Outcome', !!outcome)}
       </div>
       <div class="spec-detail-body" id="spec-detail-body">
         ${renderTabBody(activeTab)}
@@ -237,6 +244,9 @@ function renderDetail() {
   });
   contentEl.querySelector('#spec-action-btn')?.addEventListener('click', () => {
     if (nextAction) runSpecCommand(nextAction.command);
+  });
+  contentEl.querySelector('#spec-rename-btn')?.addEventListener('click', () => {
+    if (activeSpec) showRenameModal(activeSpec.status);
   });
   if (activeTab === 'tasks') attachTaskActionHandlers();
 }
@@ -255,8 +265,11 @@ function nextActionForPhase(phase) {
       return { command: 'spec.plan', label: 'Run /spec.plan', hint: 'Generate plan.md from the spec.' };
     case 'planned':
       return { command: 'spec.tasks', label: 'Run /spec.tasks', hint: 'Break the plan into discrete tasks.' };
+    case 'tasks_generated':
+    case 'implementing':
+      return { command: 'spec.implement', label: 'Run /spec.implement', hint: 'Implement the next pending task — one per click.' };
     default:
-      return null; // tasks_generated / implementing / done — Slice 2 wires /spec.implement
+      return null; // 'done' or unknown
   }
 }
 
@@ -333,6 +346,9 @@ function renderTabBody(tab) {
 
   const md = activeSpec?.[tab];
   if (md) return renderMarkdown(md);
+  if (tab === 'outcome') {
+    return `<div class="spec-empty-tab">No outcomes yet — they're captured automatically as <code>/spec.implement</code> completes each task.</div>`;
+  }
   const cmdMap = { spec: '/spec.new', plan: '/spec.plan', tasks: '/spec.tasks' };
   return `<div class="spec-empty-tab">No <code>${tab}.md</code> yet — run <code>${cmdMap[tab]}</code> from the terminal.</div>`;
 }
@@ -495,18 +511,28 @@ function showNewSpecPrompt() {
   overlay.innerHTML = `
     <div class="spec-modal spec-modal-wide" role="dialog" aria-modal="true" aria-labelledby="spec-modal-title">
       <h3 id="spec-modal-title">New Spec</h3>
-      <p>Describe what you want to build. The first line becomes the title; the rest seeds <code>spec.md</code>.</p>
+      <p>Give your spec a short, action-oriented title. Description is optional and seeds <code>spec.md</code> if provided.</p>
+
+      <label class="spec-modal-field-label" for="spec-modal-title-input">Title</label>
+      <input
+        id="spec-modal-title-input"
+        type="text"
+        class="spec-modal-input"
+        placeholder="Add Share button to ProductPage"
+        autocomplete="off"
+        spellcheck="false"
+      />
+
+      <label class="spec-modal-field-label" for="spec-modal-desc-input">Description <span class="spec-modal-field-optional">(optional)</span></label>
       <textarea
+        id="spec-modal-desc-input"
         class="spec-modal-textarea"
-        rows="10"
-        placeholder="Add Share button to ProductPage&#10;&#10;Customers viewing a product page have no quick way to share it on social media. The current flow requires copying the URL and pasting it manually into Twitter/X. We want a Share button next to the cart CTA that opens a Twitter intent URL prefilled with the product title and canonical URL."
+        rows="6"
+        placeholder="Customers viewing a product page have no quick way to share it on social media. We want a Share button next to the cart CTA that opens a Twitter intent URL prefilled with the product title and canonical URL."
         autocomplete="off"
         spellcheck="false"
       ></textarea>
-      <div class="spec-modal-meta">
-        <span class="spec-modal-slug-label">Slug:</span>
-        <code class="spec-modal-slug">—</code>
-      </div>
+
       <div class="spec-modal-error" role="alert"></div>
       <div class="spec-modal-actions">
         <button type="button" class="btn btn-secondary spec-modal-cancel">Cancel</button>
@@ -516,26 +542,28 @@ function showNewSpecPrompt() {
   `;
   document.body.appendChild(overlay);
 
-  const input = overlay.querySelector('.spec-modal-textarea');
-  const slugEl = overlay.querySelector('.spec-modal-slug');
+  const titleInput = overlay.querySelector('#spec-modal-title-input');
+  const descInput = overlay.querySelector('#spec-modal-desc-input');
   const errorEl = overlay.querySelector('.spec-modal-error');
   const cancelBtn = overlay.querySelector('.spec-modal-cancel');
   const createBtn = overlay.querySelector('.spec-modal-create');
 
-  setTimeout(() => input.focus(), 30);
-
-  // Live slug preview from the first line
-  const updateSlugPreview = () => {
-    const { title } = parseTitleAndBody(input.value);
-    slugEl.textContent = title ? deriveSlugPreview(title) : '—';
-  };
-  input.addEventListener('input', updateSlugPreview);
+  setTimeout(() => titleInput.focus(), 30);
 
   const close = () => overlay.remove();
   const submit = async () => {
-    const { title, description } = parseTitleAndBody(input.value);
+    const title = titleInput.value.trim();
+    const description = descInput.value.trim();
     if (!title) {
-      input.focus();
+      titleInput.focus();
+      return;
+    }
+    // If the title is all symbols / non-Latin characters, the auto-derived
+    // slug ends up empty. Surface that as a friendly message instead of
+    // exposing the word "slug" to the user.
+    if (!deriveSlugPreview(title)) {
+      errorEl.textContent = 'Title needs at least one letter or number.';
+      titleInput.focus();
       return;
     }
     createBtn.disabled = true;
@@ -549,14 +577,17 @@ function showNewSpecPrompt() {
       return;
     }
     close();
-    // SPEC_DATA push refreshes the list. /spec.new (Slice 1.7) will deep-link
-    // straight into the new detail view; for now the user lands on the list.
   };
 
   cancelBtn.addEventListener('click', close);
   createBtn.addEventListener('click', submit);
-  input.addEventListener('keydown', e => {
-    // Cmd/Ctrl+Enter submits — bare Enter inserts a newline (textarea default)
+  // Title input: Enter submits
+  titleInput.addEventListener('keydown', e => {
+    if (e.key === 'Enter') { e.preventDefault(); submit(); }
+    if (e.key === 'Escape') close();
+  });
+  // Description: Cmd/Ctrl+Enter submits, bare Enter inserts newline
+  descInput.addEventListener('keydown', e => {
     if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) {
       e.preventDefault();
       submit();
@@ -566,21 +597,6 @@ function showNewSpecPrompt() {
   overlay.addEventListener('click', e => {
     if (e.target === overlay) close();
   });
-}
-
-// First non-empty line is the title; remaining text (after a blank line) is
-// the description. Trims aggressively so a stray trailing newline doesn't
-// matter.
-function parseTitleAndBody(raw) {
-  const text = String(raw || '').trim();
-  if (!text) return { title: '', description: '' };
-  const lines = text.split(/\r?\n/);
-  const title = lines[0].trim();
-  // Skip the title line and any blank lines after it
-  let i = 1;
-  while (i < lines.length && lines[i].trim() === '') i++;
-  const description = lines.slice(i).join('\n').trim();
-  return { title, description };
 }
 
 // Same shape as specManager.generateSlug — duplicated here so the renderer
@@ -665,6 +681,104 @@ function showSuggestionModal(projectPath) {
   });
 }
 
+// Rename modal — lets the user fix an ugly auto-derived slug or rename a
+// spec post-hoc. Renaming is non-trivial: backend moves the folder, rewrites
+// every spec-derived task's `source` marker in tasks.json, and updates
+// status.json — all atomic from the user's perspective.
+
+function showRenameModal(status) {
+  const projectPath = state.getProjectPath();
+  if (!projectPath) return;
+
+  const overlay = document.createElement('div');
+  overlay.className = 'spec-modal-overlay';
+  overlay.innerHTML = `
+    <div class="spec-modal" role="dialog" aria-modal="true" aria-labelledby="spec-rename-title">
+      <h3 id="spec-rename-title">Rename Spec</h3>
+      <p>Both the folder and every task's <code>source</code> marker will update.</p>
+
+      <label class="spec-modal-field-label" for="spec-rename-title-input">Title</label>
+      <input
+        id="spec-rename-title-input"
+        type="text"
+        class="spec-modal-input"
+        autocomplete="off"
+        spellcheck="false"
+      />
+
+      <label class="spec-modal-field-label" for="spec-rename-slug-input">Slug <span class="spec-modal-field-optional">(folder name, kebab-case)</span></label>
+      <input
+        id="spec-rename-slug-input"
+        type="text"
+        class="spec-modal-input"
+        autocomplete="off"
+        spellcheck="false"
+        pattern="[a-z0-9]+(?:-[a-z0-9]+)*"
+      />
+
+      <div class="spec-modal-error" role="alert"></div>
+      <div class="spec-modal-actions">
+        <button type="button" class="btn btn-secondary spec-rename-cancel">Cancel</button>
+        <button type="button" class="btn btn-primary spec-rename-save">Save</button>
+      </div>
+    </div>
+  `;
+  document.body.appendChild(overlay);
+
+  const titleInput = overlay.querySelector('#spec-rename-title-input');
+  const slugInput = overlay.querySelector('#spec-rename-slug-input');
+  const errorEl = overlay.querySelector('.spec-modal-error');
+  const cancelBtn = overlay.querySelector('.spec-rename-cancel');
+  const saveBtn = overlay.querySelector('.spec-rename-save');
+
+  titleInput.value = status.title || '';
+  slugInput.value = status.slug || '';
+  setTimeout(() => slugInput.select(), 30);
+
+  const close = () => overlay.remove();
+  const submit = async () => {
+    const newTitle = titleInput.value.trim();
+    const newSlug = slugInput.value.trim();
+    if (!newTitle) {
+      errorEl.textContent = 'Title cannot be empty.';
+      titleInput.focus();
+      return;
+    }
+    if (!newSlug || !/^[a-z0-9]+(?:-[a-z0-9]+)*$/.test(newSlug)) {
+      errorEl.textContent = 'Slug must be kebab-case (a-z, 0-9, single hyphens).';
+      slugInput.focus();
+      return;
+    }
+    saveBtn.disabled = true;
+    const result = await ipcRenderer.invoke(IPC.RENAME_SPEC, {
+      projectPath,
+      oldSlug: status.slug,
+      opts: { slug: newSlug, title: newTitle }
+    });
+    if (!result || result.error) {
+      errorEl.textContent = result?.error || 'Rename failed.';
+      saveBtn.disabled = false;
+      return;
+    }
+    // Slug changed → swap our active reference so the next reload hits the new folder
+    if (result.slug && result.slug !== status.slug) {
+      activeSlug = result.slug;
+    }
+    close();
+    reloadDetail();
+  };
+
+  cancelBtn.addEventListener('click', close);
+  saveBtn.addEventListener('click', submit);
+  [titleInput, slugInput].forEach(el => el.addEventListener('keydown', e => {
+    if (e.key === 'Enter') { e.preventDefault(); submit(); }
+    if (e.key === 'Escape') close();
+  }));
+  overlay.addEventListener('click', e => {
+    if (e.target === overlay) close();
+  });
+}
+
 function showInlineError(message) {
   // Lightweight toast — same overlay shell as the modal, info-only
   const overlay = document.createElement('div');
@@ -723,5 +837,6 @@ module.exports = {
   toggle,
   startWatchingForProject,
   stopWatching,
-  showNewSpecPrompt
+  showNewSpecPrompt,
+  showRenameModal
 };

--- a/src/renderer/specsDashboard.js
+++ b/src/renderer/specsDashboard.js
@@ -268,24 +268,33 @@ async function reloadDetail() {
 
 function renderDetailHeader() {
   if (!detailContentEl || !selectedSpec) return;
-  const { status, spec, plan, tasks } = selectedSpec;
+  const { status, spec, plan, tasks, outcome } = selectedSpec;
   const phaseLabel = status.phase.replace(/_/g, ' ');
   const aiLabel = status.ai_tool || '';
+  const nextAction = nextActionForPhase(status.phase);
 
   detailContentEl.innerHTML = `
     <div class="specs-dashboard-detail-head">
       <div class="specs-dashboard-detail-meta">
         <span class="specs-dashboard-detail-slug">${escapeHtml(status.slug)}</span>
+        <button class="spec-rename-btn" id="spec-rename-btn" title="Rename spec" aria-label="Rename spec">
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M11 4H4a2 2 0 0 0-2 2v14a2 2 0 0 0 2 2h14a2 2 0 0 0 2-2v-7"/>
+            <path d="M18.5 2.5a2.121 2.121 0 0 1 3 3L12 15l-4 1 1-4 9.5-9.5z"/>
+          </svg>
+        </button>
         ${aiLabel ? `<span class="specs-detail-ai">${escapeHtml(aiLabel)}</span>` : ''}
       </div>
       <h3 class="specs-dashboard-detail-title">${escapeHtml(status.title)}</h3>
       <div class="specs-dashboard-detail-meta">
         <span class="spec-phase-badge phase-${status.phase}">${phaseLabel}</span>
       </div>
+      ${nextAction ? renderNextActionBar(nextAction) : ''}
       <div class="specs-dashboard-detail-tabs">
         ${tabBtn('spec',  'Spec',  !!spec)}
         ${tabBtn('plan',  'Plan',  !!plan)}
         ${tabBtn('tasks', tasksTabLabel(!!tasks), !!tasks || hasSpecTasks())}
+        ${tabBtn('outcome', 'Outcome', !!outcome)}
       </div>
     </div>
     <div class="specs-dashboard-detail-body" id="specs-dashboard-detail-body"></div>
@@ -298,6 +307,83 @@ function renderDetailHeader() {
       attachTaskActionHandlers();
     });
   });
+  detailContentEl.querySelector('#spec-action-btn')?.addEventListener('click', () => {
+    if (nextAction) runSpecCommand(nextAction.command);
+  });
+  detailContentEl.querySelector('#spec-rename-btn')?.addEventListener('click', () => {
+    if (selectedSpec) {
+      // Reuse the side panel's rename modal for consistency. After a successful
+      // rename, the slug change propagates via SPEC_DATA push so we sync our
+      // selection too.
+      const oldSlug = selectedSpec.status.slug;
+      require('./specPanel').showRenameModal?.(selectedSpec.status);
+      // Fallback: poll for slug change via the next SPEC_DATA push and re-select.
+      // (specPanel's modal will reload its own detail; we react when the rename
+      // completes by checking the cached specs list on the next push.)
+      const onceListener = (event, payload) => {
+        const renamedSlug = (payload?.specs || []).find(s =>
+          s.title === selectedSpec.status.title && s.slug !== oldSlug
+        )?.slug;
+        if (renamedSlug) {
+          selectedSlug = renamedSlug;
+          reloadDetail();
+        }
+        ipcRenderer.removeListener(IPC.SPEC_DATA, onceListener);
+      };
+      ipcRenderer.on(IPC.SPEC_DATA, onceListener);
+      // Auto-cleanup after 30s in case rename was cancelled
+      setTimeout(() => ipcRenderer.removeListener(IPC.SPEC_DATA, onceListener), 30000);
+    }
+  });
+}
+
+function nextActionForPhase(phase) {
+  switch (phase) {
+    case 'draft':
+      return { command: 'spec.new',  label: 'Run /spec.new', hint: 'Have Claude write spec.md from your description.' };
+    case 'specified':
+      return { command: 'spec.plan', label: 'Run /spec.plan', hint: 'Generate plan.md from the spec.' };
+    case 'planned':
+      return { command: 'spec.tasks', label: 'Run /spec.tasks', hint: 'Break the plan into discrete tasks.' };
+    case 'tasks_generated':
+    case 'implementing':
+      return { command: 'spec.implement', label: 'Run /spec.implement', hint: 'Implement the next pending task — one per click.' };
+    default:
+      return null;
+  }
+}
+
+function renderNextActionBar(action) {
+  return `
+    <div class="spec-next-action">
+      <div class="spec-next-action-text">
+        <strong>${escapeHtml(action.label)}</strong>
+        <span>${escapeHtml(action.hint)}</span>
+      </div>
+      <button class="btn btn-primary spec-action-btn" id="spec-action-btn">
+        ${escapeHtml(action.label)}
+      </button>
+    </div>
+  `;
+}
+
+async function runSpecCommand(command) {
+  if (!selectedSlug) return;
+  const projectPath = state.getProjectPath();
+  if (!projectPath) return;
+  const result = await ipcRenderer.invoke(IPC.BUILD_SPEC_COMMAND_FILE, {
+    projectPath,
+    slug: selectedSlug,
+    command,
+    aiTool: 'claude-code'
+  });
+  if (!result || !result.success) {
+    console.error('specsDashboard: BUILD_SPEC_COMMAND_FILE failed', result?.error);
+    return;
+  }
+  if (typeof window.terminalSendCommand === 'function') {
+    window.terminalSendCommand(result.instruction);
+  }
 }
 
 function tabBtn(tab, label, hasContent) {
@@ -319,6 +405,8 @@ function renderDetailBody() {
   const md = selectedSpec[selectedTab];
   if (md) {
     body.innerHTML = renderMarkdown(md);
+  } else if (selectedTab === 'outcome') {
+    body.innerHTML = `<div class="spec-empty-tab">No outcomes yet — they're captured automatically as <code>/spec.implement</code> completes each task.</div>`;
   } else {
     const cmdMap = { spec: '/spec.new', plan: '/spec.plan', tasks: '/spec.tasks' };
     body.innerHTML = `<div class="spec-empty-tab">No <code>${selectedTab}.md</code> yet — run <code>${cmdMap[selectedTab]}</code> from the terminal.</div>`;

--- a/src/renderer/styles/components/panels.css
+++ b/src/renderer/styles/components/panels.css
@@ -4773,6 +4773,25 @@
   color: var(--text-muted);
 }
 
+.spec-rename-btn {
+  background: transparent;
+  border: none;
+  color: var(--text-muted);
+  cursor: pointer;
+  padding: 2px;
+  border-radius: var(--radius-sm);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition-fast);
+  margin-left: 4px;
+}
+
+.spec-rename-btn:hover {
+  color: var(--accent-primary);
+  background: var(--accent-subtle);
+}
+
 .spec-detail-header {
   border-bottom: 1px solid var(--border-subtle);
   padding-bottom: var(--space-md);
@@ -5135,6 +5154,24 @@
 
 .spec-modal-input:focus {
   border-color: var(--accent-primary);
+}
+
+.spec-modal-field-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-tertiary);
+  font-weight: 600;
+  margin-bottom: -4px;
+  margin-top: var(--space-xs);
+}
+
+.spec-modal-field-optional {
+  text-transform: none;
+  letter-spacing: 0;
+  color: var(--text-muted);
+  font-weight: 400;
+  font-size: 10px;
 }
 
 .spec-modal-textarea {

--- a/src/shared/ipcChannels.js
+++ b/src/shared/ipcChannels.js
@@ -143,6 +143,7 @@ const IPC = {
   GET_SPEC: 'get-spec',
   CREATE_SPEC: 'create-spec',
   UPDATE_SPEC_STATUS: 'update-spec-status',
+  RENAME_SPEC: 'rename-spec',
   WATCH_SPECS: 'watch-specs',
   UNWATCH_SPECS: 'unwatch-specs',
   SPEC_DATA: 'spec-data',

--- a/src/templates/commands/claude-code/spec.implement.md
+++ b/src/templates/commands/claude-code/spec.implement.md
@@ -1,0 +1,67 @@
+You are running the implementation loop for an existing Frame spec. Take the
+NEXT pending task on this spec and ship it end-to-end in this single turn —
+then capture what you actually did so the next session has context.
+
+## Context
+
+- Project root: `{project_path}`
+- Spec slug: `{slug}`
+- Inputs (read these first, in order):
+  - `.frame/specs/{slug}/spec.md` — what we're building (intent, constraints)
+  - `.frame/specs/{slug}/plan.md` — the architecture and approach
+  - `.frame/specs/{slug}/tasks.md` — the canonical task list
+  - `.frame/specs/{slug}/outcome.md` — what previous tasks actually shipped (read this if it exists; it tells you why the codebase may differ from the plan)
+  - `tasks.json` — find the next task where `source` starts with `spec:{slug}:` AND `status === "pending"` (lowest T-number first)
+
+## What "implement" means
+
+Pick exactly ONE pending task. Don't bundle. You'll be invoked again per task.
+Within this single turn:
+
+1. Decide on the smallest concrete change that satisfies the task
+2. Edit the relevant files (use the Edit / Write tools as needed)
+3. If the change requires anything the plan didn't predict — a missed constraint,
+   a refactor that should be its own task, a dependency you have to add — STOP and
+   surface it to the user before continuing. Don't silently expand scope.
+
+## When the change is in place
+
+**Mark the task completed** by editing `tasks.json` directly:
+- Find the task object whose `source === "spec:{slug}:T<n>"`
+- Set `status: "completed"`
+- Set `completedAt` and `updatedAt` to the current ISO timestamp
+
+**Capture what shipped** by appending to `.frame/specs/{slug}/outcome.md`. Create
+the file if it doesn't exist; otherwise append to the end. Each entry uses this
+exact shape:
+
+```
+## T<n> — <task title>
+
+<2–3 sentence summary. What you actually did. Any deviation from plan.md.
+Files touched. No filler. No "I successfully implemented...". Just the facts.>
+
+_Captured: <ISO date> · <N> file change(s)_
+
+---
+```
+
+The trailing `---` keeps multiple entries readable.
+
+## Style for the outcome entry
+
+- Imperative voice, past tense actions ("Wired the…", "Replaced X with Y because…").
+- If the implementation diverged from `plan.md`, **name the divergence**. That's the
+  whole point of capturing this.
+- If you noticed followup work that should become its own task or spec, add a
+  one-liner: `Followup: <one sentence>`.
+- Hard cap: 4 sentences. Be ruthless. The reader 6 months from now should learn
+  the story without reading the diff.
+
+## Stop conditions
+
+- Task is ambiguous → ask one focused clarifying question, do nothing else.
+- Plan is materially out of date (file paths gone, approach contradicts current code)
+  → flag it, do nothing else, do not implement.
+- No pending tasks remain → tell the user the spec is fully implemented and suggest
+  marking phase `"done"` in `status.json`.

--- a/tasks.json
+++ b/tasks.json
@@ -7,7 +7,7 @@
   },
   "project": "Frame",
   "version": "2.0",
-  "lastUpdated": "2026-04-30T15:56:06.717Z",
+  "lastUpdated": "2026-05-01T00:00:00Z",
   "taskSchema": {
     "_comment": "This schema shows the expected structure for each task",
     "id": "unique-id (task-xxx format)",
@@ -858,13 +858,13 @@
       "title": "Add `src/templates/roles/AGENTS.md` starter template with Purpose / Steps / Commands / Notes sections and an inline behavior protocol covering session-start read, first-run capture, follow-up delta-only mode, and capture-only-with-approval.",
       "description": "",
       "source": "spec:agentlar-iin-roller-tanmlamay-dnyorum-aklmdaki-f:T01",
-      "status": "pending",
+      "status": "completed",
       "priority": "medium",
       "category": "feature",
       "context": "From spec: agentlar-iin-roller-tanmlamay-dnyorum-aklmdaki-f",
       "createdAt": "2026-04-30T15:56:06.716Z",
-      "updatedAt": "2026-04-30T15:56:06.716Z",
-      "completedAt": null
+      "updatedAt": "2026-05-01T14:15:03.484Z",
+      "completedAt": "2026-05-01T14:15:03.484Z"
     },
     {
       "id": "task-spec-agentlar-iin-roller-tanmlamay-dnyorum-aklmdaki-f-T02",
@@ -917,11 +917,86 @@
       "createdAt": "2026-04-30T15:56:06.716Z",
       "updatedAt": "2026-04-30T15:56:06.716Z",
       "completedAt": null
+    },
+    {
+      "id": "spec-2.1",
+      "title": "Interactive Tasks subview + Specs Dashboard + resizable panel",
+      "description": "Side-panel Tasks tab now renders the live tasks.json subset (filtered by source: spec:<slug>:*) as an interactive list with hover-revealed Start/Complete/Pause/Reopen actions. Phase auto-advance now considers task statuses (any in_progress/completed → 'implementing'; all completed → 'done'; reopen rewinds). Second fs.watch on tasks.json so flips from the standalone Tasks panel propagate. Full-page Specs Dashboard (card grid + filter chips + 480px detail aside) opened from a Dashboard button in the panel header — symmetric with Tasks Dashboard. Drag handle on panel's left edge (360-1000px, persisted) plus one-tap Expand/Compact toggle (420 ↔ 800).",
+      "userRequest": "User said: bu spec'in tasklarını nerede göreceğim? bunları bir yerde görmek istiyorum. plus: panel görünümünden dashboarda mı geçirsek + paneli büyütebilelim.",
+      "acceptanceCriteria": "Done: Tasks tab renders interactive list with X/Y count. Status flips work and auto-advance phase. Dashboard button opens full-page card grid; cards show progress bar, phase badge, AI tool, time. Card click slides in 480px detail aside with same Spec/Plan/Tasks tabs and interactive task list. Side panel resizable via left-edge drag handle (persisted) and Expand toggle. Side panel auto-hides when dashboard opens.",
+      "notes": "Shipped via PR #72 (commit 670670d).",
+      "status": "completed",
+      "priority": "high",
+      "category": "feature",
+      "context": "Session 2026-04-30 - Slice 2.1",
+      "createdAt": "2026-04-30T00:00:00Z",
+      "updatedAt": "2026-05-01T00:00:00Z",
+      "completedAt": "2026-05-01T00:00:00Z"
+    },
+    {
+      "id": "spec-2.2",
+      "title": "/spec.implement loop + outcome.md capture",
+      "description": "Wire the implementation phase: a 'Run /spec.implement' next-action button (visible when phase is 'tasks_generated' or 'implementing' with pending tasks) sends a prompt that asks Claude to (1) read spec/plan/tasks, (2) take the next pending task, (3) implement it, (4) flip the task to completed in tasks.json via the existing UPDATE_TASK channel, AND (5) — critical — append a 2-3 sentence outcome to .frame/specs/<slug>/outcome.md under heading '## T<n> — <title>'. Outcome captures what was actually done, deviations from plan, files touched, followups. Lives in the same .frame/specs/<slug>/ folder. Per-task, append-only. Plant the capture step as the FINAL instruction in the prompt template so the agent writes while context is fresh.",
+      "userRequest": "User said: tasklar execute edildiğinde ve tamamlandığında ne yapıldığını da kayıt altına almak istiyorum. yani planda aslında ne yapılacağı var ama task bittikten sonra farklı şeyler olduysa kayıt altına alınabilir mi?",
+      "acceptanceCriteria": "/spec.implement button visible at the right phase; click sends interpolated prompt to terminal via existing BUILD_SPEC_COMMAND_FILE pipeline; Claude completes one task per click and appends entry to outcome.md; status.json phase auto-advances via task-status driven derivePhase (already shipped). Template enforces brevity (max 3 sentences, no marketing tone). Tested round-trip with at least one task in this codebase's own .frame/specs/.",
+      "notes": "Outcome capture is the answer to the spec-drift problem we discussed. Lives in /spec.implement template (Slice 2.2), separate Outcome UI tab is Slice 2.3.",
+      "status": "pending",
+      "priority": "high",
+      "category": "feature",
+      "context": "Session 2026-05-01 - Slice 2 design + outcome capture",
+      "createdAt": "2026-05-01T00:00:00Z",
+      "updatedAt": "2026-05-01T00:00:00Z",
+      "completedAt": null
+    },
+    {
+      "id": "spec-2.3",
+      "title": "Outcome tab in spec detail (side panel + dashboard)",
+      "description": "Render outcome.md in a new 'Outcome' tab next to Spec/Plan/Tasks. Same markdown rendering pipeline as the other tabs. Empty state: 'Outcomes capture as tasks complete via /spec.implement'. Tab label shows entry count when present. Available in both the side panel detail view and the dashboard detail aside (same render helper either way).",
+      "userRequest": "Subtask of outcome capture flow (Slice 2.2 design).",
+      "acceptanceCriteria": "Outcome tab appears in detail view when outcome.md exists. Renders entries in newest-first order. Each entry shows title, captured date, and the summary paragraph. Live-updates via SPEC_DATA push when /spec.implement appends a new entry.",
+      "notes": "After 2.2 lands and outcome.md starts being written, this tab gives users the readable surface for it.",
+      "status": "pending",
+      "priority": "medium",
+      "category": "feature",
+      "context": "Session 2026-05-01 - Slice 2",
+      "createdAt": "2026-05-01T00:00:00Z",
+      "updatedAt": "2026-05-01T00:00:00Z",
+      "completedAt": null
+    },
+    {
+      "id": "spec-2.4",
+      "title": "Branch automation per spec",
+      "description": "First /spec.implement run for a spec creates a feat/<slug> branch and switches to it (uses existing CREATE_GIT_BRANCH IPC). Subsequent runs assume already on that branch. status.json gets a `branch` field tracking the linkage. UI surface: small branch chip on spec detail header showing the linked branch. Avoid creating branches when one with the same name already exists or when there are uncommitted changes — surface a soft warning instead.",
+      "userRequest": "Subtask of Slice 2 implementation loop (per meta task spec-driven-dev).",
+      "acceptanceCriteria": "Fresh /spec.implement on a spec → feat/<slug> branch created and active. status.json.branch reflects it. Re-running /spec.implement on the same spec → no new branch, just continues. Conflict cases (branch exists, dirty tree) handled with a clear modal warning.",
+      "notes": "Optional add-on; some users may prefer manual branching. Could ship behind a per-project setting if it gets pushback.",
+      "status": "pending",
+      "priority": "medium",
+      "category": "feature",
+      "context": "Session 2026-05-01 - Slice 2",
+      "createdAt": "2026-05-01T00:00:00Z",
+      "updatedAt": "2026-05-01T00:00:00Z",
+      "completedAt": null
+    },
+    {
+      "id": "spec-2.5",
+      "title": "Multi-spec switcher (active spec context)",
+      "description": "When multiple specs are 'implementing' simultaneously, give the user a quick way to switch which spec /spec.implement targets. Likely a small selector chip in the spec panel header showing the 'active spec' for implementation, plus the same indicator in the dashboard. Avoids accidentally implementing a different spec when more than one is in flight.",
+      "userRequest": "Subtask of Slice 2 implementation loop (per meta task spec-driven-dev).",
+      "acceptanceCriteria": "When >1 spec is in 'implementing' phase, a switcher appears in panel header with the active spec selected. /spec.implement button always operates on the active one. Switcher persists across reloads.",
+      "notes": "Lower priority than 2.2/2.3 since most users will work on one spec at a time. Listed for completeness from the meta task plan.",
+      "status": "pending",
+      "priority": "low",
+      "category": "feature",
+      "context": "Session 2026-05-01 - Slice 2",
+      "createdAt": "2026-05-01T00:00:00Z",
+      "updatedAt": "2026-05-01T00:00:00Z",
+      "completedAt": null
     }
   ],
   "metadata": {
-    "totalCreated": 56,
-    "totalCompleted": 16
+    "totalCreated": 61,
+    "totalCompleted": 17
   },
   "categories": {
     "feature": "New features",


### PR DESCRIPTION
## Summary

Closes the spec → ship round trip and fixes the create-time naming UX.

**1. /spec.implement loop (Slice 2.2)**
- New \`spec.implement.md\` command template tells Claude to take ONE pending task, ship it end-to-end, mark it completed in \`tasks.json\` directly, and append a 2-3 sentence entry to \`outcome.md\`.
- "Run /spec.implement" next-action button surfaces when phase is \`tasks_generated\` or \`implementing\`, in both side panel and dashboard detail.
- **Outcome capture is the answer to spec drift**: each task records what actually happened — including deviations from plan.md — while the agent's memory is fresh.

**2. Outcome view (Slice 2.3)**
- New "Outcome" tab in side panel detail + dashboard detail aside, alongside Spec / Plan / Tasks.
- \`specManager.getSpec\` returns outcome content; existing watcher covers \`.frame/specs/<slug>/\` recursively so live updates come for free.

**3. Naming polish — two-field modal + rename**
- New Spec modal split into **Title** (required, drives slug behind the scenes) + **Description** (optional, seeds \`spec.md\`). Slug is no longer user-facing — implementation detail, not a UX concept.
- Rename ✏️ icon next to slug in detail header → modal with editable Title + Slug. \`renameSpec\` moves the folder, rewrites every spec-derived task's \`source\` marker + id + context in \`tasks.json\`, updates \`status.json\`, and pushes fresh SPEC_DATA + TASKS_DATA so all panels re-sync atomically.
- New IPC: \`RENAME_SPEC\`.

## Test plan

- [ ] Create a new spec → modal shows Title (required) + Description (optional), no Slug field
- [ ] Phase \`tasks_generated\` → "Run /spec.implement" button visible in side panel and dashboard detail
- [ ] Click /spec.implement → terminal gets short instruction; Claude reads spec/plan/tasks, takes ONE pending task, implements it, flips status to completed in tasks.json, appends a 2-3 sentence entry to outcome.md
- [ ] Outcome tab renders the outcome.md entries; new entries appear without manual reload
- [ ] Spec phase auto-advances \`tasks_generated\` → \`implementing\` after first task; → \`done\` after last
- [ ] Rename ✏️ icon → modal with current Title + Slug; change both, save → folder moves, tasks.json source markers update, status.json reflects new slug/title, panels re-sync
- [ ] Validation: invalid slug (uppercase, spaces, double hyphens) rejected with clear inline error; collision with existing slug rejected
- [ ] Existing project's ugly auto-derived slug can be renamed end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)