### PR TITLE
fix: scope terminal cap to current project instead of globally

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -448,32 +448,33 @@
         "shared/ipcChannels",
         "shared/frameConstants",
         "shared/frameTemplates",
-        "workspace"
+        "workspace",
+        "structureBootstrap"
       ],
       "functions": {
         "init": {
-          "line": 19,
+          "line": 20,
           "params": [
             "window"
           ],
           "purpose": "Initialize frame project module"
         },
         "isFrameProject": {
-          "line": 26,
+          "line": 27,
           "params": [
             "projectPath"
           ],
           "purpose": "Check if a project is a Frame project"
         },
         "getFrameConfig": {
-          "line": 34,
+          "line": 35,
           "params": [
             "projectPath"
           ],
           "purpose": "Get Frame config from project"
         },
         "createFileIfNotExists": {
-          "line": 47,
+          "line": 48,
           "params": [
             "filePath",
             "content"
@@ -481,7 +482,7 @@
           "purpose": "Create file if it doesn't exist"
         },
         "createSymlinkSafe": {
-          "line": 64,
+          "line": 65,
           "params": [
             "target",
             "linkPath"
@@ -489,21 +490,21 @@
           "purpose": "Create a symlink safely with Windows fallback"
         },
         "checkExistingFrameFiles": {
-          "line": 105,
+          "line": 106,
           "params": [
             "projectPath"
           ],
           "purpose": "Check which Frame files already exist in the project"
         },
         "showInitializeConfirmation": {
-          "line": 129,
+          "line": 130,
           "params": [
             "projectPath"
           ],
           "purpose": "Show confirmation dialog before initializing Frame project"
         },
         "initializeFrameProject": {
-          "line": 173,
+          "line": 174,
           "params": [
             "projectPath",
             "projectName"
@@ -511,27 +512,27 @@
           "purpose": "Initialize a project as Frame project"
         },
         "isSpecDrivenEnabled": {
-          "line": 319,
+          "line": 335,
           "params": [
             "projectPath"
           ],
           "purpose": "edits — slice 1 doesn't ship a \"disable\" path."
         },
         "enableSpecDriven": {
-          "line": 324,
+          "line": 340,
           "params": [
             "projectPath"
           ]
         },
         "ensureSpecDrivenArtifacts": {
-          "line": 349,
+          "line": 365,
           "params": [
             "projectPath",
             "config"
           ]
         },
         "setupIPC": {
-          "line": 399,
+          "line": 415,
           "params": [
             "ipcMain"
           ],
@@ -1375,21 +1376,21 @@
           ]
         },
         "getTerminalsByProject": {
-          "line": 191,
+          "line": 197,
           "params": [
             "projectPath"
           ],
           "purpose": "Get terminals for a specific project"
         },
         "getTerminalInfo": {
-          "line": 206,
+          "line": 212,
           "params": [
             "terminalId"
           ],
           "purpose": "Get terminal info"
         },
         "writeToTerminal": {
-          "line": 217,
+          "line": 223,
           "params": [
             "terminalId",
             "data"
@@ -1397,7 +1398,7 @@
           "purpose": "Write data to specific terminal"
         },
         "resizeTerminal": {
-          "line": 227,
+          "line": 233,
           "params": [
             "terminalId",
             "cols",
@@ -1406,33 +1407,33 @@
           "purpose": "Resize specific terminal"
         },
         "destroyTerminal": {
-          "line": 237,
+          "line": 243,
           "params": [
             "terminalId"
           ],
           "purpose": "Destroy specific terminal"
         },
         "destroyAll": {
-          "line": 249,
+          "line": 255,
           "purpose": "Destroy all terminals"
         },
         "getTerminalCount": {
-          "line": 260,
+          "line": 266,
           "purpose": "Get terminal count"
         },
         "getTerminalIds": {
-          "line": 267,
+          "line": 273,
           "purpose": "Get all terminal IDs"
         },
         "hasTerminal": {
-          "line": 274,
+          "line": 280,
           "params": [
             "terminalId"
           ],
           "purpose": "Check if terminal exists"
         },
         "setupIPC": {
-          "line": 281,
+          "line": 287,
           "params": [
             "ipcMain"
           ],
@@ -4925,7 +4926,11 @@
         "getFrameConfigTemplate",
         "SPEC_DRIVEN_SECTION",
         "getCodexWrapperTemplate",
-        "getGenericWrapperTemplate"
+        "getGenericWrapperTemplate",
+        "getStructureHookSnippet",
+        "getStructurePreCommitHookTemplate",
+        "FRAME_HOOK_MARKER_START",
+        "FRAME_HOOK_MARKER_END"
       ],
       "depends": [],
       "functions": {
@@ -4991,6 +4996,13 @@
             "promptFlag = ''"
           ],
           "purpose": "Can be customized for other AI tools in the future"
+        },
+        "getStructureHookSnippet": {
+          "line": 537
+        },
+        "getStructurePreCommitHookTemplate": {
+          "line": 558,
+          "purpose": "Husky/lefthook get the snippet appended into their own files instead."
         }
       }
     },
@@ -5428,6 +5440,78 @@
       "functions": {
         "start": {
           "line": 12
+        }
+      }
+    },
+    "main/structureBootstrap": {
+      "file": "src/main/structureBootstrap.js",
+      "description": "Structure Bootstrap",
+      "exports": [
+        "bootstrapStructure",
+        "copyParserScripts",
+        "detectHookSetup",
+        "installPreCommitHook",
+        "runInitialFullScan"
+      ],
+      "depends": [
+        "fs",
+        "path",
+        "child_process",
+        "shared/frameConstants",
+        "shared/frameTemplates"
+      ],
+      "functions": {
+        "copyParserScripts": {
+          "line": 47,
+          "params": [
+            "projectPath"
+          ],
+          "purpose": "latest parser to all projects on their next init)."
+        },
+        "detectHookSetup": {
+          "line": 84,
+          "params": [
+            "projectPath"
+          ],
+          "purpose": "- 'vanilla'  — no existing hook (or only the .sample), safe to write"
+        },
+        "hasFrameSnippet": {
+          "line": 139,
+          "params": [
+            "hookFilePath"
+          ],
+          "purpose": "Check if our managed snippet is already present in a hook file."
+        },
+        "installPreCommitHook": {
+          "line": 156,
+          "params": [
+            "projectPath"
+          ],
+          "purpose": "manualInstructions: string shown to user when we can't auto-install"
+        },
+        "appendToHookFile": {
+          "line": 211,
+          "params": [
+            "hookPath",
+            "createIfMissing",
+            "needsShebang"
+          ],
+          "purpose": "Append the Frame snippet to an existing hook file (husky case)."
+        },
+        "runInitialFullScan": {
+          "line": 247,
+          "params": [
+            "projectPath"
+          ],
+          "purpose": "Returns: { status, message }"
+        },
+        "bootstrapStructure": {
+          "line": 287,
+          "params": [
+            "projectPath",
+            "structureWasCreated"
+          ],
+          "purpose": "initial scan when we created the file, never overwriting user content."
         }
       }
     }
@@ -6312,6 +6396,13 @@
         "module": "renderer/structureMap",
         "file": "src/renderer/structureMap.js",
         "description": "Structure Map Module"
+      }
+    ],
+    "structure-bootstrap": [
+      {
+        "module": "main/structureBootstrap",
+        "file": "src/main/structureBootstrap.js",
+        "description": "Structure Bootstrap"
       }
     ],
     "task-confirm-modal": [

--- a/src/main/ptyManager.js
+++ b/src/main/ptyManager.js
@@ -127,8 +127,14 @@ function getAvailableShells() {
  * @returns {string} Terminal ID
  */
 function createTerminal(workingDir = null, projectPath = null, shellPath = null) {
-  if (ptyInstances.size >= MAX_TERMINALS) {
-    throw new Error(`Maximum terminal limit (${MAX_TERMINALS}) reached`);
+  // Per-project cap. The renderer keeps terminals from inactive projects
+  // alive in its Map for fast switch-back, so a global count would surface
+  // here as a confusing "you have 3 visible but can't open a 4th" because
+  // 6 hidden ones from a previous project are eating the global slot.
+  const projectCount = Array.from(ptyInstances.values())
+    .filter(p => p.projectPath === projectPath).length;
+  if (projectCount >= MAX_TERMINALS) {
+    throw new Error(`Maximum terminal limit (${MAX_TERMINALS}) reached for this project`);
   }
 
   const terminalId = `term-${++terminalCounter}`;

--- a/src/renderer/terminalManager.js
+++ b/src/renderer/terminalManager.js
@@ -209,15 +209,20 @@ class TerminalManager {
    * @param {string} options.shell - Shell path to use (optional)
    */
   async createTerminal(options = {}) {
-    if (this.terminals.size >= this.maxTerminals) {
-      console.error('Maximum terminal limit reached');
-      return null;
-    }
-
     // Use provided projectPath or current project
     const projectPath = options.projectPath !== undefined
       ? options.projectPath
       : this.currentProjectPath;
+
+    // Per-project cap (was previously global — but terminals from other
+    // projects are kept alive in memory for fast switch-back, so a global
+    // count of 9 silently locked users out at far fewer visible terminals).
+    const projectCount = Array.from(this.terminals.values())
+      .filter(t => t.state.projectPath === projectPath).length;
+    if (projectCount >= this.maxTerminals) {
+      console.error(`Maximum terminal limit (${this.maxTerminals}) reached for this project`);
+      return null;
+    }
 
     // Working directory: use provided cwd, or project path, or home directory
     const workingDir = options.cwd || projectPath || null;

--- a/src/renderer/terminalTabBar.js
+++ b/src/renderer/terminalTabBar.js
@@ -276,7 +276,9 @@ class TerminalTabBar {
     // Disable new terminal button if at max
     const newBtn = this.element.querySelector('.btn-new-terminal');
     newBtn.disabled = state.terminals.length >= this.manager.maxTerminals;
-    newBtn.title = newBtn.disabled ? 'Maximum terminals reached' : 'New Terminal (Ctrl+Shift+T)';
+    newBtn.title = newBtn.disabled
+      ? `Maximum terminals (${this.manager.maxTerminals}) reached for this project`
+      : 'New Terminal (Ctrl+Shift+T)';
   }
 
   _setupEventHandlers() {


### PR DESCRIPTION
## Summary
- The 9-terminal cap was enforced globally in both `terminalManager.createTerminal` (renderer) and `ptyManager.createTerminal` (main).
- But the renderer keeps terminals from inactive projects alive in memory for fast switch-back, while the tab bar only shows the current project's terminals.
- Net result: user sees 3 terminals in the tab bar (current project), clicks + for a 4th, gets silently blocked because 6 hidden terminals from a previous project are eating the global slot. The cap *says* 9, the user *experiences* 3.

## Fix
- Count per-project in both `createTerminal` paths. Each project gets its own pool of up to 9 terminals.
- The tab-bar's disabled check already used the project-scoped `state.terminals.length` against `maxTerminals`, so it was already consistent with this new behavior — no logic change needed there.
- Tooltip clarified: *"Maximum terminals (9) reached for this project"*.

## Test plan
- [ ] Open a fresh project, open 9 terminals — 10th attempt is blocked, tooltip is project-scoped
- [ ] Switch to another project — see 0 terminals (existing behavior, terminals stay alive in memory)
- [ ] Open 9 terminals in the new project — succeeds (was previously blocked at the first one because global was at 9)
- [ ] Switch back to original project — still see the original 9, none lost
- [ ] Existing single-project users see no change in behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)