### PR TITLE
fix: push SPEC_DATA after createSpec so panel updates immediately

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Auto-generated module structure",
-  "lastUpdated": "2026-05-02",
+  "lastUpdated": "2026-05-04",
   "architecture": {},
   "modules": {
     "main/aiToolManager": {
@@ -1642,7 +1642,7 @@
           ]
         },
         "updateSpecStatus": {
-          "line": 479,
+          "line": 485,
           "params": [
             "projectPath",
             "slug",
@@ -1650,14 +1650,14 @@
           ]
         },
         "deleteSpec": {
-          "line": 497,
+          "line": 503,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "renameSpec": {
-          "line": 514,
+          "line": 520,
           "params": [
             "projectPath",
             "oldSlug",
@@ -1666,30 +1666,30 @@
           "purpose": "Returns { success: true, slug, status } on success, { error } on failure."
         },
         "startWatching": {
-          "line": 621,
+          "line": 627,
           "params": [
             "projectPath"
           ],
           "purpose": "across all three platforms — if that ever changes, swap in a poller."
         },
         "stopWatching": {
-          "line": 663
+          "line": 669
         },
         "pushSpecData": {
-          "line": 683,
+          "line": 689,
           "params": [
             "projectPath"
           ]
         },
         "init": {
-          "line": 694,
+          "line": 700,
           "params": [
             "window"
           ],
           "purpose": "─── Init + IPC ────────────────────────────────────────────"
         },
         "setupIPC": {
-          "line": 698,
+          "line": 704,
           "params": [
             "ipcMain"
           ]

--- a/src/main/specManager.js
+++ b/src/main/specManager.js
@@ -473,6 +473,12 @@ function createSpec(projectPath, opts) {
     fs.writeFileSync(path.join(dir, SPEC_FILE), seed, 'utf8');
   }
 
+  // Push fresh SPEC_DATA so the panel reflects the new spec immediately.
+  // The fs.watch on the specs root fires for new sub-directories on most
+  // platforms, but timing isn't reliable enough to depend on it — the user
+  // would otherwise see the spec only after switching views.
+  pushSpecData(projectPath);
+
   return { slug, status };
 }
 


### PR DESCRIPTION
## Summary
- Fixes a bug where newly created specs didn't appear in the Specs panel until the user navigated to the Dashboard and clicked through.
- Root cause: `createSpec` in `src/main/specManager.js` wrote the spec files but never called `pushSpecData()`, leaving the panel dependent on the `fs.watch` debounce. On macOS the recursive watch isn't reliable for newly created sub-directories.
- `renameSpec` already pushed `SPEC_DATA` after completion for the same reason — `createSpec` now matches that pattern.

## Test plan
- [ ] Open Frame, open the Specs panel
- [ ] Click "+ New" → fill title (and optionally description) → Create
- [ ] Spec should appear in the panel immediately, no navigation required
- [ ] Repeat with description left empty (phase = `draft`) — should still appear instantly
- [ ] Existing spec list / file watcher behavior unchanged for edits and renames

🤖 Generated with [Claude Code](https://claude.com/claude-code)