### PR TITLE
fix: keep Changes panel in sync via fs.watch

### DIFF
--- a/.frame/specs/non-invasive-overlay/spec.md
+++ b/.frame/specs/non-invasive-overlay/spec.md
@@ -1,0 +1,185 @@
+# Non-Invasive Frame Overlay (.frame-only, zero-touch)
+
+> **What we're building:** a version of Frame that can be used on *any* codebase
+> — including a company or third-party repository the developer must never alter
+> — while still delivering Frame's full feature set (tasks, specs, notes,
+> structure map, prompt history, multi-terminal, AI-tool launching with context).
+> Frame becomes a **read-only overlay** on top of the project: it owns exactly
+> one directory, `.frame/`, and touches nothing else in the working tree.
+
+---
+
+## Problem
+
+Today Frame's identity and data are physically embedded in the project root, and
+initialization actively *mutates* the repository:
+
+- `initializeFrameProject` writes root-level files: `AGENTS.md`, `STRUCTURE.json`,
+  `PROJECT_NOTES.md`, `tasks.json`, `QUICKSTART.md`.
+- It **destructively** consumes an existing `CLAUDE.md`: reads it, `fs.unlinkSync`
+  deletes it, merges its content into `AGENTS.md`, then replaces it with a
+  `CLAUDE.md → AGENTS.md` symlink. Same pattern for `GEMINI.md`.
+- `structureBootstrap` installs a git **pre-commit hook** and copies parser
+  scripts into the project.
+- `isFrameProject` decides "is this a Frame project?" by looking for
+  `projectPath/.frame/config.json` — so the project's identity lives *inside* the
+  repo as well.
+
+Consequences that block the target use case:
+
+1. **You cannot use Frame on a codebase you don't own.** Opening a company repo
+   and initializing pollutes it with 5+ root files, deletes/relinks an existing
+   `CLAUDE.md`, and installs a git hook. None of this is acceptable on a shared,
+   reviewed, or third-party codebase.
+2. **Existing instruction files are clobbered.** Many real projects already ship
+   their own `CLAUDE.md`, `AGENTS.md`, `GEMINI.md`, Codex config, `.cursorrules`,
+   etc. Frame currently rewrites/relinks them rather than respecting them.
+3. **`git status` is never clean.** Even if a developer wanted Frame's metadata
+   to stay local, today it lands as untracked/modified files across the tree.
+
+The desired workflow — *"use Frame's organizing and context-preservation
+features on top of my real work, without leaving a fingerprint on the repo"* — is
+impossible with the current architecture.
+
+---
+
+## Goal
+
+Frame supports a single, non-invasive operating model with these properties:
+
+1. **One footprint only.** Everything Frame creates or maintains for a project
+   lives under `projectPath/.frame/`. Frame **never** creates, modifies, deletes,
+   or symlinks any file outside `.frame/` in the working tree — including the
+   project's `.gitignore`.
+
+2. **`.frame/` is the home for all Frame artifacts.** The files Frame currently
+   scatters at the root move inside `.frame/`:
+   - `.frame/AGENTS.md` (Frame's own workflow instructions for AI tools)
+   - `.frame/STRUCTURE.json`
+   - `.frame/PROJECT_NOTES.md`
+   - `.frame/tasks.json`
+   - `.frame/QUICKSTART.md`
+   - `.frame/specs/…` (already there today)
+   - `.frame/config.json`, `.frame/bin/…` (already there today)
+
+3. **Existing root instruction files are sacred — discovered, never touched.**
+   On opening a project, Frame detects any of: `CLAUDE.md`, `AGENTS.md`,
+   `GEMINI.md`, Codex config (`AGENTS.md` / Codex's own convention),
+   `.claude/CLAUDE.md`, `.cursorrules`, `.cursor/rules/*`,
+   `.github/copilot-instructions.md`. These are read **read-only** and surfaced in
+   the UI. Frame must never rewrite, delete, symlink-over, or append to them.
+
+4. **Native prompt injection, composed at launch time — not by planting files.**
+   Because Frame no longer drops a root `CLAUDE.md` symlink, the AI tool can no
+   longer auto-discover Frame's conventions from the root. Instead, Frame injects
+   context **when it launches the AI tool**, via the start command it already
+   controls (`aiToolManager.getStartCommand`). Injection composes two layers
+   without merging or duplicating them:
+
+   | AI tool | Repo's own root instruction file | Frame's behavior |
+   |---------|----------------------------------|------------------|
+   | Claude Code | `CLAUDE.md` present | Leave it alone (Claude reads it natively). Append a pointer to `.frame/AGENTS.md`. |
+   | Gemini CLI | `GEMINI.md` present | Same — leave it, point to `.frame/AGENTS.md`. |
+   | Codex / no native convention | any/none | Wrapper injects: "read the repo's instruction file if present **and** `.frame/AGENTS.md`". |
+   | any | none present | `.frame/AGENTS.md` is the sole injected source. |
+
+   The repo's instruction file remains authoritative for code conventions; Frame's
+   `.frame/AGENTS.md` adds only the Frame meta-layer (task recognition, note
+   capture, spec workflow, structure upkeep). No content is copied out of the
+   repo's files and no duplicate context is injected.
+
+5. **Committing `.frame/` is opt-in, never imposed.**
+   - **Default (zero-touch):** Frame keeps `.frame/` out of git locally using
+     `.git/info/exclude` (a per-clone, untracked file). The tracked tree —
+     including `.gitignore` — is never modified, so `git status` stays clean.
+   - **Team opt-in:** a developer/team that *wants* to share tasks and specs can
+     choose to commit `.frame/`. Frame surfaces this as an explicit choice; it
+     does not edit the tracked `.gitignore` on the user's behalf.
+
+6. **All other features keep working unchanged.** Multi-terminal, file tree,
+   file editor (which only writes when the user explicitly saves a real source
+   file — intended), git status/branches panels, overview, prompt history, AI
+   tool switching — these already read the repo or write to user-scoped storage
+   and need no behavioral change beyond path resolution.
+
+---
+
+## Constraints
+
+- **Absolute no-write rule:** outside `projectPath/.frame/`, the only writes Frame
+  may perform are to **untracked, local-only git internals**: `.git/info/exclude`
+  and `.git/hooks/*`. Nothing in the tracked working tree, ever — not even
+  `.gitignore`.
+- **Non-destructive discovery:** reading existing instruction files must never
+  open them for write, rename, or relink. `fs.unlinkSync` / `symlinkSync` against
+  root instruction files is removed entirely.
+- **Single model, not a toggle.** This replaces the embedded behavior; there is no
+  "embedded vs external" switch to maintain. (Migration of already-embedded Frame
+  projects is handled separately — see Out of Scope.)
+- **Path resolution must be centralized.** Every place that currently hardcodes a
+  root path (`tasksManager.getTasksFilePath`, `overviewManager.loadStructure /
+  loadTasks / loadDecisions`, `frameProject`, `structureBootstrap` output, etc.)
+  resolves through one helper that returns `projectPath/.frame/<file>`.
+  `specManager` already lives under `.frame/specs/` and is the reference pattern.
+- **Tool-agnostic injection.** The composition logic must work for Claude Code,
+  Gemini CLI, and Codex CLI today, and be extensible to future tools via
+  `aiToolManager` without per-tool special cases leaking across modules.
+- **Freshness without ownership.** If a discovered root instruction file changes
+  on disk, Frame re-reads it for subsequent injections (the debounced `fs.watch`
+  pattern from `specManager` is the model). Frame caches/references; it never
+  writes back.
+- **Cross-platform:** `.git/info/exclude` and `.git/hooks` handling, plus any path
+  encoding, must behave on macOS, Linux, and Windows (including the
+  symlink-unsupported Windows fallback already handled elsewhere).
+
+---
+
+## Success Criteria
+
+The work is complete when all of the following hold:
+
+1. **Clean tree.** Open an arbitrary repository, initialize Frame, use it for a
+   full session (create tasks, a spec, notes; launch an AI tool), then run
+   `git status`: the only thing git could possibly see is `.frame/`, and in the
+   default (zero-touch) setup `git status` reports **no changes at all** because
+   `.frame/` is excluded via `.git/info/exclude`. The tracked `.gitignore` is
+   byte-identical to before.
+2. **Existing instruction files untouched.** A repo that ships its own
+   `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` / `.cursorrules` has those files
+   **byte-identical** (checksum-equal) before and after a full Frame session. No
+   symlink replaces them; none is deleted.
+3. **Context reaches the AI both ways.** When Frame launches the AI tool in a repo
+   that has its own `CLAUDE.md`, the tool ends up aware of *both* the repo's
+   conventions and Frame's `.frame/AGENTS.md` meta-layer — verifiable by the tool
+   acting on Frame conventions (e.g. offering to capture a note / recognizing a
+   task) without the repo's `CLAUDE.md` having been modified.
+4. **No root artifacts.** After init and use, there are **zero** Frame-created
+   files in the project root or anywhere outside `.frame/`. All of
+   `AGENTS.md`, `STRUCTURE.json`, `PROJECT_NOTES.md`, `tasks.json`,
+   `QUICKSTART.md` are found only under `.frame/`.
+5. **Opt-in commit works.** A team that chooses to track `.frame/` can commit it
+   and a teammate cloning the repo sees the shared tasks/specs — without any
+   change to how Frame reads them.
+6. **Feature parity.** Tasks, specs, notes, structure map, overview, prompt
+   history, and AI-tool launching all function as before, now reading from
+   `.frame/`.
+
+---
+
+## Out of Scope
+
+The following are explicitly **not** part of this effort (may become separate
+specs later):
+
+- **Migration tooling for already-embedded Frame projects.** Existing projects
+  that have root `AGENTS.md`/`tasks.json`/etc. need a separate migration story
+  (move-into-`.frame/`, leave-in-place, or dual-read). Not decided here.
+- **Editing the user's tracked `.gitignore`.** Default stays `.git/info/exclude`;
+  any future "write to `.gitignore`" convenience is a separate decision.
+- **Auto-committing `.frame/`** or any git write beyond local excludes/hooks.
+- **Frame Server / browser mode**, multi-user, and remote-host concerns.
+- **Parsing existing instruction files into Frame's own structure** (e.g.
+  auto-seeding `PROJECT_NOTES.md` from a discovered `CLAUDE.md`). Discovery +
+  launch-time composition is in scope; transformation/import is not.
+- **Deep semantic validation** of discovered instruction files. Frame detects and
+  references them; it does not lint or interpret their content.

--- a/.frame/specs/non-invasive-overlay/status.json
+++ b/.frame/specs/non-invasive-overlay/status.json
@@ -1,0 +1,10 @@
+{
+  "slug": "non-invasive-overlay",
+  "title": "Non-Invasive Frame Overlay (.frame-only, zero-touch)",
+  "phase": "specified",
+  "ai_tool": "claude-code",
+  "generated_task_ids": [],
+  "created_at": "2026-06-02T12:08:24.367Z",
+  "updated_at": "2026-06-02T12:14:39.963Z",
+  "last_phase_at": "2026-06-02T12:14:39.963Z"
+}

--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Auto-generated module structure",
-  "lastUpdated": "2026-05-21",
+  "lastUpdated": "2026-06-02",
   "architecture": {},
   "modules": {
     "main/aiToolManager": {
@@ -690,48 +690,61 @@
       ],
       "depends": [
         "child_process",
+        "fs",
+        "path",
         "shared/ipcChannels"
       ],
       "functions": {
         "init": {
-          "line": 23,
+          "line": 39,
           "params": [
             "window"
           ]
         },
         "setupIPC": {
-          "line": 27,
+          "line": 47,
           "params": [
             "ipcMain"
           ]
         },
         "startWatching": {
-          "line": 37,
+          "line": 63,
           "params": [
             "projectPath"
           ]
         },
         "stopWatching": {
-          "line": 48
+          "line": 105
+        },
+        "isGitInternalPath": {
+          "line": 125,
+          "params": [
+            "filename"
+          ],
+          "purpose": "watcher can defer them to the dedicated .git watcher."
+        },
+        "scheduleRefresh": {
+          "line": 131,
+          "purpose": "single git-status run."
         },
         "pushStatus": {
-          "line": 55
+          "line": 139
         },
         "readGitStatus": {
-          "line": 73,
+          "line": 178,
           "params": [
             "projectPath"
           ]
         },
         "parsePorcelainV1": {
-          "line": 94,
+          "line": 199,
           "params": [
             "stdout"
           ],
           "purpose": "Format: \"XY <path>\\0\" with renamed/copied entries adding \"<oldpath>\\0\" after."
         },
         "classify": {
-          "line": 135,
+          "line": 240,
           "params": [
             "index",
             "worktree"
@@ -742,7 +755,8 @@
       "ipc": {
         "listens": [
           "WATCH_GIT_STATUS",
-          "UNWATCH_GIT_STATUS"
+          "UNWATCH_GIT_STATUS",
+          "REFRESH_GIT_STATUS"
         ],
         "emits": [
           "GIT_STATUS_DATA"
@@ -2489,67 +2503,70 @@
           "purpose": "Render file tree recursively"
         },
         "clearFileTree": {
-          "line": 162,
-          "purpose": "Clear file tree"
+          "line": 167,
+          "params": [
+            "{ unwatch = false } = {}"
+          ],
+          "purpose": "Pass `{ unwatch: true }` only when truly leaving a project."
         },
         "refreshFileTree": {
-          "line": 174,
+          "line": 181,
           "params": [
             "projectPath"
           ],
           "purpose": "Refresh file tree"
         },
         "loadFileTree": {
-          "line": 184,
+          "line": 191,
           "params": [
             "projectPath"
           ],
           "purpose": "Load file tree for path"
         },
         "setupIPC": {
-          "line": 192,
+          "line": 199,
           "purpose": "Setup IPC listeners"
         },
         "focus": {
-          "line": 213,
+          "line": 220,
           "purpose": "Focus file tree for keyboard navigation"
         },
         "getVisibleItems": {
-          "line": 243,
+          "line": 250,
           "purpose": "inside collapsed folders."
         },
         "handleKeydown": {
-          "line": 252,
+          "line": 259,
           "params": [
             "e"
           ],
           "purpose": "Handle keyboard navigation in file tree"
         },
         "blur": {
-          "line": 314,
+          "line": 321,
           "purpose": "Blur/unfocus file tree"
         },
         "setupSearch": {
-          "line": 324
+          "line": 331
         },
         "applyFilter": {
-          "line": 352,
+          "line": 359,
           "params": [
             "query"
           ]
         },
         "filterWrapper": {
-          "line": 365,
+          "line": 372,
           "params": [
             "wrapper",
             "query"
           ]
         },
         "setupContextMenu": {
-          "line": 401
+          "line": 408
         },
         "showContextMenu": {
-          "line": 425,
+          "line": 432,
           "params": [
             "x",
             "y",
@@ -2557,16 +2574,16 @@
           ]
         },
         "hideContextMenu": {
-          "line": 442
+          "line": 449
         },
         "handleContextMenuAction": {
-          "line": 448,
+          "line": 455,
           "params": [
             "action"
           ]
         },
         "applyGitStatusDecoration": {
-          "line": 465,
+          "line": 472,
           "purpose": "via a simple second pass."
         }
       },
@@ -2938,18 +2955,18 @@
           "purpose": "Setup button click handlers"
         },
         "setupUpdateDot": {
-          "line": 318,
+          "line": 319,
           "purpose": "→ About → \"Dismiss this version\"). Both click open Settings → About."
         },
         "revealSidebarTab": {
-          "line": 349,
+          "line": 350,
           "params": [
             "tabName"
           ],
           "purpose": "commands so they don't try to focus an element inside a hidden container."
         },
         "registerCommands": {
-          "line": 367,
+          "line": 369,
           "purpose": "Command Palette and the global keyboard handler."
         }
       },
@@ -2959,7 +2976,9 @@
           "UPDATE_AVAILABLE"
         ],
         "emits": [
-          "CLONE_GITHUB_REPO"
+          "CLONE_GITHUB_REPO",
+          "REFRESH_GIT_STATUS",
+          "REFRESH_GIT_STATUS"
         ]
       }
     },
