### PR TITLE
fix: Esc in file/diff viewers no longer cancels running CLI tool

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Auto-generated module structure",
-  "lastUpdated": "2026-06-02",
+  "lastUpdated": "2026-06-03",
   "architecture": {},
   "modules": {
     "main/aiToolManager": {
@@ -2429,15 +2429,15 @@
           "purpose": "Setup event handlers"
         },
         "setupIPC": {
-          "line": 202,
+          "line": 208,
           "purpose": "Setup IPC listeners"
         },
         "isEditorOpen": {
-          "line": 270,
+          "line": 276,
           "purpose": "Check if editor is open"
         },
         "getCurrentFile": {
-          "line": 277,
+          "line": 283,
           "purpose": "Get currently editing file path"
         }
       },
@@ -5671,29 +5671,29 @@
           "line": 24
         },
         "open": {
-          "line": 60,
+          "line": 63,
           "params": [
             "opts"
           ],
           "purpose": "Open the diff viewer for the given file."
         },
         "close": {
-          "line": 107
+          "line": 110
         },
         "setMode": {
-          "line": 116,
+          "line": 119,
           "params": [
             "mode"
           ]
         },
         "renderCurrent": {
-          "line": 124
+          "line": 127
         },
         "showLoading": {
-          "line": 135
+          "line": 138
         },
         "showEmpty": {
-          "line": 141,
+          "line": 144,
           "params": [
             "message"
           ]

--- a/src/renderer/diffViewer.js
+++ b/src/renderer/diffViewer.js
@@ -38,11 +38,14 @@ function init() {
     if (e.target === overlay) close();
   });
 
+  // Capture phase + stopPropagation so Esc doesn't leak through to a focused
+  // terminal underneath and cancel an in-flight CLI tool.
   document.addEventListener('keydown', (e) => {
-    if (e.key === 'Escape' && overlay.classList.contains('visible')) {
-      close();
-    }
-  });
+    if (e.key !== 'Escape') return;
+    if (!overlay.classList.contains('visible')) return;
+    e.stopPropagation();
+    close();
+  }, true);
 
   for (const btn of modeButtons) {
     btn.addEventListener('click', () => {

--- a/src/renderer/editor.js
+++ b/src/renderer/editor.js
@@ -161,17 +161,12 @@ function setupEventHandlers() {
   if (editorTextarea) {
     editorTextarea.addEventListener('input', checkModified);
 
-    // Keyboard shortcuts
+    // Keyboard shortcuts (Esc handled at document level below)
     editorTextarea.addEventListener('keydown', (e) => {
       // Ctrl+S or Cmd+S to save
       if ((e.ctrlKey || e.metaKey) && e.key === 's') {
         e.preventDefault();
         saveFile();
-      }
-
-      // Escape to close
-      if (e.key === 'Escape') {
-        closeEditor();
       }
 
       // Tab for indentation
@@ -185,6 +180,17 @@ function setupEventHandlers() {
       }
     });
   }
+
+  // Esc closes the editor regardless of which element has focus. We use the
+  // capturing phase + stopPropagation so the keystroke never reaches a
+  // focused terminal underneath — otherwise xterm would forward \x1b to the
+  // PTY and cancel an in-flight CLI tool (e.g. a running Claude Code prompt).
+  document.addEventListener('keydown', (e) => {
+    if (e.key !== 'Escape') return;
+    if (!editorOverlay || !editorOverlay.classList.contains('visible')) return;
+    e.stopPropagation();
+    closeEditor();
+  }, true);
 
   // Close on overlay click (outside editor)
   if (editorOverlay) {


### PR DESCRIPTION
## Summary

- Editor and Diff Viewer overlays were letting `Esc` leak through to the focused terminal underneath, which sent `\x1b` to the PTY and cancelled whatever AI agent (Claude Code, Codex, Gemini) was mid-thought
- Two causes: (1) `editor.js` had its Esc handler bound to the textarea only — if the user never clicked into the textarea, the handler never fired; (2) `diffViewer.js` used a bubble-phase document listener with no `stopPropagation`, so xterm processed the Esc before the overlay's handler ran
- Both now use the same capture-phase + `stopPropagation` pattern already established in `tasksPanel.js:685` — the event never reaches xterm, in-flight CLI prompts keep running

## Test plan

- [ ] Run `npm run dev`
- [ ] Start a long Claude Code prompt in the terminal (`claude` → ask for a multi-paragraph answer)
- [ ] While Claude is still streaming, open a file from the tree (do NOT click into the textarea)
- [ ] Press Esc
- [ ] Expected: editor overlay closes, Claude continues streaming uninterrupted
- [ ] Repeat with diff viewer (open a Changes panel diff while Claude is running, then Esc)
- [ ] Both overlays should close cleanly on Esc without touching the terminal

🤖 Generated with [Claude Code](https://claude.com/claude-code)