### PR TITLE
feat: create task start modal for branch management and auto play

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Auto-generated module structure",
-  "lastUpdated": "2026-05-01",
+  "lastUpdated": "2026-05-02",
   "architecture": {},
   "modules": {
     "main/aiToolManager": {
@@ -23,11 +23,12 @@
         "electron",
         "fs",
         "path",
+        "child_process",
         "shared/ipcChannels"
       ],
       "functions": {
         "init": {
-          "line": 72,
+          "line": 73,
           "params": [
             "window",
             "app"
@@ -35,66 +36,81 @@
           "purpose": "Initialize the AI Tool Manager"
         },
         "loadConfig": {
-          "line": 82,
+          "line": 83,
           "purpose": "Load configuration from file"
         },
         "saveConfig": {
-          "line": 97,
+          "line": 98,
           "purpose": "Save configuration to file"
         },
         "getAvailableTools": {
-          "line": 108,
+          "line": 109,
           "purpose": "Get all available AI tools"
         },
         "getActiveTool": {
-          "line": 115,
+          "line": 116,
           "purpose": "Get the currently active tool"
         },
         "setActiveTool": {
-          "line": 123,
+          "line": 124,
           "params": [
             "toolId"
           ],
           "purpose": "Set the active AI tool"
         },
         "getConfig": {
-          "line": 142,
+          "line": 143,
           "purpose": "Get full configuration for renderer"
         },
         "addCustomTool": {
-          "line": 152,
+          "line": 153,
           "params": [
             "tool"
           ],
           "purpose": "Add a custom AI tool"
         },
         "removeCustomTool": {
-          "line": 169,
+          "line": 170,
           "params": [
             "toolId"
           ],
           "purpose": "Remove a custom AI tool"
         },
+        "isPathLike": {
+          "line": 182,
+          "params": [
+            "command"
+          ]
+        },
+        "isCommandAvailable": {
+          "line": 196,
+          "params": [
+            "command",
+            "projectPath"
+          ],
+          "purpose": "shell. Tries the tool's primary command first, then its fallback."
+        },
         "setupIPC": {
-          "line": 184,
+          "line": 250,
           "purpose": "Setup IPC handlers"
         },
         "getCommand": {
-          "line": 199,
+          "line": 299,
           "params": [
             "action"
           ],
           "purpose": "Get command for specific action"
         },
         "getStartCommand": {
-          "line": 207,
+          "line": 307,
           "purpose": "Get the start command for active tool"
         }
       },
       "ipc": {
         "listens": [
           "GET_AI_TOOL_CONFIG",
-          "SET_AI_TOOL"
+          "SET_AI_TOOL",
+          "CHECK_AI_TOOL_AVAILABLE"
         ],
         "emits": [
           "AI_TOOL_CHANGED"
@@ -2057,6 +2073,7 @@
       "exports": [
         "init",
         "getCurrentTool",
+        "getAvailableTools",
         "getStartCommand",
         "getCommand",
         "supportsFeature"
@@ -2085,19 +2102,23 @@
           "line": 98,
           "purpose": "Get the current active tool"
         },
-        "getStartCommand": {
+        "getAvailableTools": {
           "line": 105,
+          "purpose": "Get all available AI tools (keyed by id)."
+        },
+        "getStartCommand": {
+          "line": 112,
           "purpose": "Get the start command for current tool"
         },
         "getCommand": {
-          "line": 112,
+          "line": 119,
           "params": [
             "action"
           ],
           "purpose": "Get a specific command for current tool"
         },
         "supportsFeature": {
-          "line": 120,
+          "line": 127,
           "params": [
             "feature"
           ],
@@ -2857,6 +2878,7 @@
         "tasksDashboard",
         "taskConfirmModal",
         "taskInfoModal",
+        "taskRunModal",
         "pluginsPanel",
         "githubPanel",
         "promptsPanel",
@@ -2879,26 +2901,26 @@
       ],
       "functions": {
         "init": {
-          "line": 37,
+          "line": 38,
           "purpose": "Initialize all modules"
         },
         "setupButtonHandlers": {
-          "line": 187,
+          "line": 191,
           "purpose": "Setup button click handlers"
         },
         "setupUpdateDot": {
-          "line": 298,
+          "line": 302,
           "purpose": "→ About → \"Dismiss this version\"). Both click open Settings → About."
         },
         "revealSidebarTab": {
-          "line": 329,
+          "line": 333,
           "params": [
             "tabName"
           ],
           "purpose": "commands so they don't try to focus an element inside a hidden container."
         },
         "registerCommands": {
-          "line": 347,
+          "line": 351,
           "purpose": "Command Palette and the global keyboard handler."
         }
       },
@@ -4387,6 +4409,7 @@
         "state",
         "tasksDashboard",
         "taskInfoModal",
+        "taskRunModal",
         "taskConfirmModal"
       ],
       "functions": {
@@ -4449,7 +4472,7 @@
           "purpose": "Handle task action buttons"
         },
         "showToast": {
-          "line": 364,
+          "line": 376,
           "params": [
             "message",
             "type = 'info'"
@@ -4457,86 +4480,95 @@
           "purpose": "Show toast notification"
         },
         "getToastIcon": {
-          "line": 399,
+          "line": 412,
           "params": [
             "type"
           ],
           "purpose": "Get toast icon based on type"
         },
-        "sendTaskToClaude": {
-          "line": 413,
+        "buildTaskPrompt": {
+          "line": 432,
           "params": [
-            "task"
+            "task",
+            "opts = {}"
           ],
-          "purpose": "Send task to Claude Code via terminal"
+          "purpose": "never made on top of an unresolved working tree."
+        },
+        "runTaskWithOptions": {
+          "line": 459,
+          "params": [
+            "task",
+            "opts = {}"
+          ],
+          "purpose": "the caller can decide whether to flip status / show \"sent\" toast."
         },
         "setClaudeRunning": {
-          "line": 436,
+          "line": 532,
           "params": [
             "running"
           ],
           "purpose": "Mark Claude Code as running (called from external modules)"
         },
         "isClaudeRunning": {
-          "line": 443,
+          "line": 539,
           "purpose": "Check if Claude Code is marked as running"
         },
         "deleteTask": {
-          "line": 452,
+          "line": 548,
           "params": [
             "taskId"
           ],
           "purpose": "load order ever shifts."
         },
         "showAddTaskModal": {
-          "line": 469,
+          "line": 565,
           "purpose": "Show add task modal"
         },
         "showEditTaskModal": {
-          "line": 488,
+          "line": 584,
           "params": [
             "taskId"
           ],
           "purpose": "Show edit task modal"
         },
         "hideTaskModal": {
-          "line": 514,
+          "line": 610,
           "purpose": "Hide task modal"
         },
         "handleTaskFormSubmit": {
-          "line": 524,
+          "line": 620,
           "params": [
             "e"
           ],
           "purpose": "Handle task form submit"
         },
         "setupModalListeners": {
-          "line": 562,
+          "line": 658,
           "purpose": "Setup modal event listeners"
         },
         "escapeHtml": {
-          "line": 602,
+          "line": 698,
           "params": [
             "text"
           ],
           "purpose": "Escape HTML for safe rendering"
         },
         "renderSourceChip": {
-          "line": 613,
+          "line": 709,
           "params": [
             "source"
           ],
           "purpose": "that's the actionable identifier the user knows."
         },
         "formatDate": {
-          "line": 624,
+          "line": 720,
           "params": [
             "isoString"
           ],
           "purpose": "Format date for display"
         },
         "initWhenReady": {
-          "line": 641,
+          "line": 737,
           "purpose": "Initialize when DOM is ready"
         }
       },
@@ -4548,6 +4580,7 @@
         ],
         "emits": [
           "LOAD_TASKS",
+          "UPDATE_TASK",
           "UPDATE_TASK",
           "DELETE_TASK",
           "ADD_TASK",
@@ -4654,7 +4687,7 @@
           "purpose": "Set active terminal"
         },
         "getMultiTerminalUI": {
-          "line": 122,
+          "line": 162,
           "purpose": "Get MultiTerminalUI instance"
         }
       },
@@ -4662,7 +4695,10 @@
         "listens": [
           "RUN_COMMAND"
         ],
-        "emits": []
+        "emits": [
+          "TERMINAL_INPUT_ID",
+          "TERMINAL_INPUT_ID"
+        ]
       }
     },
     "renderer/terminalGrid": {
@@ -5124,6 +5160,68 @@
           "line": 97
         }
       }