@@ -5885,6 +5904,11 @@
       },
       "GET_GIT_DIFF": {
         "name": "get-git-diff",
+        "direction": "",
+        "description": ""
+      },
+      "REFRESH_GIT_STATUS": {
+        "name": "refresh-git-status",
         "direction": "",
         "description": ""
       }

--- a/src/main/gitStatusManager.js
+++ b/src/main/gitStatusManager.js
@@ -1,27 +1,47 @@
 /**
  * Git Status Manager
  *
- * Polls `git status --porcelain=v1 -z` for the active project on a fixed
- * interval and pushes the parsed result to the renderer for file-tree
- * decoration.
+ * Watches the active project (event-driven, no polling) and pushes a fresh
+ * `git status --porcelain=v1 -z` snapshot to the renderer for file-tree
+ * decoration whenever something relevant changes.
+ *
+ * Two fs.watch watchers feed one debounced refresh:
+ *   • the working tree (recursive) — new/edited/deleted files, and
+ *   • the `.git` directory (recursive) — commit / stage / checkout / branch,
+ *     which only ever touch files inside `.git` (index, HEAD, refs/…) and are
+ *     missed by the worktree watcher on most platforms.
+ * On top of that we refresh on window focus and on explicit REFRESH_GIT_STATUS
+ * requests (e.g. the Changes tab being opened) as a safety net for any event a
+ * watcher dropped. The `lastSerialized` de-dupe means an unchanged status never
+ * reaches the renderer, so these extra triggers are silent when nothing moved.
  *
  * Diff viewer / staged-files panel / stage-discard actions are intentionally
  * out of scope here — those are separate features.
  */
 
 const { execFile } = require('child_process');
