### PR TITLE
feat: bundled sample project for onboarding activation

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Auto-generated module structure",
-  "lastUpdated": "2026-05-12",
+  "lastUpdated": "2026-05-13",
   "architecture": {},
   "modules": {
     "main/aiToolManager": {
@@ -859,15 +859,15 @@
           "purpose": "Create main application window"
         },
         "setupAllIPC": {
-          "line": 90,
+          "line": 92,
           "purpose": "Setup all IPC handlers"
         },
         "init": {
-          "line": 134,
+          "line": 136,
           "purpose": "Initialize application"
         },
         "initModulesWithWindow": {
-          "line": 153,
+          "line": 155,
           "params": [
             "window"
           ],
@@ -4859,32 +4859,32 @@
           "line": 71
         },
         "persistDismissPreference": {
-          "line": 127
+          "line": 132
         },
         "renderToolOptions": {
-          "line": 135
+          "line": 140
         },
         "updateToolSelection": {
-          "line": 170
+          "line": 175
         },
         "open": {
-          "line": 181
+          "line": 186
         },
         "close": {
-          "line": 187
+          "line": 192
         },
         "reopen": {
-          "line": 201,
+          "line": 206,
           "purpose": "the checkbox state from a prior session would silently re-dismiss)."
         },
         "escapeHtml": {
-          "line": 209,
+          "line": 214,
           "params": [
             "s"
           ]
         },
         "escapeAttr": {
-          "line": 218,
+          "line": 223,
           "params": [
             "s"
           ]
@@ -5274,19 +5274,21 @@
     },
     "renderer/sampleBanner": {
       "file": "src/renderer/sampleBanner.js",
-      "description": "Sample Banner",
+      "description": "Sample Mode (banner + auto-opened side panels)",
       "exports": [
         "init"
       ],
       "depends": [
-        "state"
+        "state",
+        "tasksPanel",
+        "specPanel"
       ],
       "functions": {
         "init": {
-          "line": 16
+          "line": 24
         },
         "setVisible": {
-          "line": 34,
+          "line": 58,
           "params": [
             "visible"
           ]
@@ -6236,7 +6238,7 @@
       {
         "module": "renderer/sampleBanner",
         "file": "src/renderer/sampleBanner.js",
-        "description": "Sample Banner"
+        "description": "Sample Mode (banner + auto-opened side panels)"
       }
     ],
     "server": [

--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Auto-generated module structure",
-  "lastUpdated": "2026-05-05",
+  "lastUpdated": "2026-05-12",
   "architecture": {},
   "modules": {
     "main/aiToolManager": {
@@ -245,17 +245,20 @@
         "init",
         "showFolderPicker",
         "showNewProjectDialog",
+        "openSampleProject",
+        "getSampleProjectPath",
         "setupIPC"
       ],
       "depends": [
         "electron",
         "child_process",
+        "fs",
         "path",
         "shared/ipcChannels"
       ],
       "functions": {
         "init": {
-          "line": 17,
+          "line": 18,
           "params": [
             "window",
             "callback"
@@ -263,29 +266,48 @@
           "purpose": "Initialize dialogs module"
         },
         "showFolderPicker": {
-          "line": 25,
+          "line": 26,
           "params": [
             "event"
           ],
           "purpose": "Show folder picker dialog"
         },
         "showNewProjectDialog": {
-          "line": 48,
+          "line": 49,
           "params": [
             "event"
           ],
           "purpose": "Show new project dialog"
         },
         "cloneGithubRepo": {
-          "line": 72,
+          "line": 73,
           "params": [
             "event",
             "repoUrl"
           ],
           "purpose": "Clone a GitHub repo and initialize it as a Frame project"
         },
+        "copyDirRecursive": {
+          "line": 121,
+          "params": [
+            "src",
+            "dst"
+          ],
+          "purpose": "transparent asar layer and works in both dev and packaged builds."
+        },
+        "openSampleProject": {
+          "line": 143,
+          "params": [
+            "event"
+          ],
+          "purpose": "a pristine demo that resets every launch."
+        },
+        "getSampleProjectPath": {
+          "line": 172,
+          "purpose": "the banner / read-only hints can show. Exposed via IPC.invoke."
+        },
         "setupIPC": {
-          "line": 117,
+          "line": 179,
           "params": [
             "ipcMain"
           ],
@@ -296,7 +318,9 @@
         "listens": [
           "SELECT_PROJECT_FOLDER",
           "CREATE_NEW_PROJECT",
-          "CLONE_GITHUB_REPO"
+          "CLONE_GITHUB_REPO",
+          "OPEN_SAMPLE_PROJECT",
+          "GET_SAMPLE_PROJECT_PATH"
         ],
         "emits": [
           "PROJECT_SELECTED",
@@ -2897,30 +2921,31 @@
         "appLoader",
         "settingsModal",
         "telemetryNotice",
+        "sampleBanner",
         "../package.json"
       ],
       "functions": {
         "init": {
-          "line": 38,
+          "line": 39,
           "purpose": "Initialize all modules"
         },
         "setupButtonHandlers": {
-          "line": 191,
+          "line": 193,
           "purpose": "Setup button click handlers"
         },
         "setupUpdateDot": {
-          "line": 302,
+          "line": 304,
           "purpose": "→ About → \"Dismiss this version\"). Both click open Settings → About."
         },
         "revealSidebarTab": {
-          "line": 333,
+          "line": 335,
           "params": [
             "tabName"
           ],
           "purpose": "commands so they don't try to focus an element inside a hidden container."
         },
         "registerCommands": {
-          "line": 351,
+          "line": 353,
           "purpose": "Command Palette and the global keyboard handler."
         }
       },
@@ -3849,6 +3874,9 @@
         "updateProjectUI",
         "selectProjectFolder",
         "createNewProject",
+        "openSampleProject",
+        "getIsSampleProject",
+        "onSampleChange",
         "getIsFrameProject",
         "setIsFrameProject",
         "onFrameStatusChange",
@@ -3861,112 +3889,127 @@
       ],
       "functions": {
         "init": {
-          "line": 27,
+          "line": 30,
           "params": [
             "elements"
           ],
           "purpose": "Initialize state module"
         },
         "getProjectPath": {
-          "line": 41,
+          "line": 55,
           "purpose": "Get current project path"
         },
         "setMultiTerminalUI": {
-          "line": 48,
+          "line": 62,
           "params": [
             "ui"
           ],
           "purpose": "Set MultiTerminalUI reference for terminal session management"
         },
         "setProjectPath": {
-          "line": 55,
+          "line": 69,
           "params": [
             "path"
           ],
           "purpose": "Set project path and switch terminal session"
         },
         "onProjectChange": {
-          "line": 80,
+          "line": 104,
           "params": [
             "callback"
           ],
           "purpose": "Register callback for project change"
         },
         "getIsFrameProject": {
-          "line": 87,
+          "line": 111,
           "purpose": "Get Frame project status"
         },
         "setIsFrameProject": {
-          "line": 94,
+          "line": 118,
           "params": [
             "isFrame"
           ],
           "purpose": "Set Frame project status"
         },
         "onFrameStatusChange": {
-          "line": 105,
+          "line": 129,
           "params": [
             "callback"
           ],
           "purpose": "Register callback for Frame status change"
         },
         "onFrameInitialized": {
-          "line": 112,
+          "line": 136,
           "params": [
             "callback"
           ],
           "purpose": "Register callback for Frame project initialized"
         },
         "updateFrameUI": {
-          "line": 119,
+          "line": 143,
           "purpose": "Update Frame-related UI"
         },
         "initializeAsFrameProject": {
-          "line": 134,
+          "line": 158,
           "purpose": "Initialize current project as Frame project"
         },
         "showInitializeFrameModal": {
-          "line": 143,
+          "line": 167,
           "purpose": "Show custom initialize Frame modal"
         },
         "hideInitializeFrameModal": {
-          "line": 153,
+          "line": 177,
           "purpose": "Hide initialize Frame modal"
         },
         "handleInitializeFrame": {
-          "line": 163,
+          "line": 187,
           "purpose": "Handle initialize Frame confirmation"
         },
         "setupInitFrameModalListeners": {
-          "line": 178,
+          "line": 202,
           "purpose": "Setup initialize Frame modal listeners"
         },
         "showInitSpotlight": {
-          "line": 204,
+          "line": 228,
           "purpose": "Show spotlight tour for the initialize button (first time only)"
         },
         "dismissSpotlight": {
-          "line": 242,
+          "line": 266,
           "purpose": "Dismiss spotlight and mark as seen"
         },
         "setupSpotlightListeners": {
-          "line": 253,
+          "line": 277,
           "purpose": "Setup spotlight tour listeners"
         },
         "updateProjectUI": {
-          "line": 295,
+          "line": 319,
           "purpose": "Update project UI elements"
         },
         "selectProjectFolder": {
-          "line": 328,
+          "line": 352,
           "purpose": "Request folder selection"
         },
         "createNewProject": {
-          "line": 335,
+          "line": 359,
           "purpose": "Request new project creation"
         },
+        "openSampleProject": {
+          "line": 369,
+          "purpose": "specs) is reused unchanged."
+        },
+        "getIsSampleProject": {
+          "line": 376,
+          "purpose": "Check whether the current project is the bundled sample."
+        },
+        "onSampleChange": {
+          "line": 384,
+          "params": [
+            "callback"
+          ],
+          "purpose": "\"is sample\" flag changes (opens or leaves the sample)."
+        },
         "setupIPC": {
-          "line": 342,
+          "line": 391,
           "purpose": "Setup IPC listeners"
         }
       },
@@ -3980,7 +4023,8 @@
           "CHECK_IS_FRAME_PROJECT",
           "INITIALIZE_FRAME_PROJECT",
           "SELECT_PROJECT_FOLDER",
-          "CREATE_NEW_PROJECT"
+          "CREATE_NEW_PROJECT",
+          "OPEN_SAMPLE_PROJECT"
         ]
       }
     },
@@ -4815,32 +4859,32 @@
           "line": 71
         },
         "persistDismissPreference": {
-          "line": 120
+          "line": 127
         },
         "renderToolOptions": {
-          "line": 128
+          "line": 135
         },
         "updateToolSelection": {
-          "line": 163
+          "line": 170
         },
         "open": {
-          "line": 174
+          "line": 181
         },
         "close": {
-          "line": 180
+          "line": 187
         },
         "reopen": {
-          "line": 194,
+          "line": 201,
           "purpose": "the checkbox state from a prior session would silently re-dismiss)."
         },
         "escapeHtml": {
-          "line": 202,
+          "line": 209,
           "params": [
             "s"
           ]
         },
         "escapeAttr": {
-          "line": 211,
+          "line": 218,
           "params": [
             "s"
           ]
@@ -5227,6 +5271,163 @@
           ]
         }
       }
+    },
+    "renderer/sampleBanner": {
+      "file": "src/renderer/sampleBanner.js",
+      "description": "Sample Banner",
+      "exports": [
+        "init"
+      ],
+      "depends": [
+        "state"
+      ],
+      "functions": {
+        "init": {
+          "line": 16
+        },
+        "setVisible": {
+          "line": 34,
+          "params": [
+            "visible"
+          ]
+        }
+      }
+    },
+    "templates/sample-project/src/api/server": {
+      "file": "src/templates/sample-project/src/api/server.js",
+      "description": "Express server — app factory",
+      "exports": [
+        "createApp"
+      ],
+      "depends": [
+        "express",
+        "auth/session",
+        "tasks",
+        "users"
+      ],
+      "functions": {
+        "createApp": {
+          "line": 13
+        }
+      }
+    },
+    "templates/sample-project/src/api/tasks": {
+      "file": "src/templates/sample-project/src/api/tasks.js",
+      "description": "Task CRUD endpoints",
+      "exports": [],
+      "depends": [
+        "express",
+        "db/client",
+        "auth/session"
+      ],
+      "functions": {}
+    },
+    "templates/sample-project/src/api/users": {
+      "file": "src/templates/sample-project/src/api/users.js",
+      "description": "User + team membership endpoints",
+      "exports": [],
+      "depends": [
+        "express",
+        "db/client",
+        "auth/session"
+      ],
+      "functions": {}
+    },
+    "templates/sample-project/src/auth/oauth": {
+      "file": "src/templates/sample-project/src/auth/oauth.js",
+      "description": "Google OAuth — Passport strategy + routes",
+      "exports": [
+        "configureOAuth",
+        "googleStrategy"
+      ],
+      "depends": [
+        "passport",
+        "passport-google-oauth20",
+        "db/client"
+      ],
+      "functions": {
+        "googleStrategy": {
+          "line": 15
+        },
+        "findOrCreateUser": {
+          "line": 33,
+          "params": [
+            "profile"
+          ]
+        },
+        "configureOAuth": {
+          "line": 53,
+          "params": [
+            "app"
+          ]
+        }
+      }
+    },
+    "templates/sample-project/src/auth/session": {
+      "file": "src/templates/sample-project/src/auth/session.js",
+      "description": "Session middleware + requireAuth guard",
+      "exports": [
+        "sessionMiddleware",
+        "requireAuth"
+      ],
+      "depends": [
+        "express-session"
+      ],
+      "functions": {
+        "sessionMiddleware": {
+          "line": 10
+        },
+        "requireAuth": {
+          "line": 24,
+          "params": [
+            "req",
+            "res",
+            "next"
+          ]
+        }
+      }
+    },
+    "templates/sample-project/src/db/client": {
+      "file": "src/templates/sample-project/src/db/client.js",
+      "description": "Database client — Postgres connection pool",
+      "exports": [
+        "pool",
+        "query",
+        "tx"
+      ],
+      "depends": [
+        "pg"
+      ],
+      "functions": {
+        "query": {
+          "line": 20,
+          "params": [
+            "sql",
+            "params"
+          ]
+        },
+        "tx": {
+          "line": 30,
+          "params": [
+            "fn"
+          ]
+        }
+      }
+    },
+    "templates/sample-project/src/index": {
+      "file": "src/templates/sample-project/src/index.js",
+      "description": "TaskFlow — Application entry",
+      "exports": [],
+      "depends": [
+        "api/server",
+        "auth/oauth",
+        "db/client"
+      ],
+      "functions": {
+        "start": {
+          "line": 12
+        }
+      }
     }
   },
   "ipcChannels": {
@@ -5417,6 +5618,16 @@
       },
       "CHECK_AI_TOOL_AVAILABLE": {
         "name": "check-ai-tool-available",
+        "direction": "",
+        "description": ""
+      },
+      "OPEN_SAMPLE_PROJECT": {
+        "name": "open-sample-project",
+        "direction": "",
+        "description": ""
+      },
+      "GET_SAMPLE_PROJECT_PATH": {
+        "name": "get-sample-project-path",
         "direction": "",
         "description": ""
       }
@@ -5836,6 +6047,13 @@
         "description": "Claude Usage Manager Module"
       }
     ],