+    },
+    "renderer/taskRunModal": {
+      "file": "src/renderer/taskRunModal.js",
+      "description": "Task Run Modal",
+      "exports": [
+        "init",
+        "open"
+      ],
+      "depends": [
+        "electron",
+        "shared/ipcChannels",
+        "aiToolSelector",
+        "state"
+      ],
+      "functions": {
+        "init": {
+          "line": 37
+        },
+        "updateTerminalChoiceUI": {
+          "line": 85
+        },
+        "updateBranchChoiceUI": {
+          "line": 91
+        },
+        "getTerminalChoice": {
+          "line": 99
+        },
+        "getBranchChoice": {
+          "line": 104
+        },
+        "getCliChoice": {
+          "line": 109
+        },
+        "populateCliOptions": {
+          "line": 114
+        },
+        "loadCurrentBranch": {
+          "line": 144
+        },
+        "open": {
+          "line": 164,
+          "params": [
+            "task",
+            "opts = {}"
+          ]
+        },
+        "close": {
+          "line": 190
+        },
+        "confirm": {
+          "line": 198
+        },
+        "cancel": {
+          "line": 210
+        },
+        "escapeHtml": {
+          "line": 216,
+          "params": [
+            "s"
+          ]
+        }
+      }
     }
   },
   "ipcChannels": {
@@ -5309,6 +5407,11 @@
       },
       "RENAME_SPEC": {
         "name": "rename-spec",
+        "direction": "",
+        "description": ""
+      },
+      "CHECK_AI_TOOL_AVAILABLE": {
+        "name": "check-ai-tool-available",
         "direction": "",
         "description": ""
       }
@@ -5965,6 +6068,13 @@
         "module": "renderer/taskInfoModal",
         "file": "src/renderer/taskInfoModal.js",
         "description": "Task Info Modal"
+      }
+    ],
+    "task-run-modal": [
+      {
+        "module": "renderer/taskRunModal",
+        "file": "src/renderer/taskRunModal.js",
+        "description": "Task Run Modal"
       }
     ],
     "tasks": [

--- a/index.html
+++ b/index.html
@@ -991,6 +991,56 @@
     </div>
   </div>
 
+  <!-- Run Task Modal -->
+  <div id="task-run-modal" class="task-run-modal">
+    <div class="task-run-modal-container">
+      <div class="task-run-modal-header">
+        <h3>Run task</h3>
+        <p id="task-run-modal-task-title"></p>
+      </div>
+      <div class="task-run-modal-body">
+        <div class="task-run-section">
+          <label class="task-run-section-label">Terminal</label>
+          <div class="task-run-segmented" role="radiogroup" aria-label="Terminal">
+            <label class="task-run-segment">
+              <input type="radio" name="task-run-terminal" value="current" checked>
+              <span>Use current</span>
+            </label>
+            <label class="task-run-segment">
+              <input type="radio" name="task-run-terminal" value="new">
+              <span>New terminal</span>
+            </label>
+          </div>
+          <p id="task-run-current-hint" class="task-run-hint">Make sure your AI CLI is running in the active terminal.</p>
+        </div>
+
+        <div id="task-run-cli-section" class="task-run-section" style="display:none;">
+          <label class="task-run-section-label">CLI</label>
+          <div id="task-run-cli-options" class="task-run-radio-list" role="radiogroup" aria-label="CLI"></div>
+        </div>
+
+        <div class="task-run-section">
+          <label class="task-run-section-label">Branch</label>
+          <div class="task-run-radio-list" role="radiogroup" aria-label="Branch">
+            <label class="task-run-radio">
+              <input type="radio" name="task-run-branch" value="current" checked>
+              <span>Stay on <strong id="task-run-current-branch">current branch</strong></span>
+            </label>
+            <label class="task-run-radio">
+              <input type="radio" name="task-run-branch" value="new">
+              <span>Create new branch</span>
+            </label>
+          </div>
+          <input type="text" id="task-run-new-branch-name" class="task-run-input" placeholder="Optional — leave blank to pick a name with AI" disabled>
+        </div>
+      </div>
+      <div class="task-run-modal-footer">
+        <button type="button" id="task-run-cancel" class="task-run-btn task-run-btn-cancel">Cancel</button>
+        <button type="button" id="task-run-confirm" class="task-run-btn task-run-btn-primary">Run</button>
+      </div>
+    </div>
+  </div>
+
   <!-- File Tree Context Menu -->
   <div id="file-tree-context-menu" class="context-menu" role="menu">
     <button class="context-menu-item" data-action="copy-path" type="button">Copy Filepath</button>

--- a/src/main/aiToolManager.js
+++ b/src/main/aiToolManager.js
@@ -6,6 +6,7 @@
 const { ipcMain } = require('electron');
 const fs = require('fs');
 const path = require('path');
+const { spawn } = require('child_process');
 const { IPC } = require('../shared/ipcChannels');
 
 let mainWindow = null;
@@ -178,6 +179,71 @@ function removeCustomTool(toolId) {
   return false;
 }
 
+function isPathLike(command) {
+  return !!command && (
+    command.startsWith('./') ||
+    command.startsWith('../') ||
+    command.startsWith('/')
+  );
+}
+
+/**
+ * Check whether a CLI command can actually be launched on this system.
+ * Used as a pre-flight before spawning a terminal so we don't hand the
+ * user a "command not found" + an injected prompt sitting in a bare
+ * shell. Tries the tool's primary command first, then its fallback.
+ */
+async function isCommandAvailable(command, projectPath) {
+  if (!command) return false;
+
+  // Path-based command: check the binary actually exists & is executable.
+  if (isPathLike(command)) {
+    const target = command.startsWith('/')
+      ? command
+      : (projectPath ? path.resolve(projectPath, command) : command);
+    try {
+      fs.accessSync(target, fs.constants.X_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  // PATH-based command: probe via the user's login shell so PATH
+  // additions from .zshrc/.bashrc and shim managers (asdf, nvm, brew)
+  // are visible — same reason we run the PTY shell with -l.
+  const isWin = process.platform === 'win32';
+  const shell = isWin
+    ? (process.env.COMSPEC || 'cmd.exe')
+    : (process.env.SHELL || '/bin/sh');
+  const args = isWin
+    ? ['/c', `where ${command}`]
+    : ['-lc', `command -v ${command}`];
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (ok) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(ok);
+    };
+    let child;
+    try {
+      child = spawn(shell, args, { stdio: 'ignore' });
+    } catch {
+      resolve(false);
+      return;
+    }
+    const timer = setTimeout(() => {
+      try { child.kill('SIGTERM'); } catch {}
+      finish(false);
+    }, 3000);
+    child.on('exit', (code) => finish(code === 0));
+    child.on('error', () => finish(false));
+  });
+}
+
 /**
  * Setup IPC handlers
  */
@@ -190,6 +256,40 @@ function setupIPC() {
   ipcMain.removeHandler(IPC.SET_AI_TOOL);
   ipcMain.handle(IPC.SET_AI_TOOL, (event, toolId) => {
     return setActiveTool(toolId);
+  });
+
+  ipcMain.removeHandler(IPC.CHECK_AI_TOOL_AVAILABLE);
+  ipcMain.handle(IPC.CHECK_AI_TOOL_AVAILABLE, async (event, payload = {}) => {
+    const { toolId, projectPath } = payload;
+    const tools = getAvailableTools();
+    const tool = tools[toolId];
+    if (!tool) {
+      return { available: false, resolvedCommand: null, name: toolId || null };
+    }
+
+    const primaryOk = await isCommandAvailable(tool.command, projectPath);
+
+    // When the primary is a path-based wrapper script and the tool
+    // declares a fallback, the wrapper almost always `exec`s the
+    // fallback (see .frame/bin/codex). Treat the fallback as a hard
+    // dependency in that case — wrapper presence alone isn't enough.
+    if (primaryOk && tool.fallbackCommand && isPathLike(tool.command)) {
+      const fallbackOk = await isCommandAvailable(tool.fallbackCommand, projectPath);
+      if (fallbackOk) {
+        return { available: true, resolvedCommand: tool.command, name: tool.name };
+      }
+      return { available: false, resolvedCommand: null, name: tool.name };
+    }
+
+    if (primaryOk) {
+      return { available: true, resolvedCommand: tool.command, name: tool.name };
+    }
+
+    if (tool.fallbackCommand && await isCommandAvailable(tool.fallbackCommand, projectPath)) {
+      return { available: true, resolvedCommand: tool.fallbackCommand, name: tool.name };
+    }
+
+    return { available: false, resolvedCommand: null, name: tool.name };
   });
 }
 

--- a/src/renderer/aiToolSelector.js
+++ b/src/renderer/aiToolSelector.js
@@ -100,6 +100,13 @@ function getCurrentTool() {
 }
 
 /**
+ * Get all available AI tools (keyed by id).
+ */
+function getAvailableTools() {
+  return availableTools;
+}
+
+/**
  * Get the start command for current tool
  */
 function getStartCommand() {
@@ -135,6 +142,7 @@ function supportsFeature(feature) {
 module.exports = {
   init,
   getCurrentTool,
+  getAvailableTools,
   getStartCommand,
   getCommand,
   supportsFeature

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -12,6 +12,7 @@ const tasksPanel = require('./tasksPanel');
 const tasksDashboard = require('./tasksDashboard');
 const taskConfirmModal = require('./taskConfirmModal');
 const taskInfoModal = require('./taskInfoModal');
+const taskRunModal = require('./taskRunModal');
 const pluginsPanel = require('./pluginsPanel');
 const githubPanel = require('./githubPanel');
 const promptsPanel = require('./promptsPanel');
@@ -97,6 +98,9 @@ function init() {
 
   // Initialize the shared task info modal (no-project guards, etc.)
   taskInfoModal.init();
+
+  // Initialize the play-button run-config modal
+  taskRunModal.init();
 
   // Initialize plugins panel
   pluginsPanel.init();

--- a/src/renderer/styles/components/panels.css
+++ b/src/renderer/styles/components/panels.css
@@ -573,23 +573,26 @@
   color: var(--error);
 }
 
-/* Toast Notifications */
+/* Toast Notifications — viewport-fixed, slides down from the top so
+   important messages (especially errors) aren't tucked into a narrow
+   side panel where they'd be easy to miss. */
 .tasks-toast {
-  position: absolute;
-  bottom: var(--space-lg);
+  position: fixed;
+  top: 16px;
   left: 50%;
-  transform: translateX(-50%) translateY(20px);
+  transform: translateX(-50%) translateY(-24px);
+  width: min(560px, calc(100vw - 32px));
   background: var(--bg-elevated);
   border: 1px solid var(--border-default);
   border-radius: var(--radius-md);
-  padding: var(--space-sm) var(--space-md);
+  padding: 12px 16px;
   display: flex;
   align-items: center;
   gap: var(--space-sm);
   box-shadow: var(--shadow-lg);
   opacity: 0;
-  transition: all var(--transition-normal);
-  z-index: 100;
+  transition: opacity var(--transition-normal), transform var(--transition-normal);
+  z-index: 10000;
 }
 
 .tasks-toast.visible {
@@ -601,12 +604,15 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  flex-shrink: 0;
 }
 
 .tasks-toast .toast-message {
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 500;
   color: var(--text-primary);
+  line-height: 1.4;
+  word-break: break-word;
 }
 
 .tasks-toast-success .toast-icon {
@@ -617,7 +623,22 @@
   color: var(--info);
 }
 
+/* Error variant: louder background tint, accent border, larger text
+   so a missed-CLI / failure message can't slip past the user. */
+.tasks-toast-error {
+  background: var(--error-subtle);
+  border-color: var(--error);
+  padding: 14px 18px;
+  box-shadow: var(--shadow-lg), 0 0 0 1px var(--error);
+}
+
 .tasks-toast-error .toast-icon {
+  color: var(--error);
+}
+
+.tasks-toast-error .toast-message {
+  font-size: 14px;
+  font-weight: 600;
   color: var(--error);
 }
 

--- a/src/renderer/styles/components/tasks-dashboard.css
+++ b/src/renderer/styles/components/tasks-dashboard.css
@@ -1232,3 +1232,249 @@
   outline: 2px solid var(--accent-primary);
   outline-offset: 3px;
 }
+
+/* ==================== TASK RUN MODAL ==================== */
+/* Confirms how a task should be sent to the terminal: existing vs new
+   terminal, which CLI to launch, and whether to branch off first. Same
+   blurred-backdrop language as the other task modals. */
+.task-run-modal {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 15, 16, 0.35);
+  backdrop-filter: blur(14px) saturate(130%);
+  -webkit-backdrop-filter: blur(14px) saturate(130%);
+  z-index: 9800;
+  justify-content: center;
+  align-items: center;
+}
+
+.task-run-modal.visible {
+  display: flex;
+  animation: fadeIn 0.12s ease-out;
+}
+
+.task-run-modal-container {
+  width: 92%;
+  max-width: 460px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-lg);
+  display: flex;
+  flex-direction: column;
+  animation: slideUp var(--transition-normal) ease-out;
+}
+
+.task-run-modal-header {
+  padding: var(--space-lg) var(--space-xl) var(--space-md);
+  border-bottom: 1px solid var(--border-subtle);
+}
+
+.task-run-modal-header h3 {
+  margin: 0;
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.task-run-modal-header p {
+  margin: 4px 0 0 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+  word-break: break-word;
+}
+
+.task-run-modal-body {
+  padding: var(--space-lg) var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.task-run-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.task-run-section-label {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: var(--text-tertiary);
+}
+
+.task-run-segmented {
+  display: flex;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: 3px;
+  gap: 3px;
+}
+
+.task-run-segment {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 6px 10px;
+  font-size: 12px;
+  font-weight: 500;
+  color: var(--text-secondary);
+  border-radius: calc(var(--radius-md) - 3px);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.task-run-segment input {
+  position: absolute;
+  opacity: 0;
+  pointer-events: none;
+}
+
+.task-run-segment:hover {
+  color: var(--text-primary);
+}
+
+.task-run-segment:has(input:checked) {
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+  box-shadow: var(--shadow-sm);
+}
+
+.task-run-radio-list {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.task-run-radio {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: 8px 10px;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  font-size: 13px;
+  color: var(--text-secondary);
+  transition: all var(--transition-fast);
+}
+
+.task-run-radio:hover {
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}
+
+.task-run-radio:has(input:checked) {
+  border-color: var(--accent-primary);
+  background: var(--bg-elevated);
+  color: var(--text-primary);
+}
+
+.task-run-radio input {
+  accent-color: var(--accent-primary);
+}
+
+.task-run-radio strong {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+
+.task-run-radio-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.task-run-badge {
+  font-size: 10px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  background: var(--accent-primary);
+  color: var(--bg-deep);
+  line-height: 1;
+}
+
+.task-run-input {
+  margin-top: 6px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: 8px 10px;
+  font-size: 13px;
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  transition: all var(--transition-fast);
+}
+
+.task-run-input:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+  background: var(--bg-elevated);
+}
+
+.task-run-input:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.task-run-hint {
+  margin: 0;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  line-height: 1.5;
+}
+
+.task-run-modal-footer {
+  display: flex;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+  padding: var(--space-md) var(--space-xl) var(--space-lg);
+  border-top: 1px solid var(--border-subtle);
+}
+
+.task-run-btn {
+  font-family: inherit;
+  font-size: 13px;
+  font-weight: 600;
+  padding: 8px 16px;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.task-run-btn-cancel {
+  background: transparent;
+  border: 1px solid var(--border-default);
+  color: var(--text-secondary);
+}
+
+.task-run-btn-cancel:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+  color: var(--text-primary);
+}
+
+.task-run-btn-primary {
+  background: var(--accent-primary);
+  border: 1px solid var(--accent-primary);
+  color: var(--bg-deep);
+}
+
+.task-run-btn-primary:hover {
+  filter: brightness(1.08);
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-sm);
+}
+
+.task-run-btn-primary:focus-visible {
+  outline: 2px solid var(--accent-primary);
+  outline-offset: 3px;
+}

--- a/src/renderer/taskRunModal.js
+++ b/src/renderer/taskRunModal.js
@@ -1,0 +1,228 @@
+/**
+ * Task Run Modal
+ *
+ * Confirmation/configuration modal shown when the user clicks the play
+ * button on a task. Lets them choose:
+ *   - existing terminal vs new terminal
+ *   - which AI CLI to launch (only if new terminal)
+ *   - stay on current branch vs create a new branch (optional name)
+ *
+ * Returns the chosen options to the caller via the `onRun` callback;
+ * the caller is responsible for actually orchestrating the terminal
+ * and prompt dispatch (see `tasksPanel.runTaskWithOptions`).
+ */
+
+const { ipcRenderer } = require('electron');
+const { IPC } = require('../shared/ipcChannels');
+const aiToolSelector = require('./aiToolSelector');
+const state = require('./state');
+
+let modalEl = null;
+let titleEl = null;
+let terminalRadios = null;
+let currentHintEl = null;
+let cliSection = null;
+let cliOptionsEl = null;
+let branchRadios = null;
+let currentBranchEl = null;
+let newBranchNameInput = null;
+let runBtn = null;
+let cancelBtn = null;
+
+let initialized = false;
+let activeTask = null;
+let activeOnRun = null;
+let activeOnCancel = null;
+
+function init() {
+  if (initialized) return;
+  modalEl = document.getElementById('task-run-modal');
+  if (!modalEl) return;
+
+  titleEl = document.getElementById('task-run-modal-task-title');
+  terminalRadios = modalEl.querySelectorAll('input[name="task-run-terminal"]');
+  currentHintEl = document.getElementById('task-run-current-hint');
+  cliSection = document.getElementById('task-run-cli-section');
+  cliOptionsEl = document.getElementById('task-run-cli-options');
+  branchRadios = modalEl.querySelectorAll('input[name="task-run-branch"]');
+  currentBranchEl = document.getElementById('task-run-current-branch');
+  newBranchNameInput = document.getElementById('task-run-new-branch-name');
+  runBtn = document.getElementById('task-run-confirm');
+  cancelBtn = document.getElementById('task-run-cancel');
+
+  // Toggle CLI section + warning hint based on terminal choice
+  terminalRadios.forEach(r => r.addEventListener('change', updateTerminalChoiceUI));
+
+  // Toggle new-branch input enabled state based on branch choice
+  branchRadios.forEach(r => r.addEventListener('change', updateBranchChoiceUI));
+
+  cancelBtn.addEventListener('click', cancel);
+  runBtn.addEventListener('click', confirm);
+
+  modalEl.addEventListener('click', (e) => {
+    if (e.target === modalEl) cancel();
+  });
+
+  document.addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape') return;
+    if (!modalEl.classList.contains('visible')) return;
+    e.stopPropagation();
+    cancel();
+  }, true);
+
+  modalEl.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' && modalEl.classList.contains('visible')) {
+      // Don't hijack Enter while typing in the branch-name field
+      if (e.target === newBranchNameInput) return;
+      e.preventDefault();
+      confirm();
+    }
+  });
+
+  initialized = true;
+}
+
+function updateTerminalChoiceUI() {
+  const useNew = getTerminalChoice() === 'new';
+  cliSection.style.display = useNew ? '' : 'none';
+  currentHintEl.style.display = useNew ? 'none' : '';
+}
+
+function updateBranchChoiceUI() {
+  const newBranch = getBranchChoice() === 'new';
+  newBranchNameInput.disabled = !newBranch;
+  if (newBranch) {
+    requestAnimationFrame(() => newBranchNameInput.focus());
+  }
+}
+
+function getTerminalChoice() {
+  const checked = Array.from(terminalRadios).find(r => r.checked);
+  return checked ? checked.value : 'current';
+}
+
+function getBranchChoice() {
+  const checked = Array.from(branchRadios).find(r => r.checked);
+  return checked ? checked.value : 'current';
+}
+
+function getCliChoice() {
+  const checked = cliOptionsEl.querySelector('input[name="task-run-cli"]:checked');
+  return checked ? checked.value : null;
+}
+
+function populateCliOptions() {
+  const tools = aiToolSelector.getAvailableTools() || {};
+  const current = aiToolSelector.getCurrentTool();
+  const currentId = current ? current.id : null;
+
+  cliOptionsEl.innerHTML = '';
+  Object.values(tools).forEach(tool => {
+    const id = `task-run-cli-${tool.id}`;
+    const isDefault = tool.id === currentId;
+    const wrapper = document.createElement('label');
+    wrapper.className = 'task-run-radio';
+    wrapper.innerHTML = `
+      <input type="radio" name="task-run-cli" id="${id}" value="${tool.id}">
+      <span class="task-run-radio-label">
+        <strong>${escapeHtml(tool.name)}</strong>
+        ${isDefault ? '<span class="task-run-badge">Default</span>' : ''}
+      </span>
+    `;
+    const input = wrapper.querySelector('input');
+    if (isDefault) input.checked = true;
+    cliOptionsEl.appendChild(wrapper);
+  });
+
+  // Fallback: if nothing matched (no current tool), check the first
+  if (!cliOptionsEl.querySelector('input:checked')) {
+    const first = cliOptionsEl.querySelector('input');
+    if (first) first.checked = true;
+  }
+}
+
+async function loadCurrentBranch() {
+  currentBranchEl.textContent = 'current branch';
+  const projectPath = state.getProjectPath();
+  if (!projectPath) return;
+  try {
+    const result = await ipcRenderer.invoke(IPC.LOAD_GIT_BRANCHES, projectPath);
+    if (!result || result.error || !result.currentBranch) return;
+    currentBranchEl.textContent = result.currentBranch;
+  } catch (err) {
+    // Not a git repo or git unavailable — leave the placeholder.
+  }
+}
+
+/**
+ * Open the modal for a given task.
+ * @param {object} task
+ * @param {object} opts
+ * @param {function} opts.onRun     - called with chosen options on confirm
+ * @param {function} [opts.onCancel]
+ */
+function open(task, opts = {}) {
+  if (!initialized) init();
+  if (!modalEl) return;
+
+  activeTask = task;
+  activeOnRun = typeof opts.onRun === 'function' ? opts.onRun : null;
+  activeOnCancel = typeof opts.onCancel === 'function' ? opts.onCancel : null;
+
+  if (titleEl) {
+    titleEl.textContent = task && task.title ? task.title : '';
+  }
+
+  // Reset to defaults
+  Array.from(terminalRadios).forEach(r => { r.checked = r.value === 'current'; });
+  Array.from(branchRadios).forEach(r => { r.checked = r.value === 'current'; });
+  newBranchNameInput.value = '';
+  newBranchNameInput.disabled = true;
+
+  populateCliOptions();
+  updateTerminalChoiceUI();
+  loadCurrentBranch();
+
+  modalEl.classList.add('visible');
+  requestAnimationFrame(() => runBtn && runBtn.focus());
+}
+
+function close() {
+  if (!modalEl) return;
+  modalEl.classList.remove('visible');
+  activeTask = null;
+  activeOnRun = null;
+  activeOnCancel = null;
+}
+
+function confirm() {
+  const options = {
+    useNewTerminal: getTerminalChoice() === 'new',
+    toolId: getCliChoice(),
+    branchMode: getBranchChoice(),
+    newBranchName: newBranchNameInput.value.trim() || null
+  };
+  const cb = activeOnRun;
+  close();
+  if (cb) cb(options);
+}
+
+function cancel() {
+  const cb = activeOnCancel;
+  close();
+  if (cb) cb();
+}
+
+function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+module.exports = {
+  init,
+  open
+};

--- a/src/renderer/tasksPanel.js
+++ b/src/renderer/tasksPanel.js
@@ -324,11 +324,23 @@ function handleTaskAction(taskId, action) {
 
   switch (action) {
     case 'start':
-      newStatus = 'in_progress';
-      toastMessage = 'Task sent to Claude';
-      // Send task to Claude Code via terminal
-      sendTaskToClaude(task);
-      break;
+      // Open the run-config modal first; status flips and prompt is sent
+      // only after the user confirms AND the launch actually succeeds
+      // (e.g. the chosen CLI is installed). Lazy-required to avoid
+      // load-order coupling with the rest of the renderer wiring.
+      require('./taskRunModal').open(task, {
+        onRun: async (opts) => {
+          const ok = await runTaskWithOptions(task, opts);
+          if (!ok) return;
+          ipcRenderer.send(IPC.UPDATE_TASK, {
+            projectPath,
+            taskId,
+            updates: { status: 'in_progress' }
+          });
+          showToast('Task sent', 'info');
+        }
+      });
+      return;
     case 'complete':
       newStatus = 'completed';
       toastMessage = 'Task completed';
@@ -376,21 +388,22 @@ function showToast(message, type = 'info') {
     <span class="toast-message">${message}</span>
   `;
 
-  // Add to panel
-  if (panelElement) {
-    panelElement.appendChild(toast);
-  }
+  // Mount on body so the toast lives in the viewport's coordinate space
+  // rather than inside the narrow side panel — otherwise errors sit
+  // bottom-right where they're easy to miss.
+  document.body.appendChild(toast);
 
   // Animate in
   requestAnimationFrame(() => {
     toast.classList.add('visible');
   });
 
-  // Remove after delay
+  // Errors stay longer because they require user attention.
+  const visibleMs = type === 'error' ? 4000 : 2000;
   setTimeout(() => {
     toast.classList.remove('visible');
     setTimeout(() => toast.remove(), 300);
-  }, 2000);
+  }, visibleMs);
 }
 
 /**
@@ -408,26 +421,109 @@ function getToastIcon(type) {
 }
 
 /**
- * Send task to Claude Code via terminal
+ * Build the task prompt that gets injected into the AI CLI. If the user
+ * asked for a new branch, instruct the AI to (1) surface any uncommitted
+ * changes for an explicit decision rather than silently carrying or
+ * discarding them, and (2) either use the user-provided branch name or
+ * — when none was given — suggest one and wait for confirmation before
+ * creating it. Uncommitted-check comes first so the branch decision is
+ * never made on top of an unresolved working tree.
  */
-function sendTaskToClaude(task) {
-  // Build the prompt for Claude
+function buildTaskPrompt(task, opts = {}) {
   let prompt = `Work on this task: ${task.title}`;
+  if (task.description) prompt += `. ${task.description}`;
+  if (task.priority === 'high') prompt += ` (High priority)`;
 
-  if (task.description) {
-    prompt += `. ${task.description}`;
+  if (opts.branchMode === 'new') {
+    const branchStep = opts.newBranchName
+      ? `create and switch to a new branch named "${opts.newBranchName}"`
+      : `suggest an appropriate branch name based on this task, wait for my confirmation, and then create and switch to that branch`;
+
+    prompt += `. Before starting, do the following in order:`
+      + ` First, check for uncommitted changes on the current branch — if any exist, ask me what to do with them (commit, stash, or discard) and act on my decision before continuing.`
+      + ` Then, ${branchStep}.`;
   }
+  return prompt;
+}
 
-  if (task.priority === 'high') {
-    prompt += ` (High priority)`;
-  }
+/**
+ * Send the task to a terminal according to the user's choices in the
+ * run modal. For "use current" we just write into the active terminal.
+ * For "new terminal" we pre-flight that the chosen CLI is actually
+ * installed, then spawn a terminal, launch the CLI, and inject the
+ * prompt once the CLI has had a moment to come up.
+ *
+ * Returns true on success, false if we aborted (e.g. CLI missing) so
+ * the caller can decide whether to flip status / show "sent" toast.
+ */
+async function runTaskWithOptions(task, opts = {}) {
+  const prompt = buildTaskPrompt(task, opts);
 
-  // Use global sendCommand to avoid circular dependency
-  if (typeof window.terminalSendCommand === 'function') {
-    window.terminalSendCommand(prompt);
-  } else {
+  if (!opts.useNewTerminal) {
+    // Same text-then-Enter trick as the new-terminal flow: AI CLI input
+    // boxes (Claude/Codex/Gemini) buffer text+\r in one chunk as paste
+    // content, so the trailing \r ends up in the input instead of
+    // submitting. Splitting the writes makes submit reliable.
+    if (typeof window.terminalSendPromptThenEnter === 'function') {
+      window.terminalSendPromptThenEnter(prompt);
+      return true;
+    }
+    if (typeof window.terminalSendCommand === 'function') {
+      window.terminalSendCommand(prompt);
+      return true;
+    }
     console.error('Terminal sendCommand not available');
+    return false;
   }
+
+  if (typeof window.terminalCreateAndStart !== 'function') {
+    console.error('Terminal createAndStart not available');
+    return false;
+  }
+
+  const projectPath = state.getProjectPath();
+
+  // Pre-flight: confirm the chosen CLI is installed. Without this we'd
+  // happily hand the user a "command not found" followed by the task
+  // prompt sitting in a bare shell.
+  let startCommand = null;
+  if (opts.toolId) {
+    let check;
+    try {
+      check = await ipcRenderer.invoke(IPC.CHECK_AI_TOOL_AVAILABLE, {
+        toolId: opts.toolId,
+        projectPath
+      });
+    } catch (err) {
+      console.error('Failed to verify AI tool availability', err);
+      showToast('Could not verify AI CLI availability', 'error');
+      return false;
+    }
+    if (!check || !check.available) {
+      const name = (check && check.name) || opts.toolId;
+      showToast(`${name} CLI not found on your system`, 'error');
+      return false;
+    }
+    startCommand = check.resolvedCommand;
+  }
+
+  const newTerminalId = await window.terminalCreateAndStart(projectPath, startCommand);
+  if (!newTerminalId) return false;
+
+  // Give the CLI a few seconds to boot before injecting the prompt.
+  // window.terminalCreateAndStart already waits 1s before sending the
+  // start command, so we add another 4s on top of that. Use the
+  // text-then-Enter helper so the prompt actually submits — sending
+  // text+\r in a single chunk often gets buffered as paste content by
+  // AI CLI input boxes.
+  setTimeout(() => {
+    if (typeof window.terminalSendPromptThenEnter === 'function') {
+      window.terminalSendPromptThenEnter(prompt, newTerminalId);
+    } else if (typeof window.terminalSendCommand === 'function') {
+      window.terminalSendCommand(prompt, newTerminalId);
+    }
+  }, 5000);
+  return true;
 }
 
 /**

--- a/src/renderer/terminal.js
+++ b/src/renderer/terminal.js
@@ -96,6 +96,46 @@ function setActiveTerminal(terminalId) {
 // Expose sendCommand globally for modules that can't import terminal directly (circular dependency)
 window.terminalSendCommand = sendCommand;
 
+// Expose new-terminal orchestration so tasksPanel can spawn a fresh terminal
+// and (optionally) launch an AI CLI inside it without importing terminal.js
+// directly. Returns the new terminal id, or null on failure.
+window.terminalCreateAndStart = async function(projectPath, toolStartCommand) {
+  if (!multiTerminalUI) return null;
+  if (projectPath) multiTerminalUI.setCurrentProject(projectPath);
+  const newTerminalId = await multiTerminalUI.createTerminalForCurrentProject();
+  if (!newTerminalId) return null;
+  multiTerminalUI.setActiveTerminal(newTerminalId);
+  if (toolStartCommand) {
+    setTimeout(() => {
+      multiTerminalUI.sendCommand(toolStartCommand, newTerminalId);
+    }, 1000);
+  }
+  return newTerminalId;
+};
+
+// Send a prompt as raw text first, then a separate Enter keystroke after
+// a short delay. AI CLIs (Claude Code, Codex, Gemini) buffer pasted
+// chunks differently from real keyboard input — a trailing \r in the
+// same write often gets absorbed into the input buffer instead of
+// submitting. Splitting the two writes mirrors how a human would type
+// then press Enter, and reliably triggers submit.
+window.terminalSendPromptThenEnter = function(prompt, terminalId = null) {
+  if (!multiTerminalUI) return;
+  const manager = multiTerminalUI.getManager();
+  const targetId = terminalId || (manager && manager.activeTerminalId);
+  if (!targetId) return;
+  ipcRenderer.send(IPC.TERMINAL_INPUT_ID, {
+    terminalId: targetId,
+    data: prompt
+  });
+  setTimeout(() => {
+    ipcRenderer.send(IPC.TERMINAL_INPUT_ID, {
+      terminalId: targetId,
+      data: '\r'
+    });
+  }, 300);
+};
+
 // Expose focus function globally for returning focus from other panels
 window.terminalFocus = function() {
   if (multiTerminalUI) {

--- a/src/shared/ipcChannels.js
+++ b/src/shared/ipcChannels.js
@@ -122,6 +122,7 @@ const IPC = {
   AI_TOOL_CONFIG_DATA: 'ai-tool-config-data',
   SET_AI_TOOL: 'set-ai-tool',
   AI_TOOL_CHANGED: 'ai-tool-changed',
+  CHECK_AI_TOOL_AVAILABLE: 'check-ai-tool-available',
 
   // User Settings (renderer-side preferences persisted to userData JSON)
   GET_USER_SETTING: 'get-user-setting',


### PR DESCRIPTION
## Summary      
                                                                                                                                              
  Clicking the play button on a task currently dispatches the task prompt                                                                     
  straight into the active terminal. That's fine if the user already has                                                                      
  their AI CLI running on the right branch, but it forces them to manage                                                                      
  that setup manually, and silently fails (with a "command not found" left                                                                    
  in a bare shell) when the chosen CLI isn't installed.                                                                                       
                                                                                                                                              
  This PR replaces that direct dispatch with a small configuration modal                                                                      
  so the user can decide, per task, how to launch it.                                                                                         
                                                                                                                                              
  ## What's new   
                                                                                                                                              
  When the play button is clicked, a modal opens with three choices:

  - **Terminal** — use the current terminal, or spawn a new one.                                                                              
  - **CLI** — which AI CLI to launch (only relevant when spawning a new
    terminal). Defaults to the currently selected tool.                                                                                       
  - **Branch** — stay on the current branch, or create a new one. The
    branch name is optional: if left blank, the AI is asked to suggest                                                                        
    one and wait for confirmation before creating it.                                                                                         
                                                                                                                                              
  The task's status only flips to `in_progress` after the launch actually                                                                     
  succeeds, so failed launches don't leave the board in a misleading state.                                                                   
                                                                                                                                              
  ## Implementation notes                                                                                                                     
                                                                                                                                              
  - **CLI pre-flight** (`aiToolManager.isCommandAvailable`): before spawning                                                                  
    a new terminal we verify the chosen CLI is on disk / on PATH. PATH-based
    commands are probed via the user's login shell so shim managers (asdf,                                                                    
    nvm, brew) are visible, mirroring how the PTY shell is launched. If the                                                                   
    CLI isn't found we surface an error toast and abort instead of opening                                                                    
    a useless terminal.                                                                                                                       
                                                                                                                                              
  - **New-branch prompt** (`tasksPanel.buildTaskPrompt`): when the user                                                                       
    picks "create new branch", the prompt instructs the AI to (1) check
    for uncommitted changes and ask the user how to handle them before                                                                        
    doing anything else, and (2) either use the user-provided branch name                                                                     
    or suggest one and wait for confirmation. This prevents the AI from                                                                       
    silently carrying or discarding work-in-progress when switching                                                                           
    branches.                                                                                                                                 
                                                                                                                                              
  - **Prompt dispatch** (`window.terminalSendPromptThenEnter`): AI CLI                                                                        
    input boxes (Claude Code, Codex, Gemini) buffer `text + \r` written in
    a single chunk as paste content, so the trailing `\r` ends up in the                                                                      
    input field instead of submitting. The new helper writes the text                                                                         
    first and sends a separate `\r` 300ms later, which submits reliably.                                                                      
                                                                                                                                              
  - **Toast relocation** (`tasksPanel.showToast`): the toast was anchored                                                                     
    inside the side panel, where errors at the bottom-right could easily                                                                      
    be missed. It now mounts on `document.body` at the viewport's top with                                                                    
    a louder error variant and a longer dwell time (4s vs 2s for info).                                                                       
                                                                                                                                              
  ## Test plan                                                                                                                                
                                                                                                                                              
  - [ ] Click play on a task with a project selected — the run modal opens.                                                                   
  - [ ] "Use current" + a running CLI in the active terminal — prompt is
        dispatched and submitted.                                                                                                             
  - [ ] "New terminal" with the default CLI installed — terminal spawns,                                                                      
        CLI starts, prompt arrives and submits.                                                                                               
  - [ ] "New terminal" with a CLI that is *not* installed — error toast                                                                       
        appears at the top of the viewport; no terminal is spawned; task                                                                      
        status stays `pending`.                                                                                                               
  - [ ] "Create new branch" with a name — AI is told to handle uncommitted                                                                    
        changes first, then create that branch.                                                                                               
  - [ ] "Create new branch" without a name — AI is told to suggest a name
        and wait for confirmation.                                                                                                            
  - [ ] Cancel the modal — nothing is dispatched and status doesn't change.
                                                                                                                                              
  ## Screenshots  
  
<img width="999" height="672" alt="Screenshot 2026-05-02 at 12 54 06" src="https://github.com/user-attachments/assets/37a83948-58bd-41bb-b367-44114b1205bf" />