+const fs = require('fs');
+const path = require('path');
 const { IPC } = require('../shared/ipcChannels');
 
-const POLL_INTERVAL_MS = 5000;
 const MAX_BUFFER = 10 * 1024 * 1024;
+const DEBOUNCE_MS = 200;
 
 let mainWindow = null;
-let pollTimer = null;
+let worktreeWatcher = null;
+let gitDirWatcher = null;
+let debounceTimer = null;
 let currentProjectPath = null;
 let lastSerialized = null; // de-dupe identical pushes
+let isFetching = false; // in-flight guard
+let pendingRefetch = false; // a trigger arrived mid-fetch
 
 function init(window) {
   mainWindow = window;
+  // Refocusing the app is a cheap moment to reconcile any event a watcher may
+  // have dropped while we were in the background. pushStatus() self-guards on
+  // currentProjectPath, so this is a no-op when nothing is being watched.
+  window.on('focus', () => pushStatus());
 }
 
 function setupIPC(ipcMain) {
@@ -32,6 +52,12 @@ function setupIPC(ipcMain) {
   ipcMain.on(IPC.UNWATCH_GIT_STATUS, () => {
     stopWatching();
   });
+
+  // On-demand refresh (e.g. the Changes tab was opened). Silent unless the
+  // status actually changed — see lastSerialized de-dupe in pushStatus().
+  ipcMain.on(IPC.REFRESH_GIT_STATUS, () => {
+    pushStatus();
+  });
 }
 
 function startWatching(projectPath) {
@@ -39,35 +65,114 @@ function startWatching(projectPath) {
   currentProjectPath = projectPath;
   if (!projectPath) return;
 
-  // Initial fetch (don't wait the full interval before showing decorations)
+  // Initial snapshot so decorations paint immediately.
   pushStatus();
 
-  pollTimer = setInterval(pushStatus, POLL_INTERVAL_MS);
+  // Working-tree watcher: new/edited/deleted files. Events under `.git/` are
+  // ignored here because the dedicated .git watcher handles those.
+  try {
+    worktreeWatcher = fs.watch(
+      projectPath,
+      { recursive: true, persistent: false },
+      (eventType, filename) => {
+        if (filename && isGitInternalPath(filename)) return;
+        scheduleRefresh();
+      }
+    );
+  } catch (err) {
+    console.error('gitStatusManager: worktree fs.watch failed', err);
+  }
+
+  // `.git` watcher: commit / stage / unstage / checkout / branch only ever
+  // mutate files inside `.git` (index, HEAD, refs/…). Only watch when `.git`
+  // is a real directory — for linked worktrees / submodules it's a file, in
+  // which case the worktree watcher alone is acceptable.
+  try {
+    const gitDir = path.join(projectPath, '.git');
+    const stat = fs.statSync(gitDir);
+    if (stat.isDirectory()) {
+      gitDirWatcher = fs.watch(
+        gitDir,
+        { recursive: true, persistent: false },
+        () => scheduleRefresh()
+      );
+    }
+  } catch (err) {
+    // Not a repo (no .git) or watch unsupported — fine, leave it unset.
+  }
 }
 
 function stopWatching() {
-  if (pollTimer) clearInterval(pollTimer);
-  pollTimer = null;
+  if (worktreeWatcher) {
+    try { worktreeWatcher.close(); } catch (_) { /* ignore */ }
+  }
+  worktreeWatcher = null;
+  if (gitDirWatcher) {
+    try { gitDirWatcher.close(); } catch (_) { /* ignore */ }
+  }
+  gitDirWatcher = null;
+  if (debounceTimer) {
+    clearTimeout(debounceTimer);
+    debounceTimer = null;
+  }
   currentProjectPath = null;
   lastSerialized = null;
+  pendingRefetch = false;
+}
+
+// True for paths that live inside the repo's `.git` directory, so the worktree
+// watcher can defer them to the dedicated .git watcher.
+function isGitInternalPath(filename) {
+  return filename === '.git' || filename.startsWith('.git' + path.sep) || filename.startsWith('.git/');
+}
+
+// Coalesce bursts (a checkout or `npm install` touches many files) into a
+// single git-status run.
+function scheduleRefresh() {
+  if (debounceTimer) clearTimeout(debounceTimer);
+  debounceTimer = setTimeout(() => {
+    debounceTimer = null;
+    pushStatus();
+  }, DEBOUNCE_MS);
 }
 
 async function pushStatus() {
   const projectPath = currentProjectPath;
   if (!projectPath || !mainWindow || mainWindow.isDestroyed()) return;
 
-  const result = await readGitStatus(projectPath);
+  // In-flight guard: never run two `git status` at once; remember that another
+  // trigger arrived so we reconcile once the current run finishes.
+  if (isFetching) {
+    pendingRefetch = true;
+    return;
+  }
+  isFetching = true;
 
-  // Skip if status is identical to the last push (avoids needless renderer work)
-  const serialized = JSON.stringify(result);
-  if (serialized === lastSerialized) return;
-  lastSerialized = serialized;
+  try {
+    const result = await readGitStatus(projectPath);
 
-  mainWindow.webContents.send(IPC.GIT_STATUS_DATA, {
-    projectPath,
-    isRepo: result.isRepo,
-    files: result.files
-  });
+    // Bail if watching stopped or the project changed mid-fetch.
+    if (currentProjectPath !== projectPath || !mainWindow || mainWindow.isDestroyed()) {
+      return;
+    }
+
+    // Skip if identical to the last push (avoids needless renderer work).
+    const serialized = JSON.stringify(result);
+    if (serialized !== lastSerialized) {
+      lastSerialized = serialized;
+      mainWindow.webContents.send(IPC.GIT_STATUS_DATA, {
+        projectPath,
+        isRepo: result.isRepo,
+        files: result.files
+      });
+    }
+  } finally {
+    isFetching = false;
+    if (pendingRefetch) {
+      pendingRefetch = false;
+      pushStatus();
+    }
+  }
 }
 
 function readGitStatus(projectPath) {

--- a/src/renderer/fileTreeUI.js
+++ b/src/renderer/fileTreeUI.js
@@ -158,14 +158,21 @@ function renderFileTree(files, parentElement, indent = 0) {
 
 /**
  * Clear file tree
+ *
+ * Called on every FILE_TREE_DATA render to reset the DOM/state before
+ * re-rendering, so it must NOT stop git-status watching by default —
+ * doing so would kill the poll loop right after loadFileTree() started it.
+ * Pass `{ unwatch: true }` only when truly leaving a project.
  */
-function clearFileTree() {
+function clearFileTree({ unwatch = false } = {}) {
   if (fileTreeElement) {
     fileTreeElement.innerHTML = '';
   }
   gitStatusFiles = {};
   gitStatusProjectPath = null;
-  ipcRenderer.send(IPC.UNWATCH_GIT_STATUS);
+  if (unwatch) {
+    ipcRenderer.send(IPC.UNWATCH_GIT_STATUS);
+  }
 }
 
 /**

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -156,7 +156,7 @@ function init() {
       // Start watching .frame/specs/ for the new project
       specPanel.startWatchingForProject(projectPath);
     } else {
-      fileTreeUI.clearFileTree();
+      fileTreeUI.clearFileTree({ unwatch: true });
       specPanel.stopWatching();
     }
   });
@@ -303,6 +303,7 @@ function setupButtonHandlers() {
       document.querySelectorAll('[data-sidebar-tab-content]').forEach(el => {
         el.style.display = el.dataset.sidebarTabContent === tab ? '' : 'none';
       });
+      if (tab === 'changes') ipcRenderer.send(IPC.REFRESH_GIT_STATUS);
     });
   });
 }
@@ -357,6 +358,7 @@ function revealSidebarTab(tabName) {
   document.querySelectorAll('[data-sidebar-tab-content]').forEach((el) => {
     el.style.display = el.dataset.sidebarTabContent === tabName ? '' : 'none';
   });
+  if (tabName === 'changes') ipcRenderer.send(IPC.REFRESH_GIT_STATUS);
 }
 
 /**

--- a/src/shared/ipcChannels.js
+++ b/src/shared/ipcChannels.js
@@ -133,6 +133,7 @@ const IPC = {
   // Git Status (file tree decoration)
   WATCH_GIT_STATUS: 'watch-git-status',
   UNWATCH_GIT_STATUS: 'unwatch-git-status',
+  REFRESH_GIT_STATUS: 'refresh-git-status',
   GIT_STATUS_DATA: 'git-status-data',
   GET_GIT_DIFF: 'get-git-diff',
 


### PR DESCRIPTION
 ## Problem

  The Changes panel didn't reliably reflect git status changes. The old approach
  polled `git status` on a fixed **5s interval**, which caused both latency and
  some changes (commit / stage / checkout) never showing up in the panel at all.

  ## Solution

  Removed polling in favor of an **event-driven fs.watch** architecture:

  - **Two watchers → one debounced refresh:**
    - Working tree (recursive) → new / edited / deleted files
    - `.git` directory (recursive) → commit / stage / checkout / branch
      (these only ever mutate files inside `.git`, and the worktree watcher
      misses them on most platforms)
  - **Safety net:** manual trigger via `REFRESH_GIT_STATUS` on window focus and
    when the Changes tab is opened (covers any dropped events).
  - **Noise control:**
    - `DEBOUNCE_MS = 200` → bursts (checkout, `npm install`) collapse into a
      single `git status` run
    - `lastSerialized` de-dupe → no push to the renderer when status is unchanged
    - `isFetching` / `pendingRefetch` → never run two `git status` at once; a
      trigger that arrives mid-fetch is reconciled afterward

  ## clearFileTree() regression fix

  `clearFileTree()` is called on every `FILE_TREE_DATA` render, so it no longer
  stops watching by default (doing so would kill the watcher right after
  `loadFileTree()` started it). It only passes `{ unwatch: true }` when truly
  leaving a project.

  ## Files changed

  - `src/main/gitStatusManager.js` — polling → fs.watch, debounce, in-flight guard
  - `src/renderer/fileTreeUI.js` — `clearFileTree({ unwatch })` opt-in unwatch
  - `src/renderer/index.js` — trigger REFRESH when the Changes tab is opened
  - `src/shared/ipcChannels.js` — added `REFRESH_GIT_STATUS` channel
  - `STRUCTURE.json` — updated module map

  ## Testing checklist

  - [ ] Add / edit / delete a file → Changes panel updates immediately
  - [ ] Commit / stage / unstage → panel reflects correctly
  - [ ] Branch checkout → panel reflects correctly
  - [ ] Switch projects → old watcher closes, new one starts (no leak)
  - [ ] Return to focus from background → dropped changes get reconciled