+    "client": [
+      {
+        "module": "templates/sample-project/src/db/client",
+        "file": "src/templates/sample-project/src/db/client.js",
+        "description": "Database client — Postgres connection pool"
+      }
+    ],
     "command-palette": [
       {
         "module": "renderer/commandPalette",
@@ -5948,6 +6166,11 @@
         "module": "renderer/index",
         "file": "src/renderer/index.js",
         "description": "Renderer Entry Point"
+      },
+      {
+        "module": "templates/sample-project/src/index",
+        "file": "src/templates/sample-project/src/index.js",
+        "description": "TaskFlow — Application entry"
       }
     ],
     "ipc": [
@@ -5962,6 +6185,13 @@
         "module": "main/menu",
         "file": "src/main/menu.js",
         "description": "Application Menu Module"
+      }
+    ],
+    "oauth": [
+      {
+        "module": "templates/sample-project/src/auth/oauth",
+        "file": "src/templates/sample-project/src/auth/oauth.js",
+        "description": "Google OAuth — Passport strategy + routes"
       }
     ],
     "overview": [
@@ -6000,6 +6230,27 @@
         "module": "renderer/promptsPanel",
         "file": "src/renderer/promptsPanel.js",
         "description": "Prompts Panel Module"
+      }
+    ],
+    "sample-banner": [
+      {
+        "module": "renderer/sampleBanner",
+        "file": "src/renderer/sampleBanner.js",
+        "description": "Sample Banner"
+      }
+    ],
+    "server": [
+      {
+        "module": "templates/sample-project/src/api/server",
+        "file": "src/templates/sample-project/src/api/server.js",
+        "description": "Express server — app factory"
+      }
+    ],
+    "session": [
+      {
+        "module": "templates/sample-project/src/auth/session",
+        "file": "src/templates/sample-project/src/auth/session.js",
+        "description": "Session middleware + requireAuth guard"
       }
     ],
     "settings-modal": [
@@ -6092,6 +6343,11 @@
         "module": "renderer/tasksPanel",
         "file": "src/renderer/tasksPanel.js",
         "description": "Tasks Panel Module"
+      },
+      {
+        "module": "templates/sample-project/src/api/tasks",
+        "file": "src/templates/sample-project/src/api/tasks.js",
+        "description": "Task CRUD endpoints"
       }
     ],
     "tasks-dashboard": [
@@ -6164,6 +6420,13 @@
         "module": "main/userSettings",
         "file": "src/main/userSettings.js",
         "description": "User Settings"
+      }
+    ],
+    "users": [
+      {
+        "module": "templates/sample-project/src/api/users",
+        "file": "src/templates/sample-project/src/api/users.js",
+        "description": "User + team membership endpoints"
       }
     ],
     "welcome-overlay": [

--- a/index.html
+++ b/index.html
@@ -24,6 +24,17 @@
     </span>
   </div>
 
+  <!-- Sample-project banner (only visible while inside the bundled sample) -->
+  <div id="sample-banner" class="sample-banner" role="status">
+    <span class="sample-banner-icon">&#9733;</span>
+    <span class="sample-banner-text">
+      You're exploring the <strong>sample project</strong>. Poke around freely — when you're ready, open your own project to start real work.
+    </span>
+    <span class="sample-banner-actions">
+      <button type="button" id="sample-banner-open" class="sample-banner-open">Open My Project</button>
+    </span>
+  </div>
+
   <!-- App Loader (boot splash, hidden once workspace data arrives) -->
   <div id="app-loader" class="app-loader">
     <div class="app-loader-mark">&#10022;</div>
@@ -437,6 +448,13 @@
         <div class="welcome-section">
           <h4 class="welcome-section-title">Get started</h4>
           <div class="welcome-actions">
+            <button id="welcome-try-sample" class="welcome-action welcome-action-featured">
+              <span class="welcome-action-icon">&#9733;</span>
+              <span class="welcome-action-text">
+                <span class="welcome-action-title">Try a Sample Project</span>
+                <span class="welcome-action-desc">Explore Frame on a fictional codebase — specs, tasks, notes already populated</span>
+              </span>
+            </button>
             <button id="welcome-open-folder" class="welcome-action">
               <span class="welcome-action-icon">&#128193;</span>
               <span class="welcome-action-text">

--- a/index.html
+++ b/index.html
@@ -30,9 +30,7 @@
     <span class="sample-banner-text">
       You're exploring the <strong>sample project</strong>. Poke around freely — when you're ready, open your own project to start real work.
     </span>
-    <span class="sample-banner-actions">
-      <button type="button" id="sample-banner-open" class="sample-banner-open">Open My Project</button>
-    </span>
+    <button type="button" id="sample-banner-close" class="sample-banner-close" aria-label="Dismiss">&#x2715;</button>
   </div>
 
   <!-- App Loader (boot splash, hidden once workspace data arrives) -->
@@ -493,8 +491,10 @@
             <input type="checkbox" id="welcome-dont-show" />
             <span>Don&rsquo;t show this again</span>
           </label>
-          <button id="welcome-close" class="welcome-close-btn">Close</button>
-          <button id="welcome-skip" class="welcome-skip">Skip for now</button>
+          <div class="welcome-footer-actions">
+            <button id="welcome-close" class="welcome-close-btn">Close</button>
+            <button id="welcome-start" class="welcome-start-btn">Start &rarr;</button>
+          </div>
         </div>
       </div>
     </div>

--- a/src/main/dialogs.js
+++ b/src/main/dialogs.js
@@ -3,8 +3,9 @@
  * Handles system dialogs - folder picker, file dialogs
  */
 
-const { dialog } = require('electron');
+const { dialog, app } = require('electron');
 const { spawn } = require('child_process');
+const fs = require('fs');
 const path = require('path');
 const { IPC } = require('../shared/ipcChannels');
 
@@ -112,6 +113,67 @@ async function cloneGithubRepo(event, repoUrl) {
 }
 
 /**
+ * Recursively copy a directory using node:fs reads + writes. Avoids
+ * fs.cpSync because that doesn't reliably work from inside Electron's
+ * asar archive; readFileSync + writeFileSync goes through the
+ * transparent asar layer and works in both dev and packaged builds.
+ */
+function copyDirRecursive(src, dst) {
+  fs.mkdirSync(dst, { recursive: true });
+  const entries = fs.readdirSync(src, { withFileTypes: true });
+  for (const ent of entries) {
+    const from = path.join(src, ent.name);
+    const to = path.join(dst, ent.name);
+    if (ent.isDirectory()) {
+      copyDirRecursive(from, to);
+    } else if (ent.isFile()) {
+      const data = fs.readFileSync(from);
+      fs.writeFileSync(to, data);
+    }
+  }
+}
+
+/**
+ * Open the bundled sample project, copying it into the user's app-data
+ * directory on first use so they can poke at it without affecting the
+ * source. We copy lazily — only on first open — and leave any edits the
+ * user makes alone afterward; this is a "training wheels" project, not
+ * a pristine demo that resets every launch.
+ */
+async function openSampleProject(event) {
+  const sourceDir = path.join(__dirname, '..', 'templates', 'sample-project');
+  const targetDir = path.join(app.getPath('userData'), 'sample-project');
+
+  if (!fs.existsSync(sourceDir)) {
+    console.error('Sample project template missing at', sourceDir);
+    return null;
+  }
+
+  if (!fs.existsSync(targetDir)) {
+    try {
+      copyDirRecursive(sourceDir, targetDir);
+    } catch (err) {
+      console.error('Failed to copy sample project:', err);
+      return null;
+    }
+  }
+
+  if (onProjectSelected) {
+    onProjectSelected(targetDir);
+  }
+  event.sender.send(IPC.PROJECT_SELECTED, targetDir);
+  return targetDir;
+}
+
+/**
+ * Path used by the renderer to detect "this is the sample project" so
+ * the banner / read-only hints can show. Exposed via IPC.invoke.
+ */
+function getSampleProjectPath() {
+  return path.join(app.getPath('userData'), 'sample-project');
+}
+
+/**
  * Setup IPC handlers
  */
 function setupIPC(ipcMain) {
@@ -126,11 +188,19 @@ function setupIPC(ipcMain) {
   ipcMain.on(IPC.CLONE_GITHUB_REPO, async (event, repoUrl) => {
     await cloneGithubRepo(event, repoUrl);
   });
+
+  ipcMain.on(IPC.OPEN_SAMPLE_PROJECT, async (event) => {
+    await openSampleProject(event);
+  });
+
+  ipcMain.handle(IPC.GET_SAMPLE_PROJECT_PATH, () => getSampleProjectPath());
 }
 
 module.exports = {
   init,
   showFolderPicker,
   showNewProjectDialog,
+  openSampleProject,
+  getSampleProjectPath,
   setupIPC
 };

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -38,8 +38,10 @@ let mainWindow = null;
  */
 function createWindow() {
   mainWindow = new BrowserWindow({
-    width: 1000,
-    height: 700,
+    width: 1400,
+    height: 900,
+    minWidth: 900,
+    minHeight: 600,
     webPreferences: {
       nodeIntegration: true,
       contextIsolation: false

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -31,6 +31,7 @@ const welcomeOverlay = require('./welcomeOverlay');
 const appLoader = require('./appLoader');
 const settingsModal = require('./settingsModal');
 const telemetryNotice = require('./telemetryNotice');
+const sampleBanner = require('./sampleBanner');
 
 /**
  * Initialize all modules
@@ -175,6 +176,7 @@ function init() {
   welcomeOverlay.init();
   settingsModal.init();
   telemetryNotice.init(() => settingsModal.open());
+  sampleBanner.init();
   setupUpdateDot();
   registerCommands();
   commandRegistry.bindKeyboard();

--- a/src/renderer/sampleBanner.js
+++ b/src/renderer/sampleBanner.js
@@ -1,29 +1,53 @@
 /**
- * Sample Banner
+ * Sample Mode (banner + auto-opened side panels)
  *
- * Top-of-window strip shown while the user is inside Frame's bundled
- * sample project. Reminds them this is exploration content and offers
- * a one-click "Open My Project" CTA. Subscribes to state.onSampleChange
- * so visibility tracks the actual project mode.
+ * Coordinates the UX that fires whenever the user enters the bundled
+ * sample project:
+ *   - Shows the top "this is sample content" banner
+ *   - Auto-opens Tasks and Specs panels so the user immediately sees
+ *     the populated content (the whole point of the sample is to
+ *     demonstrate what those panels look like with real-feeling data)
+ *
+ * All of this is opt-out: clicking the banner's × dismisses it for the
+ * current sample-session, and panels can be closed individually.
  */
 
 const state = require('./state');
+const tasksPanel = require('./tasksPanel');
+const specPanel = require('./specPanel');
 
 let bannerEl = null;
-let openBtnEl = null;
+let closeBtnEl = null;
 let initialized = false;
+let dismissedForCurrentSession = false;
 
 function init() {
   if (initialized) return;
   bannerEl = document.getElementById('sample-banner');
-  openBtnEl = document.getElementById('sample-banner-open');
+  closeBtnEl = document.getElementById('sample-banner-close');
   if (!bannerEl) return;
 
-  openBtnEl?.addEventListener('click', () => {
-    state.selectProjectFolder();
+  closeBtnEl?.addEventListener('click', () => {
+    dismissedForCurrentSession = true;
+    setVisible(false);
   });
 
-  state.onSampleChange((isSample) => setVisible(isSample));
+  // Banner appears whenever the user is in the sample project. Dismissal
+  // is per-sample-open: if they switch away and come back, banner shows
+  // again. Avoids being silently buried after one click.
+  state.onSampleChange((isSample) => {
+    if (isSample) {
+      dismissedForCurrentSession = false;
+      // Auto-open the side panels so the user immediately sees the
+      // populated tasks + specs the sample exists to demonstrate.
+      // Wrapped in try/catch because if the modules failed to init for
+      // any reason, we still want the banner to show.
+      try { tasksPanel.show(); } catch (err) { console.error('sampleMode: tasksPanel.show failed', err); }
+      try { specPanel.show(); } catch (err) { console.error('sampleMode: specPanel.show failed', err); }
+    }
+    setVisible(isSample && !dismissedForCurrentSession);
+  });
+
   // Initial paint — covers the case where the sample is already open
   // (e.g., session resumed after restart).
   setVisible(state.getIsSampleProject());

--- a/src/renderer/sampleBanner.js
+++ b/src/renderer/sampleBanner.js
@@ -1,0 +1,39 @@
+/**
+ * Sample Banner
+ *
+ * Top-of-window strip shown while the user is inside Frame's bundled
+ * sample project. Reminds them this is exploration content and offers
+ * a one-click "Open My Project" CTA. Subscribes to state.onSampleChange
+ * so visibility tracks the actual project mode.
+ */
+
+const state = require('./state');
+
+let bannerEl = null;
+let openBtnEl = null;
+let initialized = false;
+
+function init() {
+  if (initialized) return;
+  bannerEl = document.getElementById('sample-banner');
+  openBtnEl = document.getElementById('sample-banner-open');
+  if (!bannerEl) return;
+
+  openBtnEl?.addEventListener('click', () => {
+    state.selectProjectFolder();
+  });
+
+  state.onSampleChange((isSample) => setVisible(isSample));
+  // Initial paint — covers the case where the sample is already open
+  // (e.g., session resumed after restart).
+  setVisible(state.getIsSampleProject());
+
+  initialized = true;
+}
+
+function setVisible(visible) {
+  if (!bannerEl) return;
+  bannerEl.classList.toggle('visible', !!visible);
+}
+
+module.exports = { init };

--- a/src/renderer/state.js
+++ b/src/renderer/state.js
@@ -10,9 +10,12 @@ const SPOTLIGHT_SEEN_KEY = 'frame-init-spotlight-seen';
 
 let currentProjectPath = null;
 let isCurrentProjectFrame = false;
+let sampleProjectPath = null;     // cached from main on init
+let isCurrentProjectSample = false;
 let onProjectChangeCallbacks = [];
 let onFrameStatusChangeCallbacks = [];
 let onFrameInitializedCallbacks = [];
+let onSampleChangeCallbacks = [];
 let multiTerminalUI = null; // Reference to MultiTerminalUI instance
 
 // UI Elements
@@ -33,6 +36,17 @@ function init(elements) {
   setupIPC();
   setupInitFrameModalListeners();
   setupSpotlightListeners();
+
+  // Cache the sample project path so we can detect when the user is
+  // inside the sample without an IPC round-trip on every project switch.
+  ipcRenderer
+    .invoke(IPC.GET_SAMPLE_PROJECT_PATH)
+    .then((p) => {
+      sampleProjectPath = p || null;
+    })
+    .catch(() => {
+      sampleProjectPath = null;
+    });
 }
 
 /**
@@ -55,6 +69,16 @@ function setMultiTerminalUI(ui) {
 function setProjectPath(path) {
   const previousPath = currentProjectPath;
   currentProjectPath = path;
+
+  // Detect sample-project mode. Compared as strings — main resolved the
+  // canonical path on startup, so any project opened at exactly that path
+  // is the bundled sample.
+  const wasSample = isCurrentProjectSample;
+  isCurrentProjectSample = !!(path && sampleProjectPath && path === sampleProjectPath);
+  if (wasSample !== isCurrentProjectSample) {
+    onSampleChangeCallbacks.forEach((cb) => cb(isCurrentProjectSample));
+  }
+
   updateProjectUI();
 
   // Switch terminal session if MultiTerminalUI is available
@@ -337,6 +361,31 @@ function createNewProject() {
 }
 
 /**
+ * Open the bundled sample project. Main copies it into the user-data
+ * directory on first use, then emits PROJECT_SELECTED — the same flow
+ * the folder-picker uses, so all downstream wiring (file tree, tasks,
+ * specs) is reused unchanged.
+ */
+function openSampleProject() {
+  ipcRenderer.send(IPC.OPEN_SAMPLE_PROJECT);
+}
+
+/**
+ * Check whether the current project is the bundled sample.
+ */
+function getIsSampleProject() {
+  return isCurrentProjectSample;
+}
+
+/**
+ * Register a callback fired whenever the current project's
+ * "is sample" flag changes (opens or leaves the sample).
+ */
+function onSampleChange(callback) {
+  onSampleChangeCallbacks.push(callback);
+}
+
+/**
  * Setup IPC listeners
  */
 function setupIPC() {
@@ -369,6 +418,9 @@ module.exports = {
   updateProjectUI,
   selectProjectFolder,
   createNewProject,
+  openSampleProject,
+  getIsSampleProject,
+  onSampleChange,
   getIsFrameProject,
   setIsFrameProject,
   onFrameStatusChange,

--- a/src/renderer/styles/components/panels.css
+++ b/src/renderer/styles/components/panels.css
@@ -4604,6 +4604,32 @@
   color: var(--accent-primary);
 }
 
+#specs-refresh-btn {
+  background: transparent;
+  border: 1px solid var(--border-default);
+  color: var(--text-secondary);
+  padding: var(--space-xs);
+  border-radius: var(--radius-sm);
+  width: 28px;
+  height: 28px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all var(--transition-fast);
+}
+
+#specs-refresh-btn:hover {
+  background: var(--accent-subtle);
+  border-color: var(--accent-primary);
+  color: var(--accent-primary);
+}
+
+#specs-refresh-btn:active svg {
+  transform: rotate(180deg);
+  transition: transform 0.4s ease-out;
+}
+
 #specs-wide-toggle.is-wide {
   background: var(--accent-subtle);
   border-color: var(--accent-primary);

--- a/src/renderer/styles/components/sample-banner.css
+++ b/src/renderer/styles/components/sample-banner.css
@@ -37,27 +37,25 @@
   font-weight: 600;
 }
 
-.sample-banner-actions {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  flex-shrink: 0;
-}
-
-.sample-banner-open {
-  background: var(--accent-primary);
-  color: var(--bg-secondary);
-  border: 1px solid var(--accent-primary);
-  border-radius: 5px;
-  padding: 4px 12px;
-  font-family: inherit;
-  font-size: 11px;
-  font-weight: 500;
+/* Accent-colored × so it visually separates from the side-panel close
+   button that sits directly beneath it on the right edge. Frame's gold
+   makes it pop against the subtle banner background. */
+.sample-banner-close {
+  background: none;
+  border: none;
+  color: var(--accent-primary);
   cursor: pointer;
-  transition: background 0.12s;
+  font-size: 15px;
+  font-weight: 600;
+  padding: 4px 8px;
+  margin-right: 4px;
+  border-radius: 4px;
+  line-height: 1;
+  flex-shrink: 0;
+  transition: color 0.12s, background 0.12s;
 }
 
-.sample-banner-open:hover {
-  background: var(--accent-secondary);
-  border-color: var(--accent-secondary);
+.sample-banner-close:hover {
+  color: var(--accent-secondary);
+  background: var(--accent-subtle);
 }

--- a/src/renderer/styles/components/sample-banner.css
+++ b/src/renderer/styles/components/sample-banner.css
@@ -1,0 +1,63 @@
+/* Sample Banner — top strip shown while the bundled sample project is open */
+
+.sample-banner {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 9000;
+  background: var(--accent-subtle);
+  border-bottom: 1px solid var(--accent-primary);
+  padding: 8px 14px;
+  display: none;
+  align-items: center;
+  gap: 12px;
+  font-size: 12px;
+  color: var(--text-primary);
+}
+
+.sample-banner.visible {
+  display: flex;
+}
+
+.sample-banner-icon {
+  font-size: 14px;
+  color: var(--accent-primary);
+  flex-shrink: 0;
+}
+
+.sample-banner-text {
+  flex: 1;
+  min-width: 0;
+  line-height: 1.5;
+}
+
+.sample-banner-text strong {
+  color: var(--accent-primary);
+  font-weight: 600;
+}
+
+.sample-banner-actions {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-shrink: 0;
+}
+
+.sample-banner-open {
+  background: var(--accent-primary);
+  color: var(--bg-secondary);
+  border: 1px solid var(--accent-primary);
+  border-radius: 5px;
+  padding: 4px 12px;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.12s;
+}
+
+.sample-banner-open:hover {
+  background: var(--accent-secondary);
+  border-color: var(--accent-secondary);
+}

--- a/src/renderer/styles/components/welcome-overlay.css
+++ b/src/renderer/styles/components/welcome-overlay.css
@@ -120,6 +120,23 @@
   transform: scale(0.99);
 }
 
+/* Featured action — the sample-project entry. Marked visually so first-
+   time users have a low-friction option that doesn't require picking a
+   folder. */
+.welcome-action-featured {
+  background: var(--accent-subtle);
+  border-color: var(--accent-primary);
+}
+
+.welcome-action-featured:hover {
+  background: var(--accent-subtle);
+  border-color: var(--accent-secondary);
+}
+
+.welcome-action-featured .welcome-action-icon {
+  color: var(--accent-primary);
+}
+
 .welcome-action-icon {
   width: 22px;
   height: 22px;

--- a/src/renderer/styles/components/welcome-overlay.css
+++ b/src/renderer/styles/components/welcome-overlay.css
@@ -237,7 +237,7 @@
 
 .welcome-footer {
   display: grid;
-  grid-template-columns: 1fr auto 1fr;
+  grid-template-columns: 1fr auto;
   align-items: center;
   gap: 12px;
   margin-top: 18px;
@@ -247,15 +247,15 @@
   justify-self: start;
 }
 
-.welcome-footer .welcome-close-btn {
-  justify-self: center;
-}
-
-.welcome-footer .welcome-skip {
+.welcome-footer-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   justify-self: end;
 }
 
-.welcome-close-btn {
+/* Primary CTA — proceed into the sample */
+.welcome-start-btn {
   background: var(--accent-primary);
   color: var(--bg-secondary);
   border: 1px solid var(--accent-primary);
@@ -268,13 +268,32 @@
   transition: background 0.12s, transform 0.08s;
 }
 
-.welcome-close-btn:hover {
+.welcome-start-btn:hover {
   background: var(--accent-secondary);
   border-color: var(--accent-secondary);
 }
 
-.welcome-close-btn:active {
+.welcome-start-btn:active {
   transform: scale(0.98);
+}
+
+/* Secondary — dismiss without opening anything */
+.welcome-close-btn {
+  background: none;
+  border: 1px solid var(--border-default);
+  color: var(--text-secondary);
+  border-radius: 7px;
+  padding: 8px 18px;
+  font-family: inherit;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s, border-color 0.12s;
+}
+
+.welcome-close-btn:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+  border-color: var(--border-strong);
 }
 
 .welcome-dont-show-label {

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -41,5 +41,8 @@
 /* 12. Telemetry Notice (one-time disclosure banner) */
 @import 'components/telemetry-notice.css';
 
+/* 12b. Sample-project banner */
+@import 'components/sample-banner.css';
+
 /* 13. Tasks Dashboard (Kanban-style overlay) */
 @import 'components/tasks-dashboard.css';

--- a/src/renderer/welcomeOverlay.js
+++ b/src/renderer/welcomeOverlay.js
@@ -102,8 +102,13 @@ function setupListeners() {
     close();
   });
 
-  document.getElementById('welcome-skip').addEventListener('click', () => {
+  // "Start" is the primary CTA — it commits the user into the sample
+  // project so they don't get dropped onto a blank screen. The dedicated
+  // featured action above still exists for users who want to be explicit;
+  // this footer button is the obvious "just proceed" path.
+  document.getElementById('welcome-start').addEventListener('click', () => {
     close();
+    state.openSampleProject();
   });
 
   // Persist checkbox state immediately on change so Cmd+Q while the modal

--- a/src/renderer/welcomeOverlay.js
+++ b/src/renderer/welcomeOverlay.js
@@ -70,6 +70,13 @@ async function maybeShowOnLaunch() {
 
 function setupListeners() {
   document
+    .getElementById('welcome-try-sample')
+    .addEventListener('click', () => {
+      close();
+      state.openSampleProject();
+    });
+
+  document
     .getElementById('welcome-open-folder')
     .addEventListener('click', () => {
       close();

--- a/src/shared/ipcChannels.js
+++ b/src/shared/ipcChannels.js
@@ -16,6 +16,8 @@ const IPC = {
   CREATE_NEW_PROJECT: 'create-new-project',
   CLONE_GITHUB_REPO: 'clone-github-repo',
   CLONE_GITHUB_REPO_RESULT: 'clone-github-repo-result',
+  OPEN_SAMPLE_PROJECT: 'open-sample-project',
+  GET_SAMPLE_PROJECT_PATH: 'get-sample-project-path',
   PROJECT_SELECTED: 'project-selected',
 
   // File Tree

--- a/src/templates/sample-project/.frame/specs/add-google-oauth/outcome.md
+++ b/src/templates/sample-project/.frame/specs/add-google-oauth/outcome.md
@@ -1,0 +1,64 @@
+# Outcome — Add Google OAuth login
+
+Captured per-task by `/spec.implement`. 2-3 sentences each, written
+while the agent's memory was fresh. Skim this six months from now and
+you'll remember why the code looks the way it does.
+
+---
+
+## T1 — Add migration for google_id + google_refresh_token columns
+
+Wrote `003_google_oauth.sql`. Added a unique partial index on `google_id`
+(WHERE NOT NULL) so multiple rows can sit with NULL during the rollout.
+Tested rollback locally; works clean.
+
+## T2 — Run migration in dev; verify roll-back works
+
+Migration applied to dev DB. Rollback verified — `DROP COLUMN` works
+because we hadn't added FKs that reference google_id. Noted: production
+backfill should run inside a transaction to avoid partial state.
+
+## T3 — Provision OAuth client in Google Cloud + add env credentials
+
+Created prod + dev OAuth clients in Google Cloud Console. Dev client
+allows `http://localhost:5173` as authorized origin. Credentials in
+`.env.example` (placeholder); real values in 1Password vault.
+
+## T4 — Install passport-google-oauth20 dependency
+
+Installed at v2.0.0. Pinned exact version because the strategy's
+profile shape has shifted across majors and we want a known-good baseline.
+
+## T5 — Implement src/auth/oauth.js Passport strategy
+
+Implemented `googleStrategy` + `configureOAuth(app)` helper. Find-or-
+create logic ended up cleaner as a single SQL upsert with a partial
+index than the if/else tree in the plan — diverged from plan here. Spec
+plan should be updated next time we do similar.
+
+## T6 — Wire oauth into Express app + session middleware
+
+Mounted `passport.initialize()` and `passport.session()` after
+`sessionMiddleware`. Order matters — Passport needs the session to
+exist before it can hydrate the user. Added a comment in
+`src/auth/session.js` flagging this.
+
+## T7 — Add /auth/google/start + /auth/google/callback routes
+
+Routes added in `src/auth/oauth.js`. Used `failureRedirect: '/login?
+error=oauth'` to surface failed attempts to the UI. UI side (showing
+the error toast) wasn't in this spec — followup task created: task-020.
+
+## T8 — End-to-end test: full OAuth round-trip
+
+E2E test passes in CI. Mocked Google's consent + token endpoints with
+`nock`. Test covers: success path, denied consent, expired code,
+email-merge-with-existing-account. Coverage uneven on the merge case
+because the partial-index logic is hard to assert from the outside —
+followed up with unit tests inside `oauth.js` directly.
+
+---
+
+**Spec shipped 2026-02-22.** Total elapsed: 4 days. Estimated 3. The
+extra day went to the consent-screen UX polish (not in tasks but the
+team noticed it was ugly).

--- a/src/templates/sample-project/.frame/specs/add-google-oauth/plan.md
+++ b/src/templates/sample-project/.frame/specs/add-google-oauth/plan.md
@@ -1,0 +1,48 @@
+# Plan — Add Google OAuth login
+
+## Architecture
+
+- Use Passport.js with `passport-google-oauth20` strategy. Passport
+  handles the OAuth dance; we own user lookup/creation and session
+  attachment.
+- New columns on `users`: `google_id` (unique, nullable),
+  `google_refresh_token` (nullable). Existing rows untouched.
+- OAuth credentials live in env (`GOOGLE_OAUTH_CLIENT_ID`,
+  `GOOGLE_OAUTH_CLIENT_SECRET`). Local dev uses a separate test client.
+
+## Sequence (happy path)
+
+1. User clicks "Sign in with Google" → browser hits `/auth/google/start`
+2. Backend redirects to Google's consent screen with our client_id +
+   redirect_uri + scopes (`openid email profile`)
+3. User consents → Google redirects to `/auth/google/callback?code=...`
+4. Passport strategy exchanges the code for tokens + profile
+5. Find-or-create user in DB:
+   - If `users.google_id` matches → log them in
+   - Else if `users.email` matches a row → set `google_id` on that row
+     and log them in (account link)
+   - Else create new user row with email + google_id
+6. Establish session via `req.login(user)`
+7. Redirect to `/dashboard`
+
+## Risks + mitigations
+
+- **Account hijack via email collision.** Mitigation: only merge by
+  email if the existing user has never set a password (i.e., placeholder
+  account). For real password-set users, require an authenticated link
+  flow instead. v1 ships without this — flagged for follow-up.
+- **Refresh token leakage.** Mitigation: encrypt at rest using the
+  application key. Decrypt only when needed. Never log raw tokens.
+
+## Files touched
+
+- New: `src/auth/oauth.js`, `src/db/migrations/003_google_oauth.sql`
+- Modified: `src/auth/session.js` (serialize/deserialize hooks),
+  `src/api/server.js` (mount routes)
+- Tests: `src/auth/oauth.test.js`
+
+## Rollback
+
+The migration is reversible (`DROP COLUMN google_id, google_refresh_token`).
+The OAuth routes can be unmounted with one commit. Existing password
+login is unaffected throughout.

--- a/src/templates/sample-project/.frame/specs/add-google-oauth/spec.md
+++ b/src/templates/sample-project/.frame/specs/add-google-oauth/spec.md
@@ -1,0 +1,33 @@
+# Add Google OAuth login
+
+## Why
+
+Users currently sign in with email + password, stored in our own DB.
+Operating an auth system (rate limits, password resets, MFA, account
+recovery) is real engineering cost we don't want to carry. We want users
+to click "Sign in with Google" and never see a password prompt.
+
+## What's in scope
+
+- Google as the **only** new provider in v1 (not GitHub, not Microsoft —
+  see PROJECT_NOTES 2026-02-19)
+- New users created automatically on first login
+- Existing email/password users can link a Google account; if their
+  Google email matches an existing account, the accounts are merged
+- Session model unchanged — Google login just creates a session
+
+## What's out of scope
+
+- Other providers (GitHub, GitLab, Microsoft, etc.)
+- Removing the email/password path (still needed for users without
+  Google accounts)
+- SSO / SAML — separate concern, enterprise-only
+
+## Success criteria
+
+- `/auth/google/start` redirects to Google's consent screen
+- `/auth/google/callback` exchanges the code, fetches the profile,
+  finds-or-creates the user, sets the session, redirects to the dashboard
+- End-to-end test passes in CI: full round-trip from start → consent
+  (mocked) → callback → authenticated request
+- No production secrets in the repo

--- a/src/templates/sample-project/.frame/specs/add-google-oauth/status.json
+++ b/src/templates/sample-project/.frame/specs/add-google-oauth/status.json
@@ -1,0 +1,10 @@
+{
+  "slug": "add-google-oauth",
+  "title": "Add Google OAuth login",
+  "phase": "done",
+  "ai_tool": "claude-code",
+  "generated_task_ids": ["task-001", "task-002", "task-003", "task-004", "task-005", "task-006", "task-007", "task-008"],
+  "created_at": "2026-02-18T14:00:00Z",
+  "updated_at": "2026-02-22T10:00:00Z",
+  "last_phase_at": "2026-02-22T10:00:00Z"
+}

--- a/src/templates/sample-project/.frame/specs/add-google-oauth/tasks.md
+++ b/src/templates/sample-project/.frame/specs/add-google-oauth/tasks.md
@@ -1,0 +1,10 @@
+# Tasks — Add Google OAuth login
+
+- [x] T1 — Add migration for google_id + google_refresh_token columns
+- [x] T2 — Run migration in dev; verify roll-back works
+- [x] T3 — Provision OAuth client in Google Cloud + add env credentials
+- [x] T4 — Install passport-google-oauth20 dependency
+- [x] T5 — Implement src/auth/oauth.js Passport strategy
+- [x] T6 — Wire oauth into Express app + session middleware
+- [x] T7 — Add /auth/google/start + /auth/google/callback routes
+- [x] T8 — End-to-end test: full OAuth round-trip

--- a/src/templates/sample-project/.frame/specs/email-notifications/plan.md
+++ b/src/templates/sample-project/.frame/specs/email-notifications/plan.md
@@ -1,0 +1,86 @@
+# Plan — Email notifications for task assignment
+
+## Provider: Postmark
+
+Picked over SendGrid (price-comparable, worse deliverability for
+transactional) and SES (better price but harder ops — bounce/complaint
+handling is on us). Postmark gives us a clean API, automatic suppression
+list management, and reasonable pricing at our scale.
+
+## Architecture
+
+```
+Task assigned   →   Worker queue (BullMQ)   →   Postmark API   →   Inbox
+       │                      │
+       │                      ↓
+       │              Retry policy (5x, exponential)
+       │                      │
+       └──────── Audit log ───┘
+```
+
+### Why a queue
+
+- Postmark API can be slow or rate-limited. We don't want the user
+  waiting on the assignment write while we send mail.
+- Retries on transient failures (timeouts, 5xx) without coupling to
+  the request lifecycle.
+- A dead-letter queue lets ops see what's stuck.
+
+### Why not just `setImmediate`
+
+Considered. Two reasons it loses:
+1. Lost on process restart. We deploy multiple times a week.
+2. No retry, no visibility, no audit.
+
+The Redis cost (~$10/mo for our scale) is worth it.
+
+## Templates: MJML → compiled HTML
+
+Templates live in `src/email/templates/*.mjml`. A build step compiles
+them to HTML + a plain-text variant. The runtime renderer just
+interpolates `{{user_name}}`, `{{task_title}}`, `{{task_url}}` into the
+compiled output.
+
+Three templates initially:
+- `task_assigned.mjml`
+- `task_mentioned.mjml`
+- `welcome.mjml` (already exists as inline HTML — port to MJML)
+
+## Opt-out model
+
+Single boolean per user: `email_notifications_enabled` on the users
+table, defaults true. The unsubscribe link sets it to false using a
+signed token (no login required).
+
+Granularity (per-type opt-out) is explicitly deferred. We can add it
+later without a migration.
+
+## Risks
+
+- **Deliverability spiral.** If users mark emails as spam, our domain
+  reputation tanks. Mitigation: clear opt-out, sane defaults, low
+  send volume. Set up DMARC + SPF + DKIM properly before launch.
+- **Token leakage in unsubscribe links.** Mitigation: tokens are
+  scoped (just toggle this one user's bool), single-use, and signed.
+  Compromise of one token doesn't compromise the account.
+
+## Files touched (estimated)
+
+- New: `src/notifications/queue.js`, `src/notifications/sender.js`,
+  `src/email/templates/*.mjml`, `src/email/renderer.js`,
+  `src/db/migrations/008_email_prefs.sql`
+- Modified: `src/api/tasks.js` (enqueue on assign),
+  `src/api/users.js` (settings endpoint), `src/ui/Settings.jsx`
+- Tests: heavy fixturing in `tests/notifications/`
+
+## Estimated effort
+
+3-5 days of focused work. The MJML build pipeline + queue setup are
+the long poles; the actual notification logic is simple once those
+are in place.
+
+---
+
+*Run `/spec.tasks` to break this into a discrete task list when ready
+to start. Currently this spec is in `planned` phase — captured but not
+yet scheduled.*

--- a/src/templates/sample-project/.frame/specs/email-notifications/spec.md
+++ b/src/templates/sample-project/.frame/specs/email-notifications/spec.md
@@ -1,0 +1,40 @@
+# Email notifications for task assignment
+
+## Why
+
+Users assigned a task by a teammate currently find out only when they
+open TaskFlow. For small teams working asynchronously across time
+zones, that's too slow. The minimum bar: a transactional email when a
+task is assigned to you, with the title + a deep link.
+
+## What's in scope
+
+- Email on task assignment (to the assignee, not the assigner)
+- Email on task @mention in description (someone tags you)
+- Per-user opt-out in Settings → Notifications
+- Plain-text + HTML version of each email
+- Footer with unsubscribe link
+
+## What's out of scope (v1)
+
+- Slack / Discord / webhook integrations — separate spec later
+- Digest emails ("3 things happened today") — needs preference
+  modeling we don't want yet
+- Push notifications (browser or mobile)
+- Notification *inbox* in the app — see PROJECT_NOTES 2026-03-22
+
+## Open questions for /spec.plan
+
+- Email provider choice: Postmark vs SendGrid vs SES. Postmark has the
+  best deliverability for transactional; SES is cheapest. Need to pick.
+- Background job runner: BullMQ (Redis) or just `setImmediate` + retry?
+  Depends on what fails when the email API is slow.
+- Template engine: Handlebars vs MJML? MJML gives us the responsive
+  HTML for free.
+
+## Success criteria
+
+- Email arrives in inbox < 30s after assignment
+- Opt-out is honored within 1 minute of toggle
+- Unsubscribe link works without requiring login
+- No email leaks (test fixtures shouldn't be able to send real mail)

--- a/src/templates/sample-project/.frame/specs/email-notifications/status.json
+++ b/src/templates/sample-project/.frame/specs/email-notifications/status.json
@@ -1,0 +1,10 @@
+{
+  "slug": "email-notifications",
+  "title": "Email notifications for task assignment",
+  "phase": "planned",
+  "ai_tool": "claude-code",
+  "generated_task_ids": [],
+  "created_at": "2026-03-22T11:00:00Z",
+  "updated_at": "2026-03-22T15:00:00Z",
+  "last_phase_at": "2026-03-22T15:00:00Z"
+}

--- a/src/templates/sample-project/.frame/specs/migrate-to-postgres/outcome.md
+++ b/src/templates/sample-project/.frame/specs/migrate-to-postgres/outcome.md
@@ -1,0 +1,31 @@
+# Outcome — Migrate from SQLite to PostgreSQL
+
+In-flight. Entries land per task as `/spec.implement` walks the list.
+
+---
+
+## T1 — Audit current SQLite schema; map every table to a Postgres equivalent
+
+Inventory done. Found one surprise: the `attachments` table has an
+implicit dependency on SQLite's rowid that we never noticed. Replacing
+with explicit `id UUID PRIMARY KEY` in Postgres. Documented mapping in
+plan.md's table.
+
+## T2 — Stand up Postgres in docker-compose for local dev
+
+`docker-compose.yml` updated. Postgres 16 image, persistent volume,
+exposes 5432. README still references SQLite setup steps — flagged a
+followup task (task-017).
+
+## T3 — Port src/db/client.js from sqlite3 to pg with connection pooling
+
+Refactor done. Public surface (`pool`, `query`, `tx` exports) preserved
+so the rest of the codebase didn't need to change. `query()` now takes
+positional params with `$1, $2` placeholders instead of SQLite's `?` —
+swept callers and updated them all in this PR (28 sites).
+
+## T4 — Migrate users + sessions tables (queries, FK constraints)
+
+Tables migrated. `users.id` and `sessions.user_id` switched to UUID.
+Existing TEXT IDs from SQLite preserved in a `legacy_id` column during
+dual-write. Will drop after cutover. Tests green.

--- a/src/templates/sample-project/.frame/specs/migrate-to-postgres/plan.md
+++ b/src/templates/sample-project/.frame/specs/migrate-to-postgres/plan.md
@@ -1,0 +1,59 @@
+# Plan — Migrate from SQLite to PostgreSQL
+
+## Strategy: dual-write, then cutover
+
+We won't do a big-bang switch. The rollout has three phases:
+
+1. **Port code, run on Postgres in dev/staging only.** Tests must pass.
+2. **Dual-write in production.** Writes hit both DBs, reads still come
+   from SQLite. Verify with a checksum job that the two stay in sync.
+3. **Cutover.** Read traffic flips to Postgres. Keep SQLite warm for
+   one week as the rollback target.
+
+## Tables
+
+In dependency order (parent → child):
+
+```
+users         → sessions, tasks (assigned_to_user_id)
+teams         → tasks (team_id)
+attachments   → tasks (task_id FK)
+```
+
+We migrate parents first so child FKs always resolve.
+
+## Schema changes (carried over, not refactored)
+
+| Change | Why |
+|---|---|
+| `id` columns: TEXT → UUID (with `gen_random_uuid()` default) | Native UUID support, smaller index footprint |
+| Boolean columns: 0/1 → true/false | Postgres native |
+| `created_at` defaults: `CURRENT_TIMESTAMP` → `now()` | Same semantics, native syntax |
+| `tasks.payload`: TEXT (json string) → JSONB | We're already querying it as JSON; JSONB indexes it |
+
+Nothing else changes shape. Same columns, same NOT NULL constraints,
+same uniques.
+
+## Cutover plan
+
+1. T-1h: stop background workers
+2. T-30m: pause new sign-ups
+3. T-15m: final checksum verify
+4. T-5m: read traffic flips via feature flag
+5. T-0: monitor error rate + latency for 30 min
+6. If anything fires above threshold → flip flag back
+
+## Risks
+
+- **Auto-increment ID drift between engines.** Avoided by switching to
+  UUIDs in this same migration. Old TEXT ids preserved during dual-write.
+- **Connection pool exhaustion.** Postgres on Neon has a hard pool
+  limit. Configured `pg.Pool({ max: 20 })` and tested under load.
+- **Backfill speed.** Production has ~2M task rows. Initial copy uses
+  `COPY ... FROM STDIN` (~3 min on staging dry-run).
+
+## Followup
+
+ORM evaluation deferred. We agreed: ship the engine swap first, then
+re-evaluate whether to layer Knex/Drizzle over raw `pg`. Tracked as a
+PROJECT_NOTES item, not a separate spec.

--- a/src/templates/sample-project/.frame/specs/migrate-to-postgres/spec.md
+++ b/src/templates/sample-project/.frame/specs/migrate-to-postgres/spec.md
@@ -1,0 +1,39 @@
+# Migrate from SQLite to PostgreSQL
+
+## Why
+
+SQLite served us through the v0 build and beta launch. Three pressures
+made it the wrong choice for the next 6 months:
+
+1. **Concurrent writes.** SQLite's single-writer model is starting to
+   show up in p99 latencies as the team-assignment flow lands writes
+   on multiple tables in one transaction.
+2. **Hosting.** Our deployment story (single VM with the DB file on a
+   local volume) doesn't survive the multi-region story we want by Q3.
+3. **Tooling.** Connection pooling, observability, partial indexes,
+   JSONB — Postgres gives us all of them off the shelf.
+
+See PROJECT_NOTES 2026-03-08 for the SQLite vs Postgres vs MongoDB
+discussion.
+
+## What's in scope
+
+- Move all production data to a managed Postgres (Neon for prod,
+  docker-compose locally)
+- Port `src/db/client.js` from `sqlite3` to `pg`
+- Migrate every table (users, sessions, teams, tasks, attachments)
+- Backfill production data via a one-time script
+- A clean cutover window: < 5 minutes downtime, fully reversible
+
+## What's out of scope
+
+- Schema refactoring (we keep the same shape, only swap engine)
+- Multi-region — we plan for it but ship single-region now
+- ORM adoption (decision deferred — see followup notes)
+
+## Success criteria
+
+- All tests green on Postgres
+- Production data backfilled with zero row-count drift
+- p95 latency unchanged or better on representative endpoints
+- Rollback plan documented and rehearsed on staging

--- a/src/templates/sample-project/.frame/specs/migrate-to-postgres/status.json
+++ b/src/templates/sample-project/.frame/specs/migrate-to-postgres/status.json
@@ -1,0 +1,10 @@
+{
+  "slug": "migrate-to-postgres",
+  "title": "Migrate from SQLite to PostgreSQL",
+  "phase": "implementing",
+  "ai_tool": "claude-code",
+  "generated_task_ids": ["task-009", "task-010", "task-011", "task-012", "task-013", "task-014", "task-015", "task-016"],
+  "created_at": "2026-03-07T16:00:00Z",
+  "updated_at": "2026-03-11T16:00:00Z",
+  "last_phase_at": "2026-03-09T17:00:00Z"
+}

--- a/src/templates/sample-project/.frame/specs/migrate-to-postgres/tasks.md
+++ b/src/templates/sample-project/.frame/specs/migrate-to-postgres/tasks.md
@@ -1,0 +1,10 @@
+# Tasks — Migrate from SQLite to PostgreSQL
+
+- [x] T1 — Audit current SQLite schema; map every table to a Postgres equivalent
+- [x] T2 — Stand up Postgres in docker-compose for local dev
+- [x] T3 — Port src/db/client.js from sqlite3 to pg with connection pooling
+- [x] T4 — Migrate users + sessions tables (queries, FK constraints)
+- [ ] T5 — Migrate tasks + teams tables; add UUID primary keys
+- [ ] T6 — Backfill data: copy SQLite production data to Postgres staging
+- [ ] T7 — Add transaction support via tx() helper in db/client.js
+- [ ] T8 — Production cutover plan + dry-run on staging

--- a/src/templates/sample-project/.gitignore
+++ b/src/templates/sample-project/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+.env
+.env.local
+dist/
+.DS_Store
+*.log

--- a/src/templates/sample-project/AGENTS.md
+++ b/src/templates/sample-project/AGENTS.md
@@ -1,57 +1,221 @@
-# TaskFlow — Project Instructions
+# TaskFlow - Frame Project
 
-This is a **sample project** that ships with Frame to demonstrate the
-spec-driven development workflow on a realistic codebase. You're looking
-at a fictional SaaS called TaskFlow: a small team task manager built on
-Node.js + Express + PostgreSQL + React.
+This project is managed with **Frame**. AI assistants should follow the rules below to keep documentation up to date.
 
-> Open your own project when you're ready to start real work. Everything
-> here is read-friendly — feel free to poke around, edit, break things.
-> Nothing here ships anywhere.
+> **Note:** This is the **sample project** that ships with Frame. It's a fictional codebase used to demonstrate Frame's workflow on realistic content. None of this code runs. When you're ready, open your own project to start real work.
 
 ---
 
-## Project Navigation
+## Task Management (tasks.json)
 
-**Read these files at the start of each session:**
+### Task Recognition Rules
 
-1. **STRUCTURE.json** — module map (auth, db, api, ui)
-2. **PROJECT_NOTES.md** — architectural decisions and "why" notes
-3. **tasks.json** — pending and in-flight tasks
+**These ARE TASKS - add to tasks.json:**
+- When the user requests a feature or change
+- Decisions like "Let's do this", "Let's add this", "Improve this"
+- Deferred work when we say "We'll do this later", "Let's leave it for now"
+- Gaps or improvement opportunities discovered while coding
+- Situations requiring bug fixes
 
-**Specs:**
-- `.frame/specs/add-google-oauth/` — shipped (look at `outcome.md`)
-- `.frame/specs/migrate-to-postgres/` — in progress (4 of 8 tasks done)
+**These are NOT TASKS:**
+- Error messages and debugging sessions
+- Questions, explanations, information exchange
+- Temporary experiments and tests
+- Work already completed and closed
+- Instant fixes (like typo fixes)
+
+### Task Creation Flow
+
+1. Detect task patterns during conversation
+2. Ask the user at an appropriate moment: "I identified these tasks from our conversation, should I add them to tasks.json?"
+3. If the user approves, add to tasks.json
+
+### Task Structure
+
+```json
+{
+  "id": "unique-id",
+  "title": "Short and clear title",
+  "description": "Detailed explanation",
+  "status": "pending | in_progress | completed",
+  "priority": "high | medium | low",
+  "context": "Where/how this task originated",
+  "createdAt": "ISO date",
+  "updatedAt": "ISO date",
+  "completedAt": "ISO date | null"
+}
+```
+
+### Task Status Updates
+
+- When starting work on a task: `status: "in_progress"`
+- When task is completed: `status: "completed"`, update `completedAt`
+- After commit: Check and update the status of related tasks
+
+---
+
+## Spec-Driven Development (.frame/specs/)
+
+Frame supports a structured `spec → plan → tasks → implement` workflow. When the user asks you to define, plan, or implement a feature, prefer this workflow over ad-hoc edits — it preserves intent and keeps `tasks.json` in sync.
+
+### File layout
+
+Each spec lives in its own folder:
+
+```
+.frame/specs/<slug>/
+  spec.md       — what we're building (Problem, Goal, Constraints, Success Criteria, Out of Scope)
+  plan.md       — how (Architecture, Files, Dependencies, Sequencing)
+  tasks.md      — flat bullet list, "- T01 · description"
+  status.json   — phase + metadata
+```
+
+`<slug>` is kebab-case, derived from the spec title.
+
+### Lifecycle phases
+
+`draft` → `specified` → `planned` → `tasks_generated` → `implementing` → `done`
+
+Frame auto-advances phase from filesystem state (file presence). After writing each artifact, update `status.json` so `phase`, `updated_at`, and `last_phase_at` reflect reality — Frame's watcher will reconcile if you forget.
+
+### Slash commands
+
+When the user types a Frame slash command, write **exactly one file** and then update `status.json`:
+
+- `/spec.new <description>` → write `spec.md` (sections: Problem, Goal, Constraints, Success Criteria, Out of Scope). Phase → `specified`.
+- `/spec.plan` → read `spec.md`, write `plan.md` (sections: Architecture, Files, Dependencies, Sequencing). Phase → `planned`.
+- `/spec.tasks` → read `spec.md` + `plan.md`, write `tasks.md` as a flat `- T01 · ...` bullet list (5–12 tasks, imperative voice). Phase → `tasks_generated`.
+
+After `/spec.tasks`, **do not** also write entries to `tasks.json` — Frame's watcher imports them automatically with `source: "spec:<slug>:T<n>"` markers.
+
+### tasks.json linkage
+
+Spec-generated tasks carry a `source` field. Treat them like any other task — start them, complete them, update status. User-set status is preserved across spec re-imports; only title/description sync from `tasks.md`.
+
+### When to suggest a spec
+
+If the user describes work bigger than a one-shot edit (a new feature, a multi-file refactor, a cross-cutting fix), suggest a spec first: *"This sounds like a spec — want me to draft `.frame/specs/<slug>/spec.md`?"*
+
+For one-line typo fixes, build errors, or clarifying questions, skip the spec — go direct.
+
+---
+
+## PROJECT_NOTES.md Rules
+
+### When to Update?
+- When an important architectural decision is made
+- When a technology choice is made
+- When an important problem is solved and the solution method is noteworthy
+- When an approach is determined together with the user
+
+### Format
+Free format. Date + title is sufficient:
+```markdown
+### [2026-01-26] Topic title
+Conversation/decision as is, with its context...
+```
+
+### Update Flow
+- Update immediately after a decision is made
+- You can add without asking the user (for important decisions)
+- You can accumulate small decisions and add them in bulk
+
+---
+
+## 📝 Context Preservation (Automatic Note Taking)
+
+Frame's core purpose is to prevent context loss. Therefore, capture important moments and ask the user.
+
+### When to Ask?
+
+Ask the user when one of the following situations occurs: **"Should I add this conversation to PROJECT_NOTES.md?"**
+
+- When a task is successfully completed
+- When an important architectural/technical decision is made
+- When a bug is fixed and the solution method is noteworthy
+- When "let's do this later" is said (in this case, also add to tasks.json)
+- When a new pattern or best practice is discovered
+
+### Completion Detection
+
+Pay attention to these signals:
+- User approval: "okay", "done", "it worked", "nice", "fixed", "yes"
+- Moving from one topic to another
+- User continuing after build/run succeeds
+
+### How to Add?
+
+1. **DON'T write a summary** - Add the conversation as is, with its context
+2. **Add date** - In `### [YYYY-MM-DD] Title` format
+3. **Add to Session Notes section** - At the end of PROJECT_NOTES.md
+
+### When NOT to Ask
+
+- For every small change (it becomes spam)
+- Typo fixes, simple corrections
+- If the user already said "no" or "not needed", don't ask again for the same topic in that session
+
+### If User Says "No"
+
+No problem, continue. The user can also say what they consider important themselves: "add this to notes"
+
+---
+
+## STRUCTURE.json Rules
+
+**This file is the map of the codebase.**
+
+### When to Update?
+- When a new file/folder is created
+- When a file/folder is deleted or moved
+- When module dependencies change
+- When an important architectural pattern is discovered (architectureNotes)
+
+### Format
+```json
+{
+  "modules": {
+    "moduleName": {
+      "path": "src/module",
+      "purpose": "What this module does",
+      "depends": ["otherModule"]
+    }
+  },
+  "architectureNotes": {}
+}
+```
+
+---
+
+## General Rules
+
+1. **Language:** Write documentation in English (except code examples)
+2. **Date Format:** ISO 8601 (YYYY-MM-DDTHH:mm:ssZ)
+3. **After Commit:** Check tasks.json and STRUCTURE.json
+4. **Session Start:** Review pending tasks in tasks.json
+
+---
+
+## TaskFlow — Project Specifics
+
+Beyond the standard Frame rules above, here's what's specific to this codebase:
+
+**Stack:**
+- Backend: Node.js 20, Express 4
+- Database: PostgreSQL 16 (migrated from SQLite — see `.frame/specs/migrate-to-postgres/`)
+- Auth: Google OAuth via Passport.js
+- Frontend: React 18 + Vite
+
+**Conventions:**
+- Database access lives in `src/db/`; API handlers never touch SQL directly
+- React components stay under 150 lines; split into sub-folders when they grow
+- Commit messages: imperative mood, one-line summary + optional body
+
+**Specs in flight:**
+- `.frame/specs/add-google-oauth/` — shipped (read `outcome.md`)
+- `.frame/specs/migrate-to-postgres/` — implementing (4 of 8 tasks done)
 - `.frame/specs/email-notifications/` — planned, awaiting `/spec.tasks`
 
 ---
 
-## Stack at a glance
-
-- **Backend:** Node.js 20, Express 4, PostgreSQL 16 (migrated from SQLite)
-- **Frontend:** React 18 + Vite
-- **Auth:** Google OAuth (Passport.js) — see `src/auth/`
-- **Database:** `src/db/client.js` is the canonical pool; migrations in
-  `src/db/migrations/` (numbered, forward-only)
-
-## Coding Conventions
-
-- All new modules ship with a 5-line header doc explaining purpose +
-  exports. See existing files for the pattern.
-- Database access lives in `src/db/`; API handlers never touch SQL
-  directly. They go through query helpers.
-- React components stay under 150 lines. If a component grows past
-  that, split it into a sub-folder with its own components/.
-- Commit messages: imperative mood, one-line summary + optional body.
-
-## Task Management
-
-When the user describes work, draft it in `tasks.json` (status `pending`)
-and confirm before adding. When a task is connected to a spec, the
-`source` field uses `spec:<slug>:T<n>` form so the Specs panel can show
-progress.
-
----
-
-*Sample content. Frame uses this to demonstrate its workflow — your own
-projects start with a much shorter AGENTS.md template that you fill in.*
+**Note:** This file is named `AGENTS.md` to be AI-tool agnostic. A `CLAUDE.md` symlink is provided for Claude Code compatibility, and a `GEMINI.md` for Gemini CLI.

--- a/src/templates/sample-project/AGENTS.md
+++ b/src/templates/sample-project/AGENTS.md
@@ -1,0 +1,57 @@
+# TaskFlow — Project Instructions
+
+This is a **sample project** that ships with Frame to demonstrate the
+spec-driven development workflow on a realistic codebase. You're looking
+at a fictional SaaS called TaskFlow: a small team task manager built on
+Node.js + Express + PostgreSQL + React.
+
+> Open your own project when you're ready to start real work. Everything
+> here is read-friendly — feel free to poke around, edit, break things.
+> Nothing here ships anywhere.
+
+---
+
+## Project Navigation
+
+**Read these files at the start of each session:**
+
+1. **STRUCTURE.json** — module map (auth, db, api, ui)
+2. **PROJECT_NOTES.md** — architectural decisions and "why" notes
+3. **tasks.json** — pending and in-flight tasks
+
+**Specs:**
+- `.frame/specs/add-google-oauth/` — shipped (look at `outcome.md`)
+- `.frame/specs/migrate-to-postgres/` — in progress (4 of 8 tasks done)
+- `.frame/specs/email-notifications/` — planned, awaiting `/spec.tasks`
+
+---
+
+## Stack at a glance
+
+- **Backend:** Node.js 20, Express 4, PostgreSQL 16 (migrated from SQLite)
+- **Frontend:** React 18 + Vite
+- **Auth:** Google OAuth (Passport.js) — see `src/auth/`
+- **Database:** `src/db/client.js` is the canonical pool; migrations in
+  `src/db/migrations/` (numbered, forward-only)
+
+## Coding Conventions
+
+- All new modules ship with a 5-line header doc explaining purpose +
+  exports. See existing files for the pattern.
+- Database access lives in `src/db/`; API handlers never touch SQL
+  directly. They go through query helpers.
+- React components stay under 150 lines. If a component grows past
+  that, split it into a sub-folder with its own components/.
+- Commit messages: imperative mood, one-line summary + optional body.
+
+## Task Management
+
+When the user describes work, draft it in `tasks.json` (status `pending`)
+and confirm before adding. When a task is connected to a spec, the
+`source` field uses `spec:<slug>:T<n>` form so the Specs panel can show
+progress.
+
+---
+
+*Sample content. Frame uses this to demonstrate its workflow — your own
+projects start with a much shorter AGENTS.md template that you fill in.*

--- a/src/templates/sample-project/CLAUDE.md
+++ b/src/templates/sample-project/CLAUDE.md
@@ -1,7 +1,221 @@
-# TaskFlow — Project Instructions
+# TaskFlow - Frame Project
 
-> In a real Frame project, this file is a symlink to `AGENTS.md`. In the
-> sample we ship them as separate files since symlinks don't always
-> survive the copy. Treat the two as identical.
+This project is managed with **Frame**. AI assistants should follow the rules below to keep documentation up to date.
 
-See [`AGENTS.md`](./AGENTS.md) for the full project instructions.
+> **Note:** This is the **sample project** that ships with Frame. It's a fictional codebase used to demonstrate Frame's workflow on realistic content. None of this code runs. When you're ready, open your own project to start real work.
+
+---
+
+## Task Management (tasks.json)
+
+### Task Recognition Rules
+
+**These ARE TASKS - add to tasks.json:**
+- When the user requests a feature or change
+- Decisions like "Let's do this", "Let's add this", "Improve this"
+- Deferred work when we say "We'll do this later", "Let's leave it for now"
+- Gaps or improvement opportunities discovered while coding
+- Situations requiring bug fixes
+
+**These are NOT TASKS:**
+- Error messages and debugging sessions
+- Questions, explanations, information exchange
+- Temporary experiments and tests
+- Work already completed and closed
+- Instant fixes (like typo fixes)
+
+### Task Creation Flow
+
+1. Detect task patterns during conversation
+2. Ask the user at an appropriate moment: "I identified these tasks from our conversation, should I add them to tasks.json?"
+3. If the user approves, add to tasks.json
+
+### Task Structure
+
+```json
+{
+  "id": "unique-id",
+  "title": "Short and clear title",
+  "description": "Detailed explanation",
+  "status": "pending | in_progress | completed",
+  "priority": "high | medium | low",
+  "context": "Where/how this task originated",
+  "createdAt": "ISO date",
+  "updatedAt": "ISO date",
+  "completedAt": "ISO date | null"
+}
+```
+
+### Task Status Updates
+
+- When starting work on a task: `status: "in_progress"`
+- When task is completed: `status: "completed"`, update `completedAt`
+- After commit: Check and update the status of related tasks
+
+---
+
+## Spec-Driven Development (.frame/specs/)
+
+Frame supports a structured `spec → plan → tasks → implement` workflow. When the user asks you to define, plan, or implement a feature, prefer this workflow over ad-hoc edits — it preserves intent and keeps `tasks.json` in sync.
+
+### File layout
+
+Each spec lives in its own folder:
+
+```
+.frame/specs/<slug>/
+  spec.md       — what we're building (Problem, Goal, Constraints, Success Criteria, Out of Scope)
+  plan.md       — how (Architecture, Files, Dependencies, Sequencing)
+  tasks.md      — flat bullet list, "- T01 · description"
+  status.json   — phase + metadata
+```
+
+`<slug>` is kebab-case, derived from the spec title.
+
+### Lifecycle phases
+
+`draft` → `specified` → `planned` → `tasks_generated` → `implementing` → `done`
+
+Frame auto-advances phase from filesystem state (file presence). After writing each artifact, update `status.json` so `phase`, `updated_at`, and `last_phase_at` reflect reality — Frame's watcher will reconcile if you forget.
+
+### Slash commands
+
+When the user types a Frame slash command, write **exactly one file** and then update `status.json`:
+
+- `/spec.new <description>` → write `spec.md` (sections: Problem, Goal, Constraints, Success Criteria, Out of Scope). Phase → `specified`.
+- `/spec.plan` → read `spec.md`, write `plan.md` (sections: Architecture, Files, Dependencies, Sequencing). Phase → `planned`.
+- `/spec.tasks` → read `spec.md` + `plan.md`, write `tasks.md` as a flat `- T01 · ...` bullet list (5–12 tasks, imperative voice). Phase → `tasks_generated`.
+
+After `/spec.tasks`, **do not** also write entries to `tasks.json` — Frame's watcher imports them automatically with `source: "spec:<slug>:T<n>"` markers.
+
+### tasks.json linkage
+
+Spec-generated tasks carry a `source` field. Treat them like any other task — start them, complete them, update status. User-set status is preserved across spec re-imports; only title/description sync from `tasks.md`.
+
+### When to suggest a spec
+
+If the user describes work bigger than a one-shot edit (a new feature, a multi-file refactor, a cross-cutting fix), suggest a spec first: *"This sounds like a spec — want me to draft `.frame/specs/<slug>/spec.md`?"*
+
+For one-line typo fixes, build errors, or clarifying questions, skip the spec — go direct.
+
+---
+
+## PROJECT_NOTES.md Rules
+
+### When to Update?
+- When an important architectural decision is made
+- When a technology choice is made
+- When an important problem is solved and the solution method is noteworthy
+- When an approach is determined together with the user
+
+### Format
+Free format. Date + title is sufficient:
+```markdown
+### [2026-01-26] Topic title
+Conversation/decision as is, with its context...
+```
+
+### Update Flow
+- Update immediately after a decision is made
+- You can add without asking the user (for important decisions)
+- You can accumulate small decisions and add them in bulk
+
+---
+
+## 📝 Context Preservation (Automatic Note Taking)
+
+Frame's core purpose is to prevent context loss. Therefore, capture important moments and ask the user.
+
+### When to Ask?
+
+Ask the user when one of the following situations occurs: **"Should I add this conversation to PROJECT_NOTES.md?"**
+
+- When a task is successfully completed
+- When an important architectural/technical decision is made
+- When a bug is fixed and the solution method is noteworthy
+- When "let's do this later" is said (in this case, also add to tasks.json)
+- When a new pattern or best practice is discovered
+
+### Completion Detection
+
+Pay attention to these signals:
+- User approval: "okay", "done", "it worked", "nice", "fixed", "yes"
+- Moving from one topic to another
+- User continuing after build/run succeeds
+
+### How to Add?
+
+1. **DON'T write a summary** - Add the conversation as is, with its context
+2. **Add date** - In `### [YYYY-MM-DD] Title` format
+3. **Add to Session Notes section** - At the end of PROJECT_NOTES.md
+
+### When NOT to Ask
+
+- For every small change (it becomes spam)
+- Typo fixes, simple corrections
+- If the user already said "no" or "not needed", don't ask again for the same topic in that session
+
+### If User Says "No"
+
+No problem, continue. The user can also say what they consider important themselves: "add this to notes"
+
+---
+
+## STRUCTURE.json Rules
+
+**This file is the map of the codebase.**
+
+### When to Update?
+- When a new file/folder is created
+- When a file/folder is deleted or moved
+- When module dependencies change
+- When an important architectural pattern is discovered (architectureNotes)
+
+### Format
+```json
+{
+  "modules": {
+    "moduleName": {
+      "path": "src/module",
+      "purpose": "What this module does",
+      "depends": ["otherModule"]
+    }
+  },
+  "architectureNotes": {}
+}
+```
+
+---
+
+## General Rules
+
+1. **Language:** Write documentation in English (except code examples)
+2. **Date Format:** ISO 8601 (YYYY-MM-DDTHH:mm:ssZ)
+3. **After Commit:** Check tasks.json and STRUCTURE.json
+4. **Session Start:** Review pending tasks in tasks.json
+
+---
+
+## TaskFlow — Project Specifics
+
+Beyond the standard Frame rules above, here's what's specific to this codebase:
+
+**Stack:**
+- Backend: Node.js 20, Express 4
+- Database: PostgreSQL 16 (migrated from SQLite — see `.frame/specs/migrate-to-postgres/`)
+- Auth: Google OAuth via Passport.js
+- Frontend: React 18 + Vite
+
+**Conventions:**
+- Database access lives in `src/db/`; API handlers never touch SQL directly
+- React components stay under 150 lines; split into sub-folders when they grow
+- Commit messages: imperative mood, one-line summary + optional body
+
+**Specs in flight:**
+- `.frame/specs/add-google-oauth/` — shipped (read `outcome.md`)
+- `.frame/specs/migrate-to-postgres/` — implementing (4 of 8 tasks done)
+- `.frame/specs/email-notifications/` — planned, awaiting `/spec.tasks`
+
+---
+
+**Note:** This file is named `AGENTS.md` to be AI-tool agnostic. A `CLAUDE.md` symlink is provided for Claude Code compatibility, and a `GEMINI.md` for Gemini CLI.

--- a/src/templates/sample-project/CLAUDE.md
+++ b/src/templates/sample-project/CLAUDE.md
@@ -1,0 +1,7 @@
+# TaskFlow — Project Instructions
+
+> In a real Frame project, this file is a symlink to `AGENTS.md`. In the
+> sample we ship them as separate files since symlinks don't always
+> survive the copy. Treat the two as identical.
+
+See [`AGENTS.md`](./AGENTS.md) for the full project instructions.

--- a/src/templates/sample-project/GEMINI.md
+++ b/src/templates/sample-project/GEMINI.md
@@ -1,0 +1,7 @@
+# TaskFlow — Project Instructions
+
+> In a real Frame project, this file is a symlink to `AGENTS.md`. In the
+> sample we ship them as separate files since symlinks don't always
+> survive the copy.
+
+See [`AGENTS.md`](./AGENTS.md) for the full project instructions.

--- a/src/templates/sample-project/GEMINI.md
+++ b/src/templates/sample-project/GEMINI.md
@@ -1,7 +1,221 @@
-# TaskFlow — Project Instructions
+# TaskFlow - Frame Project
 
-> In a real Frame project, this file is a symlink to `AGENTS.md`. In the
-> sample we ship them as separate files since symlinks don't always
-> survive the copy.
+This project is managed with **Frame**. AI assistants should follow the rules below to keep documentation up to date.
 
-See [`AGENTS.md`](./AGENTS.md) for the full project instructions.
+> **Note:** This is the **sample project** that ships with Frame. It's a fictional codebase used to demonstrate Frame's workflow on realistic content. None of this code runs. When you're ready, open your own project to start real work.
+
+---
+
+## Task Management (tasks.json)
+
+### Task Recognition Rules
+
+**These ARE TASKS - add to tasks.json:**
+- When the user requests a feature or change
+- Decisions like "Let's do this", "Let's add this", "Improve this"
+- Deferred work when we say "We'll do this later", "Let's leave it for now"
+- Gaps or improvement opportunities discovered while coding
+- Situations requiring bug fixes
+
+**These are NOT TASKS:**
+- Error messages and debugging sessions
+- Questions, explanations, information exchange
+- Temporary experiments and tests
+- Work already completed and closed
+- Instant fixes (like typo fixes)
+
+### Task Creation Flow
+
+1. Detect task patterns during conversation
+2. Ask the user at an appropriate moment: "I identified these tasks from our conversation, should I add them to tasks.json?"
+3. If the user approves, add to tasks.json
+
+### Task Structure
+
+```json
+{
+  "id": "unique-id",
+  "title": "Short and clear title",
+  "description": "Detailed explanation",
+  "status": "pending | in_progress | completed",
+  "priority": "high | medium | low",
+  "context": "Where/how this task originated",
+  "createdAt": "ISO date",
+  "updatedAt": "ISO date",
+  "completedAt": "ISO date | null"
+}
+```
+
+### Task Status Updates
+
+- When starting work on a task: `status: "in_progress"`
+- When task is completed: `status: "completed"`, update `completedAt`
+- After commit: Check and update the status of related tasks
+
+---
+
+## Spec-Driven Development (.frame/specs/)
+
+Frame supports a structured `spec → plan → tasks → implement` workflow. When the user asks you to define, plan, or implement a feature, prefer this workflow over ad-hoc edits — it preserves intent and keeps `tasks.json` in sync.
+
+### File layout
+
+Each spec lives in its own folder:
+
+```
+.frame/specs/<slug>/
+  spec.md       — what we're building (Problem, Goal, Constraints, Success Criteria, Out of Scope)
+  plan.md       — how (Architecture, Files, Dependencies, Sequencing)
+  tasks.md      — flat bullet list, "- T01 · description"
+  status.json   — phase + metadata
+```
+
+`<slug>` is kebab-case, derived from the spec title.
+
+### Lifecycle phases
+
+`draft` → `specified` → `planned` → `tasks_generated` → `implementing` → `done`
+
+Frame auto-advances phase from filesystem state (file presence). After writing each artifact, update `status.json` so `phase`, `updated_at`, and `last_phase_at` reflect reality — Frame's watcher will reconcile if you forget.
+
+### Slash commands
+
+When the user types a Frame slash command, write **exactly one file** and then update `status.json`:
+
+- `/spec.new <description>` → write `spec.md` (sections: Problem, Goal, Constraints, Success Criteria, Out of Scope). Phase → `specified`.
+- `/spec.plan` → read `spec.md`, write `plan.md` (sections: Architecture, Files, Dependencies, Sequencing). Phase → `planned`.
+- `/spec.tasks` → read `spec.md` + `plan.md`, write `tasks.md` as a flat `- T01 · ...` bullet list (5–12 tasks, imperative voice). Phase → `tasks_generated`.
+
+After `/spec.tasks`, **do not** also write entries to `tasks.json` — Frame's watcher imports them automatically with `source: "spec:<slug>:T<n>"` markers.
+
+### tasks.json linkage
+
+Spec-generated tasks carry a `source` field. Treat them like any other task — start them, complete them, update status. User-set status is preserved across spec re-imports; only title/description sync from `tasks.md`.
+
+### When to suggest a spec
+
+If the user describes work bigger than a one-shot edit (a new feature, a multi-file refactor, a cross-cutting fix), suggest a spec first: *"This sounds like a spec — want me to draft `.frame/specs/<slug>/spec.md`?"*
+
+For one-line typo fixes, build errors, or clarifying questions, skip the spec — go direct.
+
+---
+
+## PROJECT_NOTES.md Rules
+
+### When to Update?
+- When an important architectural decision is made
+- When a technology choice is made
+- When an important problem is solved and the solution method is noteworthy
+- When an approach is determined together with the user
+
+### Format
+Free format. Date + title is sufficient:
+```markdown
+### [2026-01-26] Topic title
+Conversation/decision as is, with its context...
+```
+
+### Update Flow
+- Update immediately after a decision is made
+- You can add without asking the user (for important decisions)
+- You can accumulate small decisions and add them in bulk
+
+---
+
+## 📝 Context Preservation (Automatic Note Taking)
+
+Frame's core purpose is to prevent context loss. Therefore, capture important moments and ask the user.
+
+### When to Ask?
+
+Ask the user when one of the following situations occurs: **"Should I add this conversation to PROJECT_NOTES.md?"**
+
+- When a task is successfully completed
+- When an important architectural/technical decision is made
+- When a bug is fixed and the solution method is noteworthy
+- When "let's do this later" is said (in this case, also add to tasks.json)
+- When a new pattern or best practice is discovered
+
+### Completion Detection
+
+Pay attention to these signals:
+- User approval: "okay", "done", "it worked", "nice", "fixed", "yes"
+- Moving from one topic to another
+- User continuing after build/run succeeds
+
+### How to Add?
+
+1. **DON'T write a summary** - Add the conversation as is, with its context
+2. **Add date** - In `### [YYYY-MM-DD] Title` format
+3. **Add to Session Notes section** - At the end of PROJECT_NOTES.md
+
+### When NOT to Ask
+
+- For every small change (it becomes spam)
+- Typo fixes, simple corrections
+- If the user already said "no" or "not needed", don't ask again for the same topic in that session
+
+### If User Says "No"
+
+No problem, continue. The user can also say what they consider important themselves: "add this to notes"
+
+---
+
+## STRUCTURE.json Rules
+
+**This file is the map of the codebase.**
+
+### When to Update?
+- When a new file/folder is created
+- When a file/folder is deleted or moved
+- When module dependencies change
+- When an important architectural pattern is discovered (architectureNotes)
+
+### Format
+```json
+{
+  "modules": {
+    "moduleName": {
+      "path": "src/module",
+      "purpose": "What this module does",
+      "depends": ["otherModule"]
+    }
+  },
+  "architectureNotes": {}
+}
+```
+
+---
+
+## General Rules
+
+1. **Language:** Write documentation in English (except code examples)
+2. **Date Format:** ISO 8601 (YYYY-MM-DDTHH:mm:ssZ)
+3. **After Commit:** Check tasks.json and STRUCTURE.json
+4. **Session Start:** Review pending tasks in tasks.json
+
+---
+
+## TaskFlow — Project Specifics
+
+Beyond the standard Frame rules above, here's what's specific to this codebase:
+
+**Stack:**
+- Backend: Node.js 20, Express 4
+- Database: PostgreSQL 16 (migrated from SQLite — see `.frame/specs/migrate-to-postgres/`)
+- Auth: Google OAuth via Passport.js
+- Frontend: React 18 + Vite
+
+**Conventions:**
+- Database access lives in `src/db/`; API handlers never touch SQL directly
+- React components stay under 150 lines; split into sub-folders when they grow
+- Commit messages: imperative mood, one-line summary + optional body
+
+**Specs in flight:**
+- `.frame/specs/add-google-oauth/` — shipped (read `outcome.md`)
+- `.frame/specs/migrate-to-postgres/` — implementing (4 of 8 tasks done)
+- `.frame/specs/email-notifications/` — planned, awaiting `/spec.tasks`
+
+---
+
+**Note:** This file is named `AGENTS.md` to be AI-tool agnostic. A `CLAUDE.md` symlink is provided for Claude Code compatibility, and a `GEMINI.md` for Gemini CLI.

--- a/src/templates/sample-project/PROJECT_NOTES.md
+++ b/src/templates/sample-project/PROJECT_NOTES.md
@@ -1,0 +1,78 @@
+# Project Notes — TaskFlow
+
+Architectural decisions, context, and "we tried that, didn't work" notes
+that should survive across AI sessions. Add new entries at the top.
+
+---
+
+### [2026-03-22] Defer email notifications to v2
+
+Discussed adding email notifications for task assignment. Decision: punt
+to v2. Reasoning:
+
+- Adds a third dependency (email provider — SendGrid/Postmark/SES)
+- Real-time presence on the dashboard probably covers 80% of the need
+- Notifications without preferences = noise; preferences = scope explosion
+
+Captured as `.frame/specs/email-notifications/` for when we're ready.
+The spec exists in `planned` phase — we have a plan, no tasks yet.
+
+---
+
+### [2026-03-08] PostgreSQL over MongoDB
+
+We considered MongoDB for the document-shaped task records. Picked
+PostgreSQL instead because:
+
+1. Our access pattern is heavily relational (users → teams → tasks)
+2. We already needed transactions for the team-assignment flow
+3. JSONB on Postgres covers the "flexible payload" need without giving
+   up the relational primitives
+
+The migration from SQLite → Postgres is in flight; see the spec at
+`.frame/specs/migrate-to-postgres/`.
+
+---
+
+### [2026-02-19] Single OAuth provider for v1
+
+Resisted the urge to support every OAuth provider upfront. Shipped only
+Google OAuth in v1. Rationale:
+
+- 92% of our target users have Google Workspace accounts
+- Adding GitHub/GitLab/Microsoft each adds setup friction
+- Easier to add later than to refactor a multi-provider abstraction
+  built before we had real users
+
+Decision encoded in the architecture: `src/auth/oauth.js` is intentionally
+not provider-abstracted. When we add a second provider, we'll refactor —
+not before.
+
+---
+
+### [2026-02-04] Stick with Express, not Fastify
+
+Fastify is faster on paper. We don't have a performance problem. Stayed
+on Express because:
+
+- Larger ecosystem (Passport.js auth integration matters)
+- The team knows it cold
+- 10ms of latency vs developer velocity is not a real trade for us yet
+
+Revisit if we hit > 1000 req/s sustained on any single endpoint.
+
+---
+
+### [2026-01-15] No microservices
+
+Considered splitting auth, tasks, and notifications into separate
+services. Decision: monolith for the foreseeable future. Reasoning:
+
+- We're a 3-person team. Microservices is a tool for large orgs
+  managing inter-team coordination, not 3 people in a Slack channel.
+- The operational surface (3 deployments instead of 1) is not free.
+- Splitting is reversible. Premature splitting wastes weeks.
+
+If we ever hit a real reason (a service that needs different scaling,
+different language, different deploy cadence), we'll split *that* one
+specifically.

--- a/src/templates/sample-project/README.md
+++ b/src/templates/sample-project/README.md
@@ -1,0 +1,30 @@
+# TaskFlow
+
+A small team task manager — Node.js + Express + PostgreSQL + React.
+
+> This is a **sample project** that ships with Frame. It's a fictional
+> codebase used to demonstrate Frame's spec-driven workflow, task panel,
+> structure map, and project notes on a realistic scale. None of this
+> code runs.
+
+## Stack
+
+- **Backend:** Node.js 20, Express 4
+- **Database:** PostgreSQL 16 (migrated from SQLite — see
+  `.frame/specs/migrate-to-postgres/`)
+- **Auth:** Google OAuth via Passport
+- **Frontend:** React 18 + Vite
+
+## Explore Frame on this project
+
+Try these to see how Frame organizes the work:
+
+- **Tasks panel** — 20 tasks in different states; spec-derived tasks
+  show their source.
+- **Specs panel** — 3 specs in different phases: `done`, `implementing`,
+  `planned`. Click around to see the lifecycle.
+- **Overview / Structure** — module map of `src/`.
+- **Project Notes** — architectural decisions captured at the moment
+  they were made.
+
+When you're ready, **open your own project** and start with a real one.

--- a/src/templates/sample-project/STRUCTURE.json
+++ b/src/templates/sample-project/STRUCTURE.json
@@ -1,0 +1,93 @@
+{
+  "_comment": "Module map for TaskFlow. Frame's pre-commit hook regenerates this from source files in your own projects.",
+  "project": "TaskFlow",
+  "version": "1.0",
+  "lastUpdated": "2026-04-12T00:00:00Z",
+  "modules": {
+    "src/index": {
+      "path": "src/index.js",
+      "purpose": "Application entry — wires Express, DB, and auth",
+      "exports": ["start"],
+      "depends": ["src/api/server", "src/db/client", "src/auth/oauth"]
+    },
+    "src/auth/oauth": {
+      "path": "src/auth/oauth.js",
+      "purpose": "Google OAuth integration via Passport.js",
+      "exports": ["configureOAuth", "googleStrategy"],
+      "depends": ["passport", "passport-google-oauth20", "src/db/client"]
+    },
+    "src/auth/session": {
+      "path": "src/auth/session.js",
+      "purpose": "Session middleware + serialize/deserialize hooks",
+      "exports": ["sessionMiddleware", "requireAuth"],
+      "depends": ["express-session", "src/db/client"]
+    },
+    "src/db/client": {
+      "path": "src/db/client.js",
+      "purpose": "Postgres connection pool — canonical DB access point",
+      "exports": ["pool", "query", "tx"],
+      "depends": ["pg"]
+    },
+    "src/db/migrations": {
+      "path": "src/db/migrations/",
+      "purpose": "Forward-only SQL migrations, numbered",
+      "exports": [],
+      "depends": []
+    },
+    "src/api/server": {
+      "path": "src/api/server.js",
+      "purpose": "Express app setup, route mounting, error handlers",
+      "exports": ["createApp"],
+      "depends": ["express", "src/api/tasks", "src/api/users", "src/auth/session"]
+    },
+    "src/api/tasks": {
+      "path": "src/api/tasks.js",
+      "purpose": "Task CRUD endpoints: list, create, update, complete",
+      "exports": ["router"],
+      "depends": ["src/db/client", "src/auth/session"]
+    },
+    "src/api/users": {
+      "path": "src/api/users.js",
+      "purpose": "User profile + team membership endpoints",
+      "exports": ["router"],
+      "depends": ["src/db/client", "src/auth/session"]
+    },
+    "src/ui/App": {
+      "path": "src/ui/App.jsx",
+      "purpose": "React root — sets up routing and auth context",
+      "exports": ["App"],
+      "depends": ["react-router-dom", "src/ui/components/TaskList"]
+    },
+    "src/ui/components/TaskList": {
+      "path": "src/ui/components/TaskList.jsx",
+      "purpose": "Renders the user's tasks with status filters",
+      "exports": ["TaskList"],
+      "depends": ["react"]
+    }
+  },
+  "intentIndex": {
+    "auth": ["src/auth/oauth.js", "src/auth/session.js"],
+    "oauth": ["src/auth/oauth.js"],
+    "google": ["src/auth/oauth.js"],
+    "session": ["src/auth/session.js"],
+    "database": ["src/db/client.js", "src/db/migrations/"],
+    "postgres": ["src/db/client.js"],
+    "migration": ["src/db/migrations/"],
+    "api": ["src/api/server.js", "src/api/tasks.js", "src/api/users.js"],
+    "routes": ["src/api/server.js"],
+    "tasks": ["src/api/tasks.js", "src/ui/components/TaskList.jsx"],
+    "users": ["src/api/users.js"],
+    "ui": ["src/ui/App.jsx", "src/ui/components/TaskList.jsx"],
+    "react": ["src/ui/App.jsx", "src/ui/components/TaskList.jsx"]
+  },
+  "architectureNotes": {
+    "dbAccess": {
+      "rule": "API handlers never write raw SQL — go through src/db/client query helpers",
+      "rationale": "Single place to add logging, metrics, retries"
+    },
+    "authProvider": {
+      "rule": "OAuth code is intentionally not provider-abstracted in v1",
+      "rationale": "Premature abstraction — see PROJECT_NOTES.md 2026-02-19"
+    }
+  }
+}

--- a/src/templates/sample-project/package.json
+++ b/src/templates/sample-project/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "taskflow",
+  "version": "1.0.0",
+  "description": "Small-team task manager (sample project)",
+  "private": true,
+  "scripts": {
+    "dev": "node src/index.js",
+    "test": "vitest",
+    "migrate": "node scripts/migrate.js"
+  },
+  "dependencies": {
+    "express": "^4.21.0",
+    "express-session": "^1.18.0",
+    "passport": "^0.7.0",
+    "passport-google-oauth20": "^2.0.0",
+    "pg": "^8.13.0",
+    "react": "^18.3.0",
+    "react-dom": "^18.3.0",
+    "react-router-dom": "^6.27.0"
+  },
+  "devDependencies": {
+    "vite": "^5.4.0",
+    "vitest": "^2.1.0",
+    "nock": "^13.5.0"
+  }
+}

--- a/src/templates/sample-project/src/api/server.js
+++ b/src/templates/sample-project/src/api/server.js
@@ -1,0 +1,32 @@
+/**
+ * Express server — app factory
+ *
+ * Builds the Express instance, mounts middleware, mounts route modules.
+ * createApp() returns an app you can either listen() on or hand to tests.
+ */
+
+const express = require('express');
+const { sessionMiddleware } = require('../auth/session');
+const tasksRouter = require('./tasks');
+const usersRouter = require('./users');
+
+function createApp() {
+  const app = express();
+
+  app.use(express.json());
+  app.use(sessionMiddleware());
+
+  // configureOAuth() from src/auth/oauth.js mounts passport middleware + routes
+
+  app.use('/api/tasks', tasksRouter);
+  app.use('/api/users', usersRouter);
+
+  app.use((err, req, res, next) => {
+    console.error('Unhandled error:', err);
+    res.status(500).json({ error: 'internal_error' });
+  });
+
+  return app;
+}
+
+module.exports = { createApp };

--- a/src/templates/sample-project/src/api/tasks.js
+++ b/src/templates/sample-project/src/api/tasks.js
@@ -1,0 +1,68 @@
+/**
+ * Task CRUD endpoints
+ *
+ * GET    /api/tasks         List tasks for the current user's team(s)
+ * POST   /api/tasks         Create a task
+ * PATCH  /api/tasks/:id     Update status / assignee / title
+ * DELETE /api/tasks/:id     Delete a task (creator or team admin only)
+ */
+
+const express = require('express');
+const { query } = require('../db/client');
+const { requireAuth } = require('../auth/session');
+
+const router = express.Router();
+
+router.use(requireAuth);
+
+router.get('/', async (req, res) => {
+  const { rows } = await query(
+    `
+    SELECT t.*
+    FROM tasks t
+    JOIN team_members tm ON tm.team_id = t.team_id
+    WHERE tm.user_id = $1
+    ORDER BY t.updated_at DESC
+    `,
+    [req.user.id]
+  );
+  res.json(rows);
+});
+
+router.post('/', async (req, res) => {
+  const { team_id, title, description, assigned_to_user_id } = req.body;
+  const { rows } = await query(
+    `
+    INSERT INTO tasks (team_id, title, description, assigned_to_user_id)
+    VALUES ($1, $2, $3, $4)
+    RETURNING *
+    `,
+    [team_id, title, description, assigned_to_user_id || null]
+  );
+  res.status(201).json(rows[0]);
+});
+
+router.patch('/:id', async (req, res) => {
+  const { status, assigned_to_user_id, title } = req.body;
+  const { rows } = await query(
+    `
+    UPDATE tasks
+    SET status              = COALESCE($2, status),
+        assigned_to_user_id = COALESCE($3, assigned_to_user_id),
+        title               = COALESCE($4, title),
+        updated_at          = now()
+    WHERE id = $1
+    RETURNING *
+    `,
+    [req.params.id, status, assigned_to_user_id, title]
+  );
+  if (rows.length === 0) return res.status(404).json({ error: 'not_found' });
+  res.json(rows[0]);
+});
+
+router.delete('/:id', async (req, res) => {
+  await query('DELETE FROM tasks WHERE id = $1', [req.params.id]);
+  res.status(204).end();
+});
+
+module.exports = router;

--- a/src/templates/sample-project/src/api/users.js
+++ b/src/templates/sample-project/src/api/users.js
@@ -1,0 +1,42 @@
+/**
+ * User + team membership endpoints
+ *
+ * GET  /api/users/me                 Current user profile
+ * GET  /api/users/:id/teams          Teams the user belongs to
+ * POST /api/users/:id/teams/:teamId  Add user to a team (admin only)
+ */
+
+const express = require('express');
+const { query } = require('../db/client');
+const { requireAuth } = require('../auth/session');
+
+const router = express.Router();
+
+router.use(requireAuth);
+
+router.get('/me', (req, res) => {
+  res.json({
+    id: req.user.id,
+    email: req.user.email,
+    name: req.user.name
+  });
+});
+
+router.get('/:id/teams', async (req, res) => {
+  if (req.params.id !== req.user.id) {
+    return res.status(403).json({ error: 'forbidden' });
+  }
+  const { rows } = await query(
+    `
+    SELECT t.id, t.name, tm.role
+    FROM teams t
+    JOIN team_members tm ON tm.team_id = t.id
+    WHERE tm.user_id = $1
+    ORDER BY t.name
+    `,
+    [req.params.id]
+  );
+  res.json(rows);
+});
+
+module.exports = router;

--- a/src/templates/sample-project/src/auth/oauth.js
+++ b/src/templates/sample-project/src/auth/oauth.js
@@ -1,0 +1,81 @@
+/**
+ * Google OAuth — Passport strategy + routes
+ *
+ * Shipped via spec `.frame/specs/add-google-oauth/`. The find-or-create
+ * logic is a single SQL upsert (diverged from plan — see outcome.md T5).
+ *
+ * NOT provider-abstracted on purpose. When we add a second provider,
+ * refactor — not before. See PROJECT_NOTES 2026-02-19.
+ */
+
+const passport = require('passport');
+const { Strategy: GoogleStrategy } = require('passport-google-oauth20');
+const { query } = require('../db/client');
+
+function googleStrategy() {
+  return new GoogleStrategy(
+    {
+      clientID: process.env.GOOGLE_OAUTH_CLIENT_ID,
+      clientSecret: process.env.GOOGLE_OAUTH_CLIENT_SECRET,
+      callbackURL: '/auth/google/callback'
+    },
+    async (accessToken, refreshToken, profile, done) => {
+      try {
+        const user = await findOrCreateUser(profile);
+        done(null, user);
+      } catch (err) {
+        done(err);
+      }
+    }
+  );
+}
+
+async function findOrCreateUser(profile) {
+  const email = profile.emails && profile.emails[0] && profile.emails[0].value;
+  if (!email) throw new Error('Google profile missing email');
+
+  // Single upsert: either match by google_id, or attach google_id to an
+  // existing email-only account, or create a new row.
+  const { rows } = await query(
+    `
+    INSERT INTO users (email, name, google_id)
+    VALUES ($1, $2, $3)
+    ON CONFLICT (email) DO UPDATE
+      SET google_id = COALESCE(users.google_id, EXCLUDED.google_id)
+    RETURNING *
+    `,
+    [email, profile.displayName, profile.id]
+  );
+
+  return rows[0];
+}
+
+function configureOAuth(app) {
+  passport.use(googleStrategy());
+
+  passport.serializeUser((user, done) => done(null, user.id));
+  passport.deserializeUser(async (id, done) => {
+    try {
+      const { rows } = await query('SELECT * FROM users WHERE id = $1', [id]);
+      done(null, rows[0] || null);
+    } catch (err) {
+      done(err);
+    }
+  });
+
+  app.use(passport.initialize());
+  app.use(passport.session());
+
+  app.get(
+    '/auth/google/start',
+    passport.authenticate('google', { scope: ['openid', 'email', 'profile'] })
+  );
+
+  app.get(
+    '/auth/google/callback',
+    passport.authenticate('google', { failureRedirect: '/login?error=oauth' }),
+    (req, res) => res.redirect('/dashboard')
+  );
+}
+
+module.exports = { configureOAuth, googleStrategy };

--- a/src/templates/sample-project/src/auth/session.js
+++ b/src/templates/sample-project/src/auth/session.js
@@ -1,0 +1,31 @@
+/**
+ * Session middleware + requireAuth guard
+ *
+ * Passport needs the session to exist BEFORE it can hydrate the user.
+ * Mount this middleware on the Express app before configureOAuth().
+ */
+
+const session = require('express-session');
+
+function sessionMiddleware() {
+  return session({
+    secret: process.env.SESSION_SECRET,
+    resave: false,
+    saveUninitialized: false,
+    cookie: {
+      httpOnly: true,
+      sameSite: 'lax',
+      secure: process.env.NODE_ENV === 'production',
+      maxAge: 7 * 24 * 60 * 60 * 1000
+    }
+  });
+}
+
+function requireAuth(req, res, next) {
+  if (!req.user) {
+    return res.status(401).json({ error: 'authentication required' });
+  }
+  next();
+}
+
+module.exports = { sessionMiddleware, requireAuth };

--- a/src/templates/sample-project/src/db/client.js
+++ b/src/templates/sample-project/src/db/client.js
@@ -1,0 +1,45 @@
+/**
+ * Database client — Postgres connection pool
+ *
+ * Canonical DB access point. API handlers should NEVER use the pg module
+ * directly; everything goes through `query()` or `tx()` so we get a
+ * single place to add logging, metrics, and retries.
+ *
+ * See spec `.frame/specs/migrate-to-postgres/` for the SQLite → Postgres
+ * migration history.
+ */
+
+const { Pool } = require('pg');
+
+const pool = new Pool({
+  connectionString: process.env.DATABASE_URL,
+  max: 20,
+  idleTimeoutMillis: 30_000
+});
+
+async function query(sql, params) {
+  const started = Date.now();
+  const result = await pool.query(sql, params);
+  const elapsed = Date.now() - started;
+  if (elapsed > 200) {
+    console.warn(`Slow query (${elapsed}ms):`, sql.slice(0, 120));
+  }
+  return result;
+}
+
+async function tx(fn) {
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const result = await fn(client);
+    await client.query('COMMIT');
+    return result;
+  } catch (err) {
+    await client.query('ROLLBACK');
+    throw err;
+  } finally {
+    client.release();
+  }
+}
+
+module.exports = { pool, query, tx };

--- a/src/templates/sample-project/src/db/migrations/001_initial.sql
+++ b/src/templates/sample-project/src/db/migrations/001_initial.sql
@@ -1,0 +1,41 @@
+-- Initial schema for TaskFlow
+-- Forward-only migration. Roll-back happens via 001_initial_down.sql.
+
+CREATE TABLE users (
+  id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  email         TEXT UNIQUE NOT NULL,
+  name          TEXT NOT NULL,
+  password_hash TEXT,
+  google_id     TEXT,
+  created_at    TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE UNIQUE INDEX users_google_id_unique ON users (google_id) WHERE google_id IS NOT NULL;
+
+CREATE TABLE teams (
+  id         UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  name       TEXT NOT NULL,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE TABLE team_members (
+  team_id UUID REFERENCES teams(id) ON DELETE CASCADE,
+  user_id UUID REFERENCES users(id) ON DELETE CASCADE,
+  role    TEXT NOT NULL DEFAULT 'member',
+  PRIMARY KEY (team_id, user_id)
+);
+
+CREATE TABLE tasks (
+  id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  team_id               UUID NOT NULL REFERENCES teams(id),
+  title                 TEXT NOT NULL,
+  description           TEXT,
+  status                TEXT NOT NULL DEFAULT 'open',
+  assigned_to_user_id   UUID REFERENCES users(id),
+  payload               JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at            TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX tasks_assigned_to_user_id ON tasks (assigned_to_user_id);
+CREATE INDEX tasks_team_id ON tasks (team_id);

--- a/src/templates/sample-project/src/index.js
+++ b/src/templates/sample-project/src/index.js
@@ -1,0 +1,28 @@
+/**
+ * TaskFlow — Application entry
+ *
+ * Wires the Express app, database pool, and OAuth strategy, then starts
+ * the HTTP server on the configured port.
+ */
+
+const { createApp } = require('./api/server');
+const { configureOAuth } = require('./auth/oauth');
+const { pool } = require('./db/client');
+
+async function start() {
+  // Verify DB connectivity before accepting traffic
+  await pool.query('SELECT 1');
+
+  const app = createApp();
+  configureOAuth(app);
+
+  const port = Number(process.env.PORT) || 3000;
+  app.listen(port, () => {
+    console.log(`TaskFlow listening on http://localhost:${port}`);
+  });
+}
+
+start().catch((err) => {
+  console.error('Fatal startup error:', err);
+  process.exit(1);
+});

--- a/src/templates/sample-project/src/ui/App.jsx
+++ b/src/templates/sample-project/src/ui/App.jsx
@@ -1,0 +1,30 @@
+/**
+ * App root — routing + auth context
+ */
+
+import React from 'react';
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { TaskList } from './components/TaskList';
+
+export function App() {
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route path="/" element={<TaskList />} />
+        <Route path="/dashboard" element={<TaskList />} />
+        <Route path="/login" element={<Login />} />
+      </Routes>
+    </BrowserRouter>
+  );
+}
+
+function Login() {
+  return (
+    <div className="login">
+      <h1>TaskFlow</h1>
+      <a href="/auth/google/start" className="btn-google">
+        Sign in with Google
+      </a>
+    </div>
+  );
+}

--- a/src/templates/sample-project/src/ui/components/TaskList.jsx
+++ b/src/templates/sample-project/src/ui/components/TaskList.jsx
@@ -1,0 +1,50 @@
+/**
+ * TaskList — renders the user's tasks with status filters
+ */
+
+import React, { useEffect, useState } from 'react';
+
+const STATUSES = ['all', 'open', 'in_progress', 'done'];
+
+export function TaskList() {
+  const [tasks, setTasks] = useState([]);
+  const [filter, setFilter] = useState('all');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    fetch('/api/tasks')
+      .then((r) => r.json())
+      .then((data) => {
+        setTasks(data);
+        setLoading(false);
+      });
+  }, []);
+
+  const visible = filter === 'all' ? tasks : tasks.filter((t) => t.status === filter);
+
+  if (loading) return <div className="task-list-empty">Loading…</div>;
+
+  return (
+    <div className="task-list">
+      <div className="task-list-filters">
+        {STATUSES.map((s) => (
+          <button
+            key={s}
+            className={s === filter ? 'active' : ''}
+            onClick={() => setFilter(s)}
+          >
+            {s}
+          </button>
+        ))}
+      </div>
+      <ul>
+        {visible.map((t) => (
+          <li key={t.id} className={`task task-${t.status}`}>
+            <span className="task-title">{t.title}</span>
+            <span className="task-status">{t.status}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/src/templates/sample-project/tasks.json
+++ b/src/templates/sample-project/tasks.json
@@ -1,0 +1,199 @@
+{
+  "_comment": "Sample tasks demonstrating mixed states + spec-derived tasks. The `source` field links tasks to their parent spec.",
+  "project": "TaskFlow",
+  "version": "2.0",
+  "lastUpdated": "2026-04-12T00:00:00Z",
+  "tasks": [
+    {
+      "id": "task-001",
+      "title": "Add migration for google_id + google_refresh_token columns",
+      "description": "Schema change: users table gains google_id (text, unique, nullable) and google_refresh_token (text, nullable, encrypted at rest). Reversible.",
+      "status": "completed",
+      "priority": "high",
+      "category": "feature",
+      "source": "spec:add-google-oauth:T1",
+      "createdAt": "2026-02-19T10:00:00Z",
+      "completedAt": "2026-02-19T14:22:00Z"
+    },
+    {
+      "id": "task-002",
+      "title": "Run migration in dev; verify roll-back works",
+      "status": "completed",
+      "priority": "high",
+      "category": "feature",
+      "source": "spec:add-google-oauth:T2",
+      "createdAt": "2026-02-19T10:00:00Z",
+      "completedAt": "2026-02-19T15:10:00Z"
+    },
+    {
+      "id": "task-003",
+      "title": "Provision OAuth client in Google Cloud + add env credentials",
+      "status": "completed",
+      "priority": "high",
+      "category": "feature",
+      "source": "spec:add-google-oauth:T3",
+      "createdAt": "2026-02-19T10:00:00Z",
+      "completedAt": "2026-02-19T16:00:00Z"
+    },
+    {
+      "id": "task-004",
+      "title": "Install passport-google-oauth20 dependency",
+      "status": "completed",
+      "priority": "medium",
+      "category": "feature",
+      "source": "spec:add-google-oauth:T4",
+      "createdAt": "2026-02-20T09:00:00Z",
+      "completedAt": "2026-02-20T09:15:00Z"
+    },
+    {
+      "id": "task-005",
+      "title": "Implement src/auth/oauth.js Passport strategy",
+      "status": "completed",
+      "priority": "high",
+      "category": "feature",
+      "source": "spec:add-google-oauth:T5",
+      "createdAt": "2026-02-20T09:00:00Z",
+      "completedAt": "2026-02-20T15:30:00Z"
+    },
+    {
+      "id": "task-006",
+      "title": "Wire oauth into Express app + session middleware",
+      "status": "completed",
+      "priority": "high",
+      "category": "feature",
+      "source": "spec:add-google-oauth:T6",
+      "createdAt": "2026-02-20T09:00:00Z",
+      "completedAt": "2026-02-21T11:00:00Z"
+    },
+    {
+      "id": "task-007",
+      "title": "Add /auth/google/start + /auth/google/callback routes",
+      "status": "completed",
+      "priority": "high",
+      "category": "feature",
+      "source": "spec:add-google-oauth:T7",
+      "createdAt": "2026-02-20T09:00:00Z",
+      "completedAt": "2026-02-21T16:00:00Z"
+    },
+    {
+      "id": "task-008",
+      "title": "End-to-end test: full OAuth round-trip",
+      "status": "completed",
+      "priority": "medium",
+      "category": "test",
+      "source": "spec:add-google-oauth:T8",
+      "createdAt": "2026-02-21T09:00:00Z",
+      "completedAt": "2026-02-22T10:00:00Z"
+    },
+    {
+      "id": "task-009",
+      "title": "Audit current SQLite schema; map every table to a Postgres equivalent",
+      "status": "completed",
+      "priority": "high",
+      "category": "refactor",
+      "source": "spec:migrate-to-postgres:T1",
+      "createdAt": "2026-03-08T09:00:00Z",
+      "completedAt": "2026-03-09T17:00:00Z"
+    },
+    {
+      "id": "task-010",
+      "title": "Stand up Postgres in docker-compose for local dev",
+      "status": "completed",
+      "priority": "high",
+      "category": "feature",
+      "source": "spec:migrate-to-postgres:T2",
+      "createdAt": "2026-03-09T09:00:00Z",
+      "completedAt": "2026-03-09T12:00:00Z"
+    },
+    {
+      "id": "task-011",
+      "title": "Port src/db/client.js from sqlite3 to pg with connection pooling",
+      "status": "completed",
+      "priority": "high",
+      "category": "refactor",
+      "source": "spec:migrate-to-postgres:T3",
+      "createdAt": "2026-03-09T13:00:00Z",
+      "completedAt": "2026-03-10T18:00:00Z"
+    },
+    {
+      "id": "task-012",
+      "title": "Migrate users + sessions tables (queries, FK constraints)",
+      "status": "completed",
+      "priority": "high",
+      "category": "refactor",
+      "source": "spec:migrate-to-postgres:T4",
+      "createdAt": "2026-03-10T09:00:00Z",
+      "completedAt": "2026-03-11T16:00:00Z"
+    },
+    {
+      "id": "task-013",
+      "title": "Migrate tasks + teams tables; add UUID primary keys",
+      "status": "in_progress",
+      "priority": "high",
+      "category": "refactor",
+      "source": "spec:migrate-to-postgres:T5",
+      "createdAt": "2026-03-11T09:00:00Z"
+    },
+    {
+      "id": "task-014",
+      "title": "Backfill data: copy SQLite production data to Postgres staging",
+      "status": "pending",
+      "priority": "high",
+      "category": "feature",
+      "source": "spec:migrate-to-postgres:T6",
+      "createdAt": "2026-03-11T09:00:00Z"
+    },
+    {
+      "id": "task-015",
+      "title": "Add transaction support via tx() helper in db/client.js",
+      "status": "pending",
+      "priority": "medium",
+      "category": "feature",
+      "source": "spec:migrate-to-postgres:T7",
+      "createdAt": "2026-03-11T09:00:00Z"
+    },
+    {
+      "id": "task-016",
+      "title": "Production cutover plan + dry-run on staging",
+      "status": "pending",
+      "priority": "high",
+      "category": "feature",
+      "source": "spec:migrate-to-postgres:T8",
+      "createdAt": "2026-03-11T09:00:00Z"
+    },
+    {
+      "id": "task-017",
+      "title": "Update README with new docker-compose dev setup instructions",
+      "description": "After Postgres migration shipped to dev, the README still references SQLite. Fix.",
+      "status": "pending",
+      "priority": "low",
+      "category": "docs",
+      "createdAt": "2026-03-12T09:00:00Z"
+    },
+    {
+      "id": "task-018",
+      "title": "Fix flaky test in src/api/tasks.test.js — race condition on task ordering",
+      "status": "pending",
+      "priority": "medium",
+      "category": "fix",
+      "createdAt": "2026-04-02T11:00:00Z"
+    },
+    {
+      "id": "task-019",
+      "title": "Investigate slow query on /api/users/:id/tasks (>500ms p95)",
+      "description": "Index on tasks.assigned_to_user_id might be missing post-migration. Check.",
+      "status": "in_progress",
+      "priority": "high",
+      "category": "fix",
+      "createdAt": "2026-04-08T15:00:00Z"
+    },
+    {
+      "id": "task-020",
+      "title": "Add rate limiting to /auth/google/* endpoints",
+      "status": "pending",
+      "priority": "medium",
+      "category": "feature",
+      "createdAt": "2026-04-10T09:00:00Z"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

First-time users hit a blank screen after closing the welcome modal — no project, no obvious next step. This adds a **"Try a Sample Project"** entry to the welcome overlay that opens a fully-populated fictional codebase (**TaskFlow** — Node + Express + Postgres + React) so users can immediately see what Frame's specs, tasks, notes, and structure map look like on realistic content.

## What's in the sample

- **3 specs in different phases:**
  - \`add-google-oauth\` — \`done\`, with a fully-written \`outcome.md\`
  - \`migrate-to-postgres\` — \`implementing\`, 4 of 8 tasks completed
  - \`email-notifications\` — \`planned\`, plan exists but no tasks yet
- **20 tasks** across statuses, most linked to specs via \`source: spec:<slug>:T<n>\`
- **PROJECT_NOTES.md** with 5 architectural decisions
- **STRUCTURE.json** with 10 modules + full intentIndex
- **Placeholder code** (auth, db, api, ui) — enough for the file tree to feel real

## How it works

1. User clicks **Try a Sample Project** (featured at top of welcome overlay)
2. Main process lazy-copies \`src/templates/sample-project/\` into \`userData/sample-project\` (transparent-asar-safe walker — \`fs.cpSync\` doesn't read from inside the asar archive)
3. Project opens via the existing \`PROJECT_SELECTED\` flow — all panels light up
4. Top banner appears: *"You're exploring the sample project. Open your own when you're ready."* with an **Open My Project** CTA
5. User explores; edits stick because the copy is theirs to mess with

## Test plan

- [ ] \`npm run dev\` → welcome modal shows new featured button at top
- [ ] Click "Try a Sample Project" → modal closes, sample opens, banner appears
- [ ] Specs panel: 3 cards, different phases, click through tabs
- [ ] Tasks panel: 20 tasks, spec-derived tasks show source
- [ ] Overview / Structure: modules render from STRUCTURE.json
- [ ] PROJECT_NOTES.md readable in editor
- [ ] File tree shows src/, package.json, README.md
- [ ] Banner's "Open My Project" → folder picker → banner disappears after pick
- [ ] Second-time open: still works (lazy copy detects existing dir, doesn't overwrite)

## Deferred to follow-up PRs

- Read-only enforcement across panels — user can edit the copied sample freely for now
- SAMPLE badge in recent-projects sidebar
- "Import sample spec into my project" bridge for users who want a starter in their real codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)