### PR TITLE
feat:  sidebar- activity rail + Agent view, project switcher & navigable diff tabs

### DIFF
--- a/.frame/specs/sidebar-project-section/outcome.md
+++ b/.frame/specs/sidebar-project-section/outcome.md
@@ -1,0 +1,97 @@
+# Outcome — Sidebar Project Section
+
+## T01 — Add the Open Project modal markup to `index.html`
+
+Added an `#open-project-modal` `.modal-overlay` block after `#initialize-frame-modal`, mirroring its structure (modal-container/header/body/footer with a `modal-close`). Body holds three `.open-project-option` buttons (Select Folder / Create New / Clone GitHub Repo) plus a hidden `#open-project-clone-form` (URL input + error slot) and a hidden clone footer with Back/Clone buttons revealed by the clone toggle. Markup only — no JS wiring yet (T02) and styling lands in T04, so the option/form classes are currently unstyled.
+
+_Captured: 2026-06-12 · 1 file change_
+
+---
+
+## T02 — Create `openProjectModal.js`
+
+Created `src/renderer/openProjectModal.js` — a UI shell over the existing open flows: Select/Create delegate to `state`, Clone sends `CLONE_GITHUB_REPO`, with `.visible`-class show/hide and Escape gated on visibility (no terminal key leak). Wired `openProjectModal.init()` in `index.js` and repointed the `CLONE_GITHUB_REPO_RESULT` listener to call `handleCloneResult()` (inline error on failure, close + `setProjectPath` on success). The result listener stayed in `index.js` per plan.
+
+_Captured: 2026-06-12 · 2 file changes_
+
+---
+
+## T03 — Projects section block + `projectSection.js`
+
+Added the `#project-section` block under `#sidebar-header` (toggle/chevron + name, `+` button, empty-state CTA, body placeholder) and created `src/renderer/projectSection.js` owning in-memory collapse/expand (a `collapsed`/`expanded` class on the root) and wiring `+`/CTA to the modal. Exposed `expand/collapse/toggle/focusList` and inited it in `index.js`.
+
+_Captured: 2026-06-12 · 3 file changes_
+
+---
+
+## T04 — `project-section.css`
+
+Added `src/renderer/styles/components/project-section.css` (header row, rotating chevron, collapsed/expanded list visibility, dashed empty-state CTA, Open Project modal option cards + clone form) using theme variables, and registered it via `@import` in `main.css`.
+
+_Captured: 2026-06-12 · 2 file changes_
+
+---
+
+## T05 — Rehome list + per-project actions into the section
+
+Moved `#projects-list`, the AI tool row (`#btn-start-ai` + `#ai-tool-selector`), and the `#btn-initialize-frame` wrapper into `#project-section-body`, with `#init-frame-tooltip` placed as a fixed-position sibling. Removed the entire old Projects tab content in the same edit to avoid duplicate IDs — which also lands most of T07's markup removal (stacked Select/Create/Clone buttons, inline clone row, duplicate `#projects-header` `+`).
+
+_Captured: 2026-06-12 · 1 file change_
+
+---
+
+## T06 — Repoint active-project display in `state.js`
+
+Pointed `state.init`'s `pathElement` at `#project-section-name` and reworked `updateProjectUI()` to render the project **name** (full path as `title`) and toggle the empty-state CTA vs. section body across both branches. Added an `updateProjectUI()` call at the end of `init()` so the no-project empty state renders on first load (it previously wasn't invoked at startup). Dropped the old inline `style.color` writes — color now comes from CSS.
+
+_Captured: 2026-06-12 · 2 file changes_
+
+---
+
+## T07 — Remove Projects tab + dead handlers
+
+Removed the `projects` tab button (Files is now the default active tab, panel un-hidden) and deleted the dead `btn-select-project`/`btn-create-project`/clone-row/`btn-add-project` handlers in `index.js` (the old tab markup was already removed in T05). Divergence from plan: two off-spec callers of the removed buttons were also remapped to avoid silent regressions — `laneBoard.js`'s no-project CTA now sends `SELECT_PROJECT_FOLDER` directly, and `welcomeOverlay.js`'s Clone CTA opens the modal via a new `open({ clone: true })` option.
+
+_Captured: 2026-06-12 · 4 file changes_
+
+---
+
+## T08 — Remap commands
+
+Changed `focus.projectList` (`Cmd+E`) to ensure the sidebar is visible then call `projectSection.focusList()` (expand + `projectListUI.focus()`) instead of `revealSidebarTab('projects')`, and routed `project.add`/`project.create` through `openProjectModal.open()`. Files/Changes focus commands and `project.next/prev` untouched.
+
+_Captured: 2026-06-12 · 1 file change_
+
+---
+
+## T09 — Sample/overlay interplay + STRUCTURE.json
+
+Confirmed the sample-project and any project flow still highlight in the section (same `#projects-list` driven by `projectListUI` via `onProjectChange`), and the empty-state CTA (sidebar) does not conflict with the welcome overlay (separate full-screen overlay). Regenerated `STRUCTURE.json` via `npm run structure`, registering `renderer/openProjectModal` and `renderer/projectSection` (83 modules). Note: verification was static (syntax + reference sweep + duplicate-ID check), not a live app launch.
+
+_Captured: 2026-06-12 · 1 file change_
+
+---
+
+## Refinement — keep recent projects visible in the empty state (post-T06)
+
+Per user feedback: the no-active-project state was hiding the whole section body, which removed the previously-opened (workspace) project list — a liked feature. Changed `updateProjectUI()` to toggle a `has-project` class instead of hiding the body; CSS now hides `#projects-list` only when `.collapsed.has-project`, so with no active project the recent-projects list always shows alongside the "Open a project +" CTA. Also hide the chevron and AI tool row when there's no active project. Files: `state.js`, `project-section.css`.
+
+_Captured: 2026-06-12 · 2 file changes_
+
+---
+
+## Refinement 2 — Projects section becomes a minimal draggable list (post-spec)
+
+Per user feedback, dropped the collapsed active-project header row entirely: the section is now just a "Projects" label + `+` button (tighter gap to the sidebar header) above the workspace list. List shows max 3 rows then scrolls (`max-height` in CSS) and items are **drag-reorderable with persistence** — added IPC `REORDER_WORKSPACE_PROJECTS` + `workspace.reorderProjects()`, and `projectListUI` now renders in stored order (removed the lastOpenedAt recency sort) and scrolls the active project into view. Start-AI + Initialize-as-Frame were **parked** in a hidden `#parked-project-actions` holder (elements kept so `ai.startSession` command + init flow stay wired; spotlight guarded against the hidden button) pending the user's proposal for their new home. Files: `index.html`, `projectSection.js` (simplified — no collapse), `projectListUI.js`, `project-section.css`, `state.js`, `ipcChannels.js`, `workspace.js`. Followup: user will propose a new home for the parked Start/Initialize actions.
+
+_Captured: 2026-06-12 · 7 file changes_
+
+---
+
+## Refinement 3 — auto-prompt to initialize non-Frame projects (post-spec)
+
+Reused the existing `initialize-frame-modal` as an auto-prompt: switching to a non-Frame project now opens it automatically (hooked in `state.setIsFrameProject` when `!isFrame`, skipping the bundled sample). Relabeled Cancel→"Not Now", added a lead-in line and a "Don't ask again for this project" checkbox; dismiss paths route through `dismissInitPrompt()` which, when checked, adds the path to an in-memory `frameInitPromptSuppressed` Set — per-project, session-scoped, so it asks again after restart. Files: `index.html`, `state.js`, `panels.css`. Note: suppression is per-project (matches "her bu projeye geçiş"), not global; the parked Initialize button still opens the same modal manually.
+
+_Captured: 2026-06-12 · 3 file changes_
+
+---

--- a/.frame/specs/sidebar-project-section/status.json
+++ b/.frame/specs/sidebar-project-section/status.json
@@ -1,7 +1,7 @@
 {
   "slug": "sidebar-project-section",
   "title": "Sidebar Project Section — projects as the root of the sidebar",
-  "phase": "tasks_generated",
+  "phase": "done",
   "ai_tool": "claude-code",
   "generated_task_ids": [
     "task-spec-sidebar-project-section-T01",
@@ -15,6 +15,6 @@
     "task-spec-sidebar-project-section-T09"
   ],
   "created_at": "2026-06-11T16:00:00.000Z",
-  "updated_at": "2026-06-12T08:56:22.291Z",
-  "last_phase_at": "2026-06-12T08:56:22.291Z"
+  "updated_at": "2026-06-12T14:10:34.504Z",
+  "last_phase_at": "2026-06-12T14:10:34.504Z"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,9 @@ __pycache__/
 # prompts-history.txt
 release/
 
+# Frame runtime artifacts (staged spec / agent-dispatch prompts — regenerated)
+.frame/runtime/
+
 #Walkthroughs
 WALKTHROUGH/*.p8
 RELEASE.local.md

--- a/PROJECT_NOTES.md
+++ b/PROJECT_NOTES.md
@@ -832,3 +832,26 @@ Frame is gaining native spec-driven development as a core feature (4-slice plan 
 **Spec ordering decided:** 1) `agent-dispatch` → 2) frame-starter (consumes dispatch, retires sidebar Start button) → 3) `sidebar-project-section` (independent, can go in parallel).
 
 **Artifact:** spec at `.frame/specs/agent-dispatch/spec.md` (phase: specified).
+
+---
+
+### [2026-06-13] Sidebar overhaul: activity rail + Agent view (post-spec evolution)
+
+**Context:** The `sidebar-project-section` spec shipped projects as a pinned section above [Files | Changes] tabs. In this session it evolved well beyond the spec, driven by PO feedback and live iteration. Captured here because it spans many files and several deliberate decisions.
+
+**What changed:**
+- **Activity icon rail** (PO insisted Projects be its own destination): replaced the top [Files | Changes] tabs with a VS Code–style vertical icon rail **[Projects · Files · Changes · Agent]**. Icons-only + tooltips; default landing = Projects. Changes uses a **file-diff** icon (the git-branch icon is reserved for a future working-tree view).
+- **Projects view:** the full workspace list (no 3-row cap) + a prominent accent **"Add new Project"** CTA that sits where the list ends (not pinned) and opens the Open Project modal. **First project auto-opens on launch** (one-shot; skipped if a project is already active). Project rows given more vertical breathing room.
+- **Current-project dropdown** at the top of Files / Changes / Agent: shows the active project and lets you **switch project in place** (reuses `projectListUI.selectProject`), plus an "+ Open a project…" entry. Hidden on Projects (its list already highlights the active row).
+- **Agent view (new, agent-oriented):** moved the default-agent selector + **Start** out of a bottom footer into a dedicated tab (selector + full-width Start stacked for breathing room). Start = context-aware `agentDispatch.startDefaultAgent()`: on the Frames screen → focused Frame if idle, else ask **Open a new Frame / Kill & restart here**; anywhere else → new Frame. **Running Agents** = live list across **all projects**, grouped under a per-project heading (with the box icon), each row click focuses that Frame (switching project first when needed). Hover "i" explains the cross-project scope.
+- **Top bar cleanup:** removed the `+` (new frame) and Tasks buttons; **Tasks moved into the "…" more menu**. New-frame now lives as an **"Add new Frame"** button in the Frames detail rail (alongside the Home board's `+` card and Cmd+Shift+T).
+- **Home board empty state:** "No project added yet" + **"Add New Project"** → opens the Open Project modal (same flow as the sidebar), replacing the old direct folder picker.
+- **Project status badges:** Bot agent icon + filled colour pills + a custom hover tooltip (replaced the faint native `title`).
+- **Dark-mode readability + colour unification:** section headings → `--text-secondary` / 700 (matching the Home/Frames right-panel `.lane-rail-section-title`); sidebar rail, top-bar action icons and the right-panel strip icons all unified to **secondary at rest → primary on hover**.
+
+**Decisions worth keeping:**
+- Rail stays **icons-only** — hover-expand and an icon+text mode were both considered and rejected as overengineering (tooltips already label; one good default beats user prefs).
+- The Agent view is agent-oriented, but **Running Agents stays cross-project** regardless of the current-project dropdown selection (the dropdown only scopes Start / Files / Changes).
+- New-frame creation uses the **default shell** everywhere now; the old `+`'s shell-picker menu was retired with the button.
+
+**New/changed modules:** `agentPanel.js` (running-agents list); `agentDispatch.startDefaultAgent()`; `multiTerminalUI.isViewingFrame()` + `onNewLane` detail-rail callback; `projectListUI.getProjects()` + first-launch auto-select.

--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Auto-generated module structure",
-  "lastUpdated": "2026-06-12",
+  "lastUpdated": "2026-06-13",
   "architecture": {},
   "modules": {
     "main/aiToolManager": {
@@ -2132,6 +2132,7 @@
         "getProjects",
         "addProject",
         "removeProject",
+        "reorderProjects",
         "updateProjectLastOpened",
         "updateProjectFrameStatus",
         "setupIPC"
@@ -2191,15 +2192,22 @@
           ],
           "purpose": "Remove project from workspace"
         },
+        "reorderProjects": {
+          "line": 132,
+          "params": [
+            "orderedPaths"
+          ],
+          "purpose": "stale/partial order never drops projects."
+        },
         "updateProjectLastOpened": {
-          "line": 130,
+          "line": 152,
           "params": [
             "projectPath"
           ],
           "purpose": "Update project's last opened timestamp"
         },
         "updateProjectFrameStatus": {
-          "line": 146,
+          "line": 168,
           "params": [
             "projectPath",
             "isFrame"
@@ -2207,7 +2215,7 @@
           "purpose": "Update project's Frame status"
         },
         "setupIPC": {
-          "line": 162,
+          "line": 184,
           "params": [
             "ipcMain"
           ],
@@ -2218,7 +2226,8 @@
         "listens": [
           "LOAD_WORKSPACE",
           "ADD_PROJECT_TO_WORKSPACE",
-          "REMOVE_PROJECT_FROM_WORKSPACE"
+          "REMOVE_PROJECT_FROM_WORKSPACE",
+          "REORDER_WORKSPACE_PROJECTS"
         ],
         "emits": [
           "WORKSPACE_DATA",
@@ -3166,6 +3175,10 @@
         "specsDashboard",
         "state",
         "projectListUI",
+        "openProjectModal",
+        "projectSection",
+        "projectStatusBadges",
+        "agentPanel",
         "editor",
         "sidebarResize",
         "aiToolSelector",
@@ -3177,30 +3190,35 @@
         "settingsModal",
         "telemetryNotice",
         "sampleBanner",
-        "../package.json"
+        "../package.json",
+        "agentDispatch"
       ],
       "functions": {
         "init": {
-          "line": 41,
+          "line": 45,
           "purpose": "Initialize all modules"
         },
         "setupButtonHandlers": {
-          "line": 207,
+          "line": 223,
           "purpose": "Setup button click handlers"
         },
+        "setupProjectSwitcher": {
+          "line": 306,
+          "purpose": "and close on outside click / Escape."
+        },
         "setupUpdateDot": {
-          "line": 320,
+          "line": 395,
           "purpose": "→ About → \"Dismiss this version\"). Both click open Settings → About."
         },
         "revealSidebarTab": {
-          "line": 351,
+          "line": 426,
           "params": [
             "tabName"
           ],
           "purpose": "commands so they don't try to focus an element inside a hidden container."
         },
         "registerCommands": {
-          "line": 370,
+          "line": 452,
           "purpose": "Command Palette and the global keyboard handler."
         }
       },
@@ -3210,8 +3228,6 @@
           "UPDATE_AVAILABLE"
         ],
         "emits": [
-          "CLONE_GITHUB_REPO",
-          "REFRESH_GIT_STATUS",
           "REFRESH_GIT_STATUS"
         ]
       }
@@ -3232,7 +3248,8 @@
         "shared/ipcChannels",
         "laneStatus",
         "laneRail",
-        "lucide"
+        "lucide",
+        "openProjectModal"
       ],
       "functions": {
         "statusLabel": {
@@ -3735,47 +3752,102 @@
         "selectProject",
         "setActiveProject",
         "getActiveProject",
+        "getProjects",
         "addProject",
         "removeProject",
         "selectNextProject",
         "selectPrevProject",
         "focus",
-        "blur"
+        "blur",
+        "applyAgentStatuses"
       ],
       "depends": [
         "electron",
-        "shared/ipcChannels"
+        "shared/ipcChannels",
+        "lucide"
       ],
       "functions": {
+        "lucideIcon": {
+          "line": 21,
+          "params": [
+            "data",
+            "size = 12"
+          ]
+        },
         "init": {
-          "line": 18,
+          "line": 32,
           "params": [
             "containerId",
             "onSelectCallback"
           ],
           "purpose": "Initialize project list UI"
         },
+        "ensureStatusTooltip": {
+          "line": 44
+        },
+        "showStatusTooltip": {
+          "line": 53,
+          "params": [
+            "badge"
+          ]
+        },
+        "hideStatusTooltip": {
+          "line": 71
+        },
+        "setupStatusTooltip": {
+          "line": 75
+        },
         "loadProjects": {
-          "line": 27,
+          "line": 92,
           "purpose": "Load projects from workspace"
         },
         "renderProjects": {
-          "line": 34,
+          "line": 99,
           "params": [
             "projectsList"
           ],
           "purpose": "Render project list"
         },
         "createProjectItem": {
-          "line": 73,
+          "line": 140,
           "params": [
             "project",
             "index"
           ],
           "purpose": "Create a project item element"
         },
+        "renderItemStatus": {
+          "line": 205,
+          "params": [
+            "container",
+            "counts"
+          ],
+          "purpose": "`counts` is { approval, input } or undefined (no attention-worthy agents)."
+        },
+        "applyAgentStatuses": {
+          "line": 226,
+          "params": [
+            "map"
+          ],
+          "purpose": "currently-rendered items. Stored so re-renders keep the badges."
+        },
+        "attachDragHandlers": {
+          "line": 240,
+          "params": [
+            "item"
+          ],
+          "purpose": "live-reorders the DOM; on drop the new order is persisted to the workspace."
+        },
+        "persistOrder": {
+          "line": 271,
+          "purpose": "Read the current DOM order, sync the in-memory list, and persist it."
+        },
+        "scrollActiveIntoView": {
+          "line": 292,
+          "purpose": "Scroll the active project item into view within the (max-3-row) list."
+        },
         "confirmRemoveProject": {
-          "line": 127,
+          "line": 303,
           "params": [
             "projectPath",
             "projectName"
@@ -3783,25 +3855,25 @@
           "purpose": "Show confirmation dialog and remove project"
         },
         "selectProject": {
-          "line": 153,
+          "line": 329,
           "params": [
             "projectPath"
           ],
           "purpose": "Terminal session switching is handled by state.js via multiTerminalUI"
         },
         "setActiveProject": {
-          "line": 164,
+          "line": 340,
           "params": [
             "projectPath"
           ],
           "purpose": "Set active project (visual only)"
         },
         "getActiveProject": {
-          "line": 183,
+          "line": 361,
           "purpose": "Get active project path"
         },
         "addProject": {
-          "line": 190,
+          "line": 368,
           "params": [
             "projectPath",
             "projectName",
@@ -3810,38 +3882,42 @@
           "purpose": "Add project to workspace"
         },
         "removeProject": {
-          "line": 201,
+          "line": 379,
           "params": [
             "projectPath"
           ],
           "purpose": "Remove project from workspace"
         },
         "setupIPC": {
-          "line": 208,
+          "line": 386,
           "purpose": "Setup IPC listeners"
         },
         "selectNextProject": {
-          "line": 221,
+          "line": 399,
           "purpose": "Select next project in list"
         },
         "selectPrevProject": {
-          "line": 232,
+          "line": 410,
           "purpose": "Select previous project in list"
         },
         "focus": {
-          "line": 243,
+          "line": 421,
           "purpose": "Focus project list for keyboard navigation"
         },
         "handleKeydown": {
-          "line": 266,
+          "line": 444,
           "params": [
             "e"
           ],
           "purpose": "Handle keyboard navigation in project list"
         },
         "blur": {
-          "line": 301,
+          "line": 479,
           "purpose": "Blur/unfocus project list"
+        },
+        "getProjects": {
+          "line": 488,
+          "purpose": "the Files/Changes panel). Copy so callers can't mutate internal state."
         }
       },
       "ipc": {
@@ -3851,6 +3927,7 @@
         ],
         "emits": [
           "LOAD_WORKSPACE",
+          "REORDER_WORKSPACE_PROJECTS",
           "ADD_PROJECT_TO_WORKSPACE",
           "REMOVE_PROJECT_FROM_WORKSPACE"
         ]
@@ -4565,127 +4642,131 @@
       ],
       "functions": {
         "init": {
-          "line": 30,
+          "line": 34,
           "params": [
             "elements"
           ],
           "purpose": "Initialize state module"
         },
         "getProjectPath": {
-          "line": 55,
+          "line": 63,
           "purpose": "Get current project path"
         },
         "setMultiTerminalUI": {
-          "line": 62,
+          "line": 70,
           "params": [
             "ui"
           ],
           "purpose": "Set MultiTerminalUI reference for terminal session management"
         },
         "setProjectPath": {
-          "line": 69,
+          "line": 77,
           "params": [
             "path"
           ],
           "purpose": "Set project path and switch terminal session"
         },
         "onProjectChange": {
-          "line": 104,
+          "line": 112,
           "params": [
             "callback"
           ],
           "purpose": "Register callback for project change"
         },
         "getIsFrameProject": {
-          "line": 111,
+          "line": 119,
           "purpose": "Get Frame project status"
         },
         "setIsFrameProject": {
-          "line": 118,
+          "line": 126,
           "params": [
             "isFrame"
           ],
           "purpose": "Set Frame project status"
         },
         "onFrameStatusChange": {
-          "line": 129,
+          "line": 145,
           "params": [
             "callback"
           ],
           "purpose": "Register callback for Frame status change"
         },
         "onFrameInitialized": {
-          "line": 136,
+          "line": 152,
           "params": [
             "callback"
           ],
           "purpose": "Register callback for Frame project initialized"
         },
         "updateFrameUI": {
-          "line": 143,
+          "line": 159,
           "purpose": "Update Frame-related UI"
         },
         "initializeAsFrameProject": {
-          "line": 158,
+          "line": 174,
           "purpose": "Initialize current project as Frame project"
         },
         "showInitializeFrameModal": {
-          "line": 167,
+          "line": 183,
           "purpose": "Show custom initialize Frame modal"
         },
         "hideInitializeFrameModal": {
-          "line": 177,
+          "line": 196,
           "purpose": "Hide initialize Frame modal"
         },
+        "dismissInitPrompt": {
+          "line": 208,
+          "purpose": "current project for the rest of this session."
+        },
         "handleInitializeFrame": {
-          "line": 187,
+          "line": 219,
           "purpose": "Handle initialize Frame confirmation"
         },
         "setupInitFrameModalListeners": {
-          "line": 202,
+          "line": 234,
           "purpose": "Setup initialize Frame modal listeners"
         },
         "showInitSpotlight": {
-          "line": 228,
+          "line": 260,
           "purpose": "Show spotlight tour for the initialize button (first time only)"
         },
         "dismissSpotlight": {
-          "line": 266,
+          "line": 301,
           "purpose": "Dismiss spotlight and mark as seen"
         },
         "setupSpotlightListeners": {
-          "line": 277,
+          "line": 312,
           "purpose": "Setup spotlight tour listeners"
         },
         "updateProjectUI": {
-          "line": 319,
+          "line": 354,
           "purpose": "Update project UI elements"
         },
         "selectProjectFolder": {
-          "line": 352,
+          "line": 378,
           "purpose": "Request folder selection"
         },
         "createNewProject": {
-          "line": 359,
+          "line": 385,
           "purpose": "Request new project creation"
         },
         "openSampleProject": {
-          "line": 369,
+          "line": 395,
           "purpose": "specs) is reused unchanged."
         },
         "getIsSampleProject": {
-          "line": 376,
+          "line": 402,
           "purpose": "Check whether the current project is the bundled sample."
         },
         "onSampleChange": {
-          "line": 384,
+          "line": 410,
           "params": [
             "callback"
           ],
           "purpose": "\"is sample\" flag changes (opens or leaves the sample)."
         },
         "setupIPC": {
-          "line": 391,
+          "line": 417,
           "purpose": "Setup IPC listeners"
         }
       },
@@ -5605,48 +5686,49 @@
       "depends": [
         "electron",
         "shared/ipcChannels",
-        "state"
+        "state",
+        "openProjectModal"
       ],
       "functions": {
         "init": {
-          "line": 23
+          "line": 24
         },
         "loadAITools": {
-          "line": 53
+          "line": 54
         },
         "maybeShowOnLaunch": {
-          "line": 64
+          "line": 65
         },
         "setupListeners": {
-          "line": 71
+          "line": 72
         },
         "persistDismissPreference": {
-          "line": 132
+          "line": 133
         },
         "renderToolOptions": {
-          "line": 140
+          "line": 141
         },
         "updateToolSelection": {
-          "line": 175
+          "line": 176
         },
         "open": {
-          "line": 186
+          "line": 187
         },
         "close": {
-          "line": 192
+          "line": 193
         },
         "reopen": {
-          "line": 206,
+          "line": 207,
           "purpose": "the checkbox state from a prior session would silently re-dismiss)."
         },
         "escapeHtml": {
-          "line": 214,
+          "line": 215,
           "params": [
             "s"
           ]
         },
         "escapeAttr": {
-          "line": 223,
+          "line": 224,
           "params": [
             "s"
           ]
@@ -5966,7 +6048,7 @@
           "line": 100
         },
         "_startTicker": {
-          "line": 181
+          "line": 193
         }
       }
     },
@@ -6499,6 +6581,7 @@
       "exports": [
         "init",
         "dispatch",
+        "startDefaultAgent",
         "dispatchSpecCommand",
         "getSpecLaneInfo",
         "getTaskLaneInfo",
@@ -6533,8 +6616,31 @@
           ],
           "purpose": "running (default: current tool)"
         },
+        "startDefaultAgent": {
+          "line": 165,
+          "purpose": "- Anywhere else (Home / any other tab) it always opens a new Frame."
+        },
+        "_startAgentIn": {
+          "line": 200,
+          "params": [
+            "terminalId",
+            "{ fresh = false } = {}"
+          ],
+          "purpose": "spawned shell a beat to accept input before the command is typed."
+        },
+        "_startAgentInNewFrame": {
+          "line": 210
+        },
+        "_askNewOrRestart": {
+          "line": 228,
+          "params": [
+            "frameName",
+            "hasAgent"
+          ],
+          "purpose": "safe default (never silently kills running work)."
+        },
         "dispatchSpecCommand": {
-          "line": 178,
+          "line": 285,
           "params": [
             "{ slug",
             "title = null",
@@ -6542,79 +6648,79 @@
           ]
         },
         "getSpecLaneInfo": {
-          "line": 242,
+          "line": 349,
           "params": [
             "slug"
           ],
           "purpose": "states fail open on purpose."
         },
         "getTaskLaneInfo": {
-          "line": 261,
+          "line": 368,
           "params": [
             "taskId"
           ],
           "purpose": "requires a live agent process."
         },
         "specStatusDotHtml": {
-          "line": 282,
+          "line": 389,
           "params": [
             "slug"
           ],
           "purpose": "Presentation helpers kept here so all surfaces share one mapping."
         },
         "taskStatusDotHtml": {
-          "line": 286,
+          "line": 393,
           "params": [
             "taskId"
           ]
         },
         "_activityDotHtml": {
-          "line": 290,
+          "line": 397,
           "params": [
             "info"
           ]
         },
         "onSpecLaneActivity": {
-          "line": 307,
+          "line": 414,
           "params": [
             "callback"
           ],
           "purpose": "Returns an unsubscribe function."
         },
         "_notifySpecLane": {
-          "line": 315,
+          "line": 422,
           "params": [
             "slug"
           ]
         },
         "onTaskLaneActivity": {
-          "line": 335,
+          "line": 442,
           "params": [
             "callback"
           ],
           "purpose": "Returns an unsubscribe function."
         },
         "_notifyTaskLane": {
-          "line": 343,
+          "line": 450,
           "params": [
             "taskId"
           ]
         },
         "_assignedLane": {
-          "line": 361,
+          "line": 468,
           "params": [
             "slug"
           ],
           "purpose": "lane means the spec is unassigned again."
         },
         "_laneName": {
-          "line": 371,
+          "line": 478,
           "params": [
             "terminalId"
           ]
         },
         "_askContinueOrNew": {
-          "line": 380,
+          "line": 487,
           "params": [
             "frameName",
             "specName"
@@ -6622,20 +6728,20 @@
           "purpose": "Resolves 'continue' | 'new' | 'cancel'; continue is the default action."
         },
         "_escapeHtml": {
-          "line": 412,
+          "line": 519,
           "params": [
             "s"
           ]
         },
         "_waitForAgentReady": {
-          "line": 431,
+          "line": 538,
           "params": [
             "terminalId"
           ],
           "purpose": "the prompt to a y/n chooser, so those lanes time out instead."
         },
         "_fail": {
-          "line": 466,
+          "line": 573,
           "params": [
             "terminalId",
             "message"
@@ -6643,10 +6749,193 @@
           "purpose": "for what is presentation-only."
         },
         "_showToast": {
-          "line": 471,
+          "line": 578,
           "params": [
             "message",
             "type = 'info'"
+          ]
+        }
+      },
+      "ipc": {
+        "listens": [
+          "TERMINAL_DESTROYED"
+        ],
+        "emits": []
+      }
+    },
+    "renderer/openProjectModal": {
+      "file": "src/renderer/openProjectModal.js",
+      "description": "Open Project Modal",
+      "exports": [
+        "init",
+        "open",
+        "close",
+        "isVisible",
+        "handleCloneResult"
+      ],
+      "depends": [
+        "electron",
+        "shared/ipcChannels",
+        "state"
+      ],
+      "functions": {
+        "open": {
+          "line": 29,
+          "params": [
+            "opts = {}"
+          ],
+          "purpose": "(used by the welcome overlay's \"Clone GitHub\" entry point)."
+        },
+        "close": {
+          "line": 39,
+          "purpose": "Hide the modal and reset the clone form."
+        },
+        "isVisible": {
+          "line": 45
+        },
+        "resetCloneForm": {
+          "line": 52,
+          "purpose": "Collapse the clone form back to the option list and clear its state."
+        },
+        "showCloneForm": {
+          "line": 65,
+          "purpose": "Reveal the in-modal clone URL form and focus the input."
+        },
+        "submitClone": {
+          "line": 80,
+          "purpose": "Send the clone request for the current URL value (if any)."
+        },
+        "handleCloneResult": {
+          "line": 92,
+          "params": [
+            "result"
+          ],
+          "purpose": "Returns true if it consumed the result (modal handled the feedback)."
+        },
+        "init": {
+          "line": 109,
+          "purpose": "Wire all modal controls. Safe to call once at startup."
+        }
+      },
+      "ipc": {
+        "listens": [],
+        "emits": [
+          "CLONE_GITHUB_REPO"
+        ]
+      }
+    },
+    "renderer/projectSection": {
+      "file": "src/renderer/projectSection.js",
+      "description": "Projects Section",
+      "exports": [
+        "init",
+        "focusList"
+      ],
+      "depends": [
+        "openProjectModal",
+        "projectListUI"
+      ],
+      "functions": {
+        "focusList": {
+          "line": 19,
+          "purpose": "command."
+        },
+        "init": {
+          "line": 23
+        }
+      }
+    },
+    "renderer/projectStatusBadges": {
+      "file": "src/renderer/projectStatusBadges.js",
+      "description": "Project Status Badges",
+      "exports": [
+        "init",
+        "recompute"
+      ],
+      "depends": [
+        "electron",
+        "shared/ipcChannels",
+        "laneStatus",
+        "projectListUI"
+      ],
+      "functions": {
+        "init": {
+          "line": 28,
+          "params": [
+            "multiTerminalUI"
+          ]
+        },
+        "schedule": {
+          "line": 39
+        },
+        "recompute": {
+          "line": 51,
+          "purpose": "Tally attention-worthy agent statuses per project and push to the list."
+        }
+      },
+      "ipc": {
+        "listens": [
+          "TERMINAL_DESTROYED"
+        ],
+        "emits": []
+      }
+    },
+    "renderer/agentPanel": {
+      "file": "src/renderer/agentPanel.js",
+      "description": "Agent Panel",
+      "exports": [
+        "init",
+        "recompute"
+      ],
+      "depends": [
+        "electron",
+        "shared/ipcChannels",
+        "laneStatus",
+        "state",
+        "projectListUI"
+      ],
+      "functions": {
+        "init": {
+          "line": 35,
+          "params": [
+            "ui"
+          ]
+        },
+        "schedule": {
+          "line": 47
+        },
+        "recompute": {
+          "line": 60,
+          "purpose": "grouped under a heading per project (active project first)."
+        },
+        "_buildRow": {
+          "line": 124,
+          "params": [
+            "a"
+          ],
+          "purpose": "sub-line is just the Frame name."
+        },
+        "_projectNames": {
+          "line": 146,
+          "purpose": "path -> the workspace's display name for that project (fallback: basename)."
+        },
+        "_focus": {
+          "line": 157,
+          "params": [
+            "a"
+          ],
+          "purpose": "so the lane is in view before we enter it."
+        },
+        "_label": {
+          "line": 165,
+          "params": [
+            "agentName"
+          ]
+        },
+        "_basename": {
+          "line": 169,
+          "params": [
+            "p"
           ]
         }
       },
@@ -6871,6 +7160,11 @@
       },
       "TERMINAL_PROCESS_DATA": {
         "name": "terminal-process-data",
+        "direction": "",
+        "description": ""
+      },
+      "REORDER_WORKSPACE_PROJECTS": {
+        "name": "reorder-workspace-projects",
         "direction": "",
         "description": ""
       }
@@ -7250,6 +7544,13 @@
   "files": {},
   "conventions": {},
   "intentIndex": {
+    "agent": [
+      {
+        "module": "renderer/agentPanel",
+        "file": "src/renderer/agentPanel.js",
+        "description": "Agent Panel"
+      }
+    ],
     "agent-dispatch": [
       {
         "module": "renderer/agentDispatch",
@@ -7493,6 +7794,13 @@
         "description": "Google OAuth — Passport strategy + routes"
       }
     ],
+    "open-project-modal": [
+      {
+        "module": "renderer/openProjectModal",
+        "file": "src/renderer/openProjectModal.js",
+        "description": "Open Project Modal"
+      }
+    ],
     "overview": [
       {
         "module": "main/overviewManager",
@@ -7522,6 +7830,20 @@
         "module": "renderer/pluginsPanel",
         "file": "src/renderer/pluginsPanel.js",
         "description": "Plugins Panel Module"
+      }
+    ],
+    "project-section": [
+      {
+        "module": "renderer/projectSection",
+        "file": "src/renderer/projectSection.js",
+        "description": "Projects Section"
+      }
+    ],
+    "project-status-badges": [
+      {
+        "module": "renderer/projectStatusBadges",
+        "file": "src/renderer/projectStatusBadges.js",
+        "description": "Project Status Badges"
       }
     ],
     "prompts": [

--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -2778,7 +2778,8 @@
       "file": "src/renderer/gitChangesPanel.js",
       "description": "Git Changes Panel (Changes sidebar tab)",
       "exports": [
-        "init"
+        "init",
+        "getOrderedFiles"
       ],
       "depends": [
         "electron",
@@ -2786,54 +2787,57 @@
       ],
       "functions": {
         "init": {
-          "line": 22,
+          "line": 25,
           "params": [
             "opts = {}"
           ]
         },
         "handleStatus": {
-          "line": 53,
+          "line": 56,
           "params": [
             "payload"
           ]
         },
         "showMessage": {
-          "line": 77,
+          "line": 88,
           "params": [
             "text"
           ]
         },
         "partition": {
-          "line": 88,
+          "line": 99,
           "params": [
             "files"
           ],
           "purpose": "`staged` and `changes` (VSCode parity)."
         },
         "renderGroup": {
-          "line": 125,
+          "line": 136,
           "params": [
             "group",
             "entries"
           ]
         },
         "buildRow": {
-          "line": 143,
+          "line": 154,
           "params": [
             "entry"
           ]
         },
         "badgeChar": {
-          "line": 184,
+          "line": 195,
           "params": [
             "entry"
           ]
         },
         "normalize": {
-          "line": 196,
+          "line": 207,
           "params": [
             "ch"
           ]
+        },
+        "getOrderedFiles": {
+          "line": 213
         }
       },
       "ipc": {
@@ -3160,7 +3164,7 @@
         "terminal",
         "fileTreeUI",
         "gitChangesPanel",
-        "diffViewer",
+        "diffSection",
         "historyPanel",
         "tasksPanel",
         "tasksDashboard",
@@ -3199,26 +3203,26 @@
           "purpose": "Initialize all modules"
         },
         "setupButtonHandlers": {
-          "line": 223,
+          "line": 220,
           "purpose": "Setup button click handlers"
         },
         "setupProjectSwitcher": {
-          "line": 306,
+          "line": 303,
           "purpose": "and close on outside click / Escape."
         },
         "setupUpdateDot": {
-          "line": 395,
+          "line": 392,
           "purpose": "→ About → \"Dismiss this version\"). Both click open Settings → About."
         },
         "revealSidebarTab": {
-          "line": 426,
+          "line": 423,
           "params": [
             "tabName"
           ],
           "purpose": "commands so they don't try to focus an element inside a hidden container."
         },
         "registerCommands": {
-          "line": 452,
+          "line": 449,
           "purpose": "Command Palette and the global keyboard handler."
         }
       },
@@ -3428,7 +3432,8 @@
         "laneDetailRail",
         "overviewPanel",
         "taskSection",
-        "specSection"
+        "specSection",
+        "diffSection"
       ],
       "functions": {}
     },
@@ -6945,6 +6950,64 @@
         ],
         "emits": []
       }
+    },
+    "renderer/diffSection": {
+      "file": "src/renderer/diffSection.js",
+      "description": "Diff Section Module",
+      "exports": [],
+      "depends": [
+        "electron",
+        "diff2html",
+        "shared/ipcChannels",
+        "lucide",
+        "gitChangesPanel"
+      ],
+      "functions": {
+        "lucideIcon": {
+          "line": 23,
+          "params": [
+            "data",
+            "size = 16"
+          ]
+        },
+        "setHost": {
+          "line": 31,
+          "params": [
+            "h"
+          ]
+        },
+        "open": {
+          "line": 40,
+          "params": [
+            "ref"
+          ],
+          "purpose": "it) or creates one if none."
+        },
+        "createViewport": {
+          "line": 45
+        },
+        "_orderedFiles": {
+          "line": 191
+        },
+        "_basename": {
+          "line": 199,
+          "params": [
+            "p"
+          ]
+        },
+        "_escape": {
+          "line": 205,
+          "params": [
+            "text"
+          ]
+        }
+      },
+      "ipc": {
+        "listens": [
+          "GIT_STATUS_DATA"
+        ],
+        "emits": []
+      }
     }
   },
   "ipcChannels": {
@@ -7624,6 +7687,13 @@
         "module": "main/dialogs",
         "file": "src/main/dialogs.js",
         "description": "Dialogs Module"
+      }
+    ],
+    "diff-section": [
+      {
+        "module": "renderer/diffSection",
+        "file": "src/renderer/diffSection.js",
+        "description": "Diff Section Module"
       }
     ],
     "diff-viewer": [

--- a/index.html
+++ b/index.html
@@ -54,38 +54,18 @@
       ></button>
     </div>
 
-    <div class="sidebar-tabs">
-      <button class="sidebar-tab-btn active" data-sidebar-tab="projects">Projects</button>
-      <button class="sidebar-tab-btn" data-sidebar-tab="files">Files</button>
-      <button class="sidebar-tab-btn" data-sidebar-tab="changes">Changes</button>
-    </div>
-
-    <!-- Projects Tab Content -->
-    <div class="sidebar-tab-content" data-sidebar-tab-content="projects">
-      <div id="project-info">
-        <div>Current Project:</div>
-        <div id="project-path">No project selected</div>
+    <!-- Parked per-project actions (Start AI / Initialize as Frame). Removed
+         from the Projects section for now; kept in the DOM so the ai.startSession
+         command and the init-frame flow stay wired until they get a new home.
+         The default-agent selector now lives in the sidebar footer below. -->
+    <div id="parked-project-actions" hidden>
+      <div class="ai-tool-row">
+        <button id="btn-start-ai" class="btn btn-success" tabindex="-1" disabled>Start Claude Code</button>
       </div>
-
-      <div id="project-actions">
-        <button id="btn-select-project" class="btn" tabindex="-1">Select Project Folder</button>
-        <button id="btn-create-project" class="btn btn-secondary" tabindex="-1">Create New Project</button>
-        <button id="btn-clone-github" class="btn btn-secondary" tabindex="-1">Clone GitHub Repo</button>
-        <div id="clone-github-input-row" style="display:none; gap:4px; margin-top:4px;">
-          <input id="clone-github-url" type="text" placeholder="https://github.com/user/repo" tabindex="-1" style="flex:1; font-size:11px; padding:4px 8px; border-radius:4px; border:1px solid var(--border-color); background:var(--input-bg, #2a2a2a); color:var(--text-color); outline:none;" />
-          <button id="btn-clone-github-confirm" class="btn btn-success" tabindex="-1" style="font-size:11px; padding:4px 8px;">Clone</button>
-          <button id="btn-clone-github-cancel" class="btn btn-secondary" tabindex="-1" style="font-size:11px; padding:4px 8px;">✕</button>
-        </div>
-        <div class="ai-tool-row">
-          <button id="btn-start-ai" class="btn btn-success" tabindex="-1" disabled>Start Claude Code</button>
-          <select id="ai-tool-selector" class="ai-tool-select" tabindex="-1">
-            <option value="claude">Claude</option>
-            <option value="codex">Codex</option>
-          </select>
-        </div>
-        <div class="init-frame-wrapper">
-          <button id="btn-initialize-frame" class="btn btn-frame-init" tabindex="-1" style="display: none;">Initialize as Frame Project</button>
-        </div>
+      <div class="init-frame-wrapper">
+        <button id="btn-initialize-frame" class="btn btn-frame-init" tabindex="-1" style="display: none;">Initialize as Frame Project</button>
+      </div>
+    </div>
 
     <!-- Hover tooltip for Initialize Frame button (fixed position, escapes overflow) -->
     <div id="init-frame-tooltip" class="init-frame-tooltip">
@@ -107,88 +87,190 @@
         <span>+ more</span>
       </div>
     </div>
-      </div>
 
-      <!-- Projects Section -->
-      <div id="projects-section">
-        <div id="projects-header">
-          <span>Projects</span>
-          <button id="btn-add-project" class="btn-icon" tabindex="-1" title="Add Project">+</button>
-        </div>
-        <div id="projects-list">
-          <div class="no-projects-message">No projects yet. Add a project to get started.</div>
-        </div>
-      </div>
-    </div>
+    <!-- Sidebar body: activity rail + the active view's panel. The rail makes
+         Projects / Files / Changes first-class views (editor-style), with
+         Projects as the default landing view. -->
+    <div id="sidebar-body">
+      <nav class="sidebar-rail" aria-label="Sidebar views">
+        <button class="sidebar-tab-btn sidebar-rail-btn active" data-sidebar-tab="projects" title="Projects" aria-label="Projects" tabindex="-1">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/>
+          </svg>
+        </button>
+        <button class="sidebar-tab-btn sidebar-rail-btn" data-sidebar-tab="files" title="Files" aria-label="Files" tabindex="-1">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M20 7h-3a2 2 0 0 1-2-2V2"/><path d="M9 18a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h7l4 4v10a2 2 0 0 1-2 2Z"/><path d="M3 7.6v12.8A1.6 1.6 0 0 0 4.6 22h9.8"/>
+          </svg>
+        </button>
+        <button class="sidebar-tab-btn sidebar-rail-btn" data-sidebar-tab="changes" title="Changes" aria-label="Changes" tabindex="-1">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M15 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7Z"/><path d="M14 2v4a2 2 0 0 0 2 2h4"/><path d="M9 10h6"/><path d="M12 13V7"/><path d="M9 17h6"/>
+          </svg>
+        </button>
+        <button class="sidebar-tab-btn sidebar-rail-btn" data-sidebar-tab="agent" title="Agent" aria-label="Agent" tabindex="-1">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/>
+          </svg>
+        </button>
+      </nav>
 
-    <!-- Files Tab Content -->
-    <div class="sidebar-tab-content" data-sidebar-tab-content="files" style="display:none;">
-      <div id="files-empty-state" class="files-empty">Select a project to browse files</div>
-
-      <div id="file-explorer-header" style="display: none;">
-        <div class="file-explorer-title">
-          <span>Files</span>
-          <button id="btn-refresh-tree" class="btn-icon" tabindex="-1" title="Refresh">
-            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2"/>
+      <div class="sidebar-panel">
+        <!-- Current-project dropdown: shows which project Files / Changes are
+             on, and lets the user switch project right here. Hidden on Projects
+             (the list highlights its own active row). -->
+        <div id="sidebar-current-project-wrap" class="sidebar-current-project-wrap" style="display:none;">
+          <button id="sidebar-current-project" class="sidebar-current-project" tabindex="-1" title="Switch project" aria-haspopup="true" aria-expanded="false">
+            <svg class="sidebar-current-project-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/>
+            </svg>
+            <span class="sidebar-current-project-name" id="sidebar-current-project-name">No project</span>
+            <svg class="sidebar-current-project-caret" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+              <polyline points="6 9 12 15 18 9"/>
             </svg>
           </button>
+          <div id="sidebar-project-menu" class="sidebar-project-menu" role="menu" hidden></div>
         </div>
-        <div class="file-tree-search">
-          <input
-            id="file-tree-search"
-            type="text"
-            placeholder="Filter files…"
-            autocomplete="off"
-            spellcheck="false"
-            tabindex="-1"
-          />
-          <button id="file-tree-search-clear" class="file-tree-search-clear" tabindex="-1" title="Clear filter" type="button">&#x2715;</button>
-        </div>
-      </div>
 
-      <div id="file-tree">
-        <!-- File tree will be populated here -->
+        <!-- Projects view (default): the full workspace list, then an
+             Add new Project button that opens the same modal as the old `+`. -->
+        <div class="sidebar-tab-content sidebar-view-projects" data-sidebar-tab-content="projects">
+          <div id="project-section" class="project-section">
+            <div class="project-section-header">
+              <span class="project-section-title">Projects</span>
+              <button type="button" class="project-section-help" tabindex="-1" aria-label="About projects">
+                <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                  <circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/>
+                </svg>
+              </button>
+              <span class="project-section-help-tip" role="tooltip">When the app first opens, the first project opens automatically. Drag &amp; drop to reorder your projects.</span>
+            </div>
+            <!-- Workspace project list: drag to reorder, fills the view -->
+            <div id="projects-list" class="project-section-list">
+              <div class="no-projects-message">No projects yet. Add a project to get started.</div>
+            </div>
+          </div>
+          <button id="project-add-btn" class="project-add-btn" tabindex="-1" title="Open a project">
+            <span class="project-add-btn-icon">+</span><span>Add new Project</span>
+          </button>
+        </div>
+
+        <!-- Files view -->
+        <div class="sidebar-tab-content" data-sidebar-tab-content="files" style="display:none;">
+          <div id="files-empty-state" class="files-empty">Select a project to browse files</div>
+
+          <div id="file-explorer-header" style="display: none;">
+            <div class="file-tree-search">
+              <div class="file-tree-search-field">
+                <input
+                  id="file-tree-search"
+                  type="text"
+                  placeholder="Filter files…"
+                  autocomplete="off"
+                  spellcheck="false"
+                  tabindex="-1"
+                />
+                <button id="file-tree-search-clear" class="file-tree-search-clear" tabindex="-1" title="Clear filter" type="button">&#x2715;</button>
+              </div>
+              <button id="btn-refresh-tree" class="btn-icon" tabindex="-1" title="Refresh">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M21.5 2v6h-6M2.5 22v-6h6M2 11.5a10 10 0 0 1 18.8-4.3M22 12.5a10 10 0 0 1-18.8 4.2"/>
+                </svg>
+              </button>
+            </div>
+          </div>
+
+          <div id="file-tree">
+            <!-- File tree will be populated here -->
+          </div>
+        </div>
+
+        <!-- Changes view -->
+        <div class="sidebar-tab-content" data-sidebar-tab-content="changes" style="display:none;">
+          <div id="git-changes-empty" class="git-changes-empty">Select a project to see changes</div>
+
+          <div id="git-changes-body" style="display:none;">
+            <div class="git-changes-section" data-git-changes-group="staged" style="display:none;">
+              <div class="git-changes-section-header">Staged Changes</div>
+              <div class="git-changes-list" data-git-changes-list="staged"></div>
+            </div>
+
+            <!-- No header here: "Changes" would duplicate the tab name. Staged /
+                 Conflict sections keep theirs to mark the distinction. -->
+            <div class="git-changes-section" data-git-changes-group="changes" style="display:none;">
+              <div class="git-changes-list" data-git-changes-list="changes"></div>
+            </div>
+
+            <div class="git-changes-section" data-git-changes-group="conflict" style="display:none;">
+              <div class="git-changes-section-header">Merge Conflicts</div>
+              <div class="git-changes-list" data-git-changes-list="conflict"></div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Agent view: default-agent controls (selector + Start) and the live
+             running-agents list across all projects. Replaces the old bottom
+             Agent footer card. -->
+        <div class="sidebar-tab-content sidebar-view-agent" data-sidebar-tab-content="agent" style="display:none;">
+          <div id="sidebar-agent-footer" class="sidebar-agent-footer">
+            <div class="sidebar-agent-footer-head">
+              <span class="sidebar-agent-footer-icon" aria-hidden="true">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                  <path d="M12 8V4H8"/>
+                  <rect width="16" height="12" x="4" y="8" rx="2"/>
+                  <path d="M2 14h2"/>
+                  <path d="M20 14h2"/>
+                  <path d="M15 13v2"/>
+                  <path d="M9 13v2"/>
+                </svg>
+              </span>
+              <span class="sidebar-agent-footer-label">Default Agent</span>
+            </div>
+            <div class="sidebar-agent-footer-row">
+              <select id="ai-tool-selector" class="ai-tool-select" tabindex="-1" title="Default agent">
+                <option value="claude">Claude</option>
+                <option value="codex">Codex</option>
+              </select>
+              <button id="sidebar-agent-launch" class="sidebar-agent-launch" tabindex="-1" title="Start default agent">
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor" stroke="none" aria-hidden="true">
+                  <path d="M8 5v14l11-7z"/>
+                </svg>
+                <span>Start</span>
+              </button>
+            </div>
+          </div>
+
+          <div class="agent-running-header">
+            <span class="agent-running-header-label">Running agents</span>
+            <button type="button" class="agent-running-help" tabindex="-1" aria-label="About running agents">
+              <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/>
+              </svg>
+            </button>
+            <span class="agent-running-help-tip" role="tooltip">Here you can see agents running across all your projects — not just the current one.</span>
+          </div>
+          <div id="agent-running-list" class="agent-running-list">
+            <div class="agent-running-empty">No agents running — pick an agent and hit Start.</div>
+          </div>
+        </div>
+
+        <!-- Update Available Banner -->
+        <button
+          type="button"
+          id="sidebar-update-banner"
+          class="sidebar-update-banner"
+          style="display:none;"
+          aria-label="Update available, click to view details"
+        >
+          <span class="sidebar-update-banner-icon">&uarr;</span>
+          <span class="sidebar-update-banner-text">
+            <span class="sidebar-update-banner-title">New version available</span>
+            <span class="sidebar-update-banner-version" id="sidebar-update-banner-version">v0.0.0</span>
+          </span>
+          <span class="sidebar-update-banner-arrow">&rarr;</span>
+        </button>
       </div>
     </div>
-
-    <!-- Changes Tab Content -->
-    <div class="sidebar-tab-content" data-sidebar-tab-content="changes" style="display:none;">
-      <div id="git-changes-empty" class="git-changes-empty">Select a project to see changes</div>
-
-      <div id="git-changes-body" style="display:none;">
-        <div class="git-changes-section" data-git-changes-group="staged" style="display:none;">
-          <div class="git-changes-section-header">Staged Changes</div>
-          <div class="git-changes-list" data-git-changes-list="staged"></div>
-        </div>
-
-        <div class="git-changes-section" data-git-changes-group="changes" style="display:none;">
-          <div class="git-changes-section-header">Changes</div>
-          <div class="git-changes-list" data-git-changes-list="changes"></div>
-        </div>
-
-        <div class="git-changes-section" data-git-changes-group="conflict" style="display:none;">
-          <div class="git-changes-section-header">Merge Conflicts</div>
-          <div class="git-changes-list" data-git-changes-list="conflict"></div>
-        </div>
-      </div>
-    </div>
-
-    <!-- Update Available Banner (sidebar footer) -->
-    <button
-      type="button"
-      id="sidebar-update-banner"
-      class="sidebar-update-banner"
-      style="display:none;"
-      aria-label="Update available, click to view details"
-    >
-      <span class="sidebar-update-banner-icon">&uarr;</span>
-      <span class="sidebar-update-banner-text">
-        <span class="sidebar-update-banner-title">New version available</span>
-        <span class="sidebar-update-banner-version" id="sidebar-update-banner-version">v0.0.0</span>
-      </span>
-      <span class="sidebar-update-banner-arrow">&rarr;</span>
-    </button>
   </div>
 
   <!-- Main Content Area -->
@@ -554,6 +636,7 @@
           <button class="modal-close" id="init-frame-modal-close">&#x2715;</button>
         </div>
         <div class="modal-body">
+          <p class="init-modal-lead">This project isn't set up with Frame yet. Initialize it to enable AI context, task tracking, and session notes.</p>
           <p class="init-modal-description">This will create the following files in your project:</p>
           <ul class="init-modal-file-list">
             <li><span class="file-icon">&#128193;</span> .frame/ <span class="file-desc">config directory</span></li>
@@ -572,8 +655,60 @@
           </div>
         </div>
         <div class="modal-footer">
-          <button class="modal-btn modal-btn-cancel" id="init-frame-cancel">Cancel</button>
+          <label class="init-modal-dontask" title="Stops asking for this project until you restart Frame">
+            <input type="checkbox" id="init-frame-dontask"> Don't ask again for this project
+          </label>
+          <button class="modal-btn modal-btn-cancel" id="init-frame-cancel">Not Now</button>
           <button class="modal-btn modal-btn-primary" id="init-frame-confirm">Initialize</button>
+        </div>
+      </div>
+    </div>
+
+    <!-- Open Project Modal -->
+    <div id="open-project-modal" class="modal-overlay">
+      <div class="modal-container">
+        <div class="modal-header">
+          <h3>Open a Project</h3>
+          <button class="modal-close" id="open-project-modal-close">&#x2715;</button>
+        </div>
+        <div class="modal-body">
+          <div class="open-project-options">
+            <button type="button" id="open-project-select" class="open-project-option">
+              <span class="open-project-option-icon">&#128193;</span>
+              <span class="open-project-option-text">
+                <span class="open-project-option-title">Select Project Folder</span>
+                <span class="open-project-option-desc">Open an existing folder on your machine</span>
+              </span>
+            </button>
+            <button type="button" id="open-project-create" class="open-project-option">
+              <span class="open-project-option-icon">&#10024;</span>
+              <span class="open-project-option-text">
+                <span class="open-project-option-title">Create New Project</span>
+                <span class="open-project-option-desc">Choose a location for a new project</span>
+              </span>
+            </button>
+            <button type="button" id="open-project-clone-toggle" class="open-project-option">
+              <span class="open-project-option-icon">&#128279;</span>
+              <span class="open-project-option-text">
+                <span class="open-project-option-title">Clone GitHub Repo</span>
+                <span class="open-project-option-desc">Clone a repository by its URL</span>
+              </span>
+            </button>
+          </div>
+          <div id="open-project-clone-form" class="open-project-clone-form" style="display:none;">
+            <input
+              id="open-project-clone-url"
+              type="text"
+              placeholder="https://github.com/user/repo"
+              autocomplete="off"
+              spellcheck="false"
+            />
+            <div id="open-project-clone-error" class="open-project-clone-error" style="display:none;"></div>
+          </div>
+        </div>
+        <div class="modal-footer" id="open-project-clone-footer" style="display:none;">
+          <button class="modal-btn modal-btn-cancel" id="open-project-clone-cancel">Back</button>
+          <button class="modal-btn modal-btn-primary" id="open-project-clone-confirm">Clone</button>
         </div>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -195,9 +195,8 @@
               <div class="git-changes-list" data-git-changes-list="staged"></div>
             </div>
 
-            <!-- No header here: "Changes" would duplicate the tab name. Staged /
-                 Conflict sections keep theirs to mark the distinction. -->
             <div class="git-changes-section" data-git-changes-group="changes" style="display:none;">
+              <div class="git-changes-section-header">Unstaged</div>
               <div class="git-changes-list" data-git-changes-list="changes"></div>
             </div>
 
@@ -1101,7 +1100,7 @@
         </div>
       </div>
       <div id="diff-viewer-content">
-        <div id="diff-viewer-host"></div>
+        <div id="diff-viewer-host" class="frame-diff"></div>
         <div id="diff-viewer-empty" style="display:none;"></div>
       </div>
     </div>

--- a/src/main/workspace.js
+++ b/src/main/workspace.js
@@ -125,6 +125,28 @@ function removeProject(projectPath) {
 }
 
 /**
+ * Reorder the active workspace's projects to match the given list of paths.
+ * Paths not present in `orderedPaths` keep their relative order at the end, so a
+ * stale/partial order never drops projects.
+ */
+function reorderProjects(orderedPaths) {
+  if (!Array.isArray(orderedPaths)) return;
+  const workspace = loadWorkspace();
+  const active = workspace.activeWorkspace;
+  const projects = workspace.workspaces[active].projects;
+
+  const rank = new Map(orderedPaths.map((p, i) => [p, i]));
+  const next = orderedPaths.length;
+  workspace.workspaces[active].projects = [...projects].sort((a, b) => {
+    const ra = rank.has(a.path) ? rank.get(a.path) : next;
+    const rb = rank.has(b.path) ? rank.get(b.path) : next;
+    return ra - rb;
+  });
+
+  saveWorkspace(workspace);
+}
+
+/**
  * Update project's last opened timestamp
  */
 function updateProjectLastOpened(projectPath) {
@@ -176,6 +198,12 @@ function setupIPC(ipcMain) {
     const projects = getProjects();
     event.sender.send(IPC.WORKSPACE_UPDATED, projects);
   });
+
+  ipcMain.on(IPC.REORDER_WORKSPACE_PROJECTS, (event, orderedPaths) => {
+    reorderProjects(orderedPaths);
+    // No WORKSPACE_UPDATED echo: the renderer already applied the new order
+    // optimistically, and re-rendering mid-drag would fight the user.
+  });
 }
 
 module.exports = {
@@ -184,6 +212,7 @@ module.exports = {
   getProjects,
   addProject,
   removeProject,
+  reorderProjects,
   updateProjectLastOpened,
   updateProjectFrameStatus,
   setupIPC

--- a/src/renderer/agentDispatch.js
+++ b/src/renderer/agentDispatch.js
@@ -151,6 +151,113 @@ async function dispatch({ terminalId = null, createNew = false, toolId = null, p
   return { success: true, terminalId: targetId, error: null };
 }
 
+/**
+ * Start the default agent (the active AI tool) from the sidebar shortcut —
+ * a prompt-less launch, unlike dispatch() which delivers a prompt.
+ *
+ * Context decides the target:
+ *   - On the Frames surface (viewMode 'detail') the focused Frame is the
+ *     target. If it's idle the agent starts right there; if it's busy
+ *     (a live agent or a foreground process) the user is asked whether to
+ *     open a new Frame or kill this one and start fresh.
+ *   - Anywhere else (Home / any other tab) it always opens a new Frame.
+ */
+async function startDefaultAgent() {
+  if (!multiTerminalUI) {
+    _showToast('Terminal system is not ready yet', 'error');
+    return;
+  }
+  if (!state.getProjectPath()) {
+    _showToast('Open a project first', 'error');
+    return;
+  }
+
+  const manager = multiTerminalUI.getManager();
+  const focusedId = manager.activeTerminalId;
+  const onFrames = multiTerminalUI.isViewingFrame() && focusedId && manager.getTerminal(focusedId);
+
+  if (!onFrames) {
+    _startAgentInNewFrame();
+    return;
+  }
+
+  const s = laneStatus.getStatus(focusedId);
+  const idle = !s.agentName && s.status === 'idle';
+  if (idle) {
+    _startAgentIn(focusedId);
+    return;
+  }
+
+  // Focused Frame is busy — let the user decide rather than clobbering it.
+  const choice = await _askNewOrRestart(_laneName(focusedId), !!s.agentName);
+  if (choice === 'cancel') return;
+  if (choice === 'restart') manager.closeTerminal(focusedId);
+  _startAgentInNewFrame();
+}
+
+// Start the active tool's CLI in an existing lane. `fresh` allows a newly
+// spawned shell a beat to accept input before the command is typed.
+function _startAgentIn(terminalId, { fresh = false } = {}) {
+  multiTerminalUI.enterLane(terminalId);
+  const startCommand = require('./aiToolSelector').getStartCommand();
+  if (!startCommand) {
+    _showToast('No AI CLI selected', 'error');
+    return;
+  }
+  setTimeout(() => multiTerminalUI.sendCommand(startCommand, terminalId), fresh ? 800 : 50);
+}
+
+async function _startAgentInNewFrame() {
+  let id = null;
+  try {
+    id = await multiTerminalUI.createTerminalForCurrentProject();
+  } catch (err) {
+    console.error('agentDispatch: terminal creation failed', err);
+  }
+  if (!id) {
+    const max = multiTerminalUI.getManager().maxTerminals;
+    _showToast(`Could not create a new Frame — maximum (${max}) may be reached for this project`, 'error');
+    return;
+  }
+  _startAgentIn(id, { fresh: true });
+}
+
+// "Open a new Frame / Kill & restart here" — asked when the focused Frame is
+// busy. Resolves 'new' | 'restart' | 'cancel'; opening a new Frame is the
+// safe default (never silently kills running work).
+function _askNewOrRestart(frameName, hasAgent) {
+  return new Promise((resolve) => {
+    const what = hasAgent ? 'a running agent' : 'a running process';
+    const overlay = document.createElement('div');
+    overlay.className = 'spec-modal-overlay';
+    overlay.innerHTML = `
+      <div class="spec-modal" role="dialog" aria-modal="true" aria-labelledby="launch-lane-title">
+        <h3 id="launch-lane-title">This Frame is busy</h3>
+        <p><strong>${_escapeHtml(frameName)}</strong> already has ${what}. Where should the agent start?</p>
+        <div class="spec-modal-actions">
+          <button type="button" class="btn btn-secondary launch-restart">Kill &amp; restart here</button>
+          <button type="button" class="btn btn-primary launch-new-frame">Open a new Frame</button>
+        </div>
+      </div>
+    `;
+    document.body.appendChild(overlay);
+
+    const done = (choice) => {
+      overlay.remove();
+      resolve(choice);
+    };
+    overlay.querySelector('.launch-new-frame').addEventListener('click', () => done('new'));
+    overlay.querySelector('.launch-restart').addEventListener('click', () => done('restart'));
+    overlay.addEventListener('click', (e) => {
+      if (e.target === overlay) done('cancel');
+    });
+    overlay.addEventListener('keydown', (e) => {
+      if (e.key === 'Escape') done('cancel');
+    });
+    setTimeout(() => overlay.querySelector('.launch-new-frame').focus(), 30);
+  });
+}
+
 // ─── Spec lane assignments ──────────────────────────────────
 //
 // Which lane each spec (slug) is working in. Functional state, kept
@@ -495,6 +602,7 @@ function _showToast(message, type = 'info') {
 module.exports = {
   init,
   dispatch,
+  startDefaultAgent,
   dispatchSpecCommand,
   getSpecLaneInfo,
   getTaskLaneInfo,

--- a/src/renderer/agentPanel.js
+++ b/src/renderer/agentPanel.js
@@ -1,0 +1,173 @@
+/**
+ * Agent Panel
+ *
+ * The Agent rail view's "Running agents" list: one row per Frame that
+ * currently has a live agent, across ALL projects. Each row shows the agent,
+ * its Frame (and project, when not the active one) and a live status; clicking
+ * focuses that Frame — switching project first when the agent runs elsewhere.
+ *
+ * Derived state only: the list is recomputed from laneStatus + the open-
+ * terminal set on every change, so a crashed agent or a closed Frame can never
+ * leave a stale row (no stored "running" flag to forget to clear). Initialized
+ * with the MultiTerminalUI instance, the same idiom as laneStatus / agentDispatch.
+ */
+
+const { ipcRenderer } = require('electron');
+const { IPC } = require('../shared/ipcChannels');
+const laneStatus = require('./laneStatus');
+const state = require('./state');
+
+let multiTerminalUI = null;
+let listEl = null;
+let scheduled = false;
+
+// status → { dot flavor, label }. Only attention/activity states are mapped;
+// anything else (a live agent sitting at a settled prompt) reads as "Ready".
+const STATUS_META = {
+  'agent-working': { flavor: 'working', label: 'Working' },
+  'agent-approval': { flavor: 'approval', label: 'Needs approval' },
+  'agent-input': { flavor: 'input', label: 'Awaiting input' }
+};
+
+/**
+ * @param {object} ui - the live MultiTerminalUI (for getManager()).
+ */
+function init(ui) {
+  multiTerminalUI = ui;
+  listEl = document.getElementById('agent-running-list');
+
+  // Status transitions emit through laneStatus; a destroyed terminal does not,
+  // so recompute on destroy too. Both paths are debounced to one rAF.
+  laneStatus.onChange(() => schedule());
+  ipcRenderer.on(IPC.TERMINAL_DESTROYED, () => schedule());
+
+  recompute();
+}
+
+function schedule() {
+  if (scheduled) return;
+  scheduled = true;
+  requestAnimationFrame(() => {
+    scheduled = false;
+    recompute();
+  });
+}
+
+/**
+ * Rebuild the running-agents list from the live terminal + status state,
+ * grouped under a heading per project (active project first).
+ */
+function recompute() {
+  if (!listEl || !multiTerminalUI) return;
+
+  let states;
+  try {
+    states = multiTerminalUI.getManager().getTerminalStates(true);
+  } catch (_) {
+    states = [];
+  }
+
+  const currentProject = state.getProjectPath();
+  const nameByPath = _projectNames();
+
+  // Group agents by their project path. Map preserves first-seen order, which
+  // we then nudge so the active project sorts to the top.
+  const groups = new Map(); // path -> { name, agents: [] }
+  for (const s of states) {
+    const st = laneStatus.getStatus(s.id);
+    if (!st.agentName) continue; // only lanes with a live agent process
+    const path = s.projectPath || null;
+    if (!groups.has(path)) {
+      groups.set(path, {
+        name: path ? (nameByPath.get(path) || _basename(path)) : 'No project',
+        agents: []
+      });
+    }
+    groups.get(path).agents.push({
+      id: s.id,
+      agentName: st.agentName,
+      status: st.status,
+      frameName: s.customName || s.name,
+      projectPath: path
+    });
+  }
+
+  if (groups.size === 0) {
+    listEl.innerHTML = '<div class="agent-running-empty">No agents running — pick an agent and hit Start.</div>';
+    return;
+  }
+
+  const ordered = [...groups.entries()].sort(
+    (a, b) => (a[0] === currentProject ? 0 : 1) - (b[0] === currentProject ? 0 : 1)
+  );
+
+  listEl.innerHTML = '';
+  for (const [, group] of ordered) {
+    const groupEl = document.createElement('div');
+    groupEl.className = 'agent-running-group';
+
+    const title = document.createElement('div');
+    title.className = 'agent-running-group-title';
+    title.innerHTML = '<svg class="agent-running-group-icon" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">'
+      + '<path d="m7.5 4.27 9 5.15"/><path d="M21 8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16Z"/><path d="m3.3 7 8.7 5 8.7-5"/><path d="M12 22V12"/>'
+      + '</svg><span class="agent-running-group-name"></span>';
+    title.querySelector('.agent-running-group-name').textContent = group.name;
+    groupEl.appendChild(title);
+
+    for (const a of group.agents) groupEl.appendChild(_buildRow(a));
+    listEl.appendChild(groupEl);
+  }
+}
+
+// One running-agent row. The project is already the group heading, so the
+// sub-line is just the Frame name.
+function _buildRow(a) {
+  const meta = STATUS_META[a.status] || { flavor: 'ready', label: 'Ready' };
+  const row = document.createElement('button');
+  row.type = 'button';
+  row.className = 'agent-running-item';
+  row.title = `Focus ${a.frameName}`;
+  row.innerHTML = `
+    <span class="agent-running-dot ${meta.flavor}"></span>
+    <span class="agent-running-info">
+      <span class="agent-running-name"></span>
+      <span class="agent-running-sub"></span>
+    </span>
+    <span class="agent-running-status ${meta.flavor}"></span>
+  `;
+  row.querySelector('.agent-running-name').textContent = _label(a.agentName);
+  row.querySelector('.agent-running-sub').textContent = a.frameName;
+  row.querySelector('.agent-running-status').textContent = meta.label;
+  row.addEventListener('click', () => _focus(a));
+  return row;
+}
+
+// path -> the workspace's display name for that project (fallback: basename).
+function _projectNames() {
+  const map = new Map();
+  try {
+    for (const p of require('./projectListUI').getProjects()) map.set(p.path, p.name);
+  } catch (_) { /* projectListUI not ready — basenames are fine */ }
+  return map;
+}
+
+// Focus the agent's Frame. When it lives in another project, switch to that
+// project first (state.setProjectPath drives multiTerminalUI.setCurrentProject)
+// so the lane is in view before we enter it.
+function _focus(a) {
+  if (!multiTerminalUI) return;
+  if (a.projectPath && a.projectPath !== state.getProjectPath()) {
+    state.setProjectPath(a.projectPath);
+  }
+  multiTerminalUI.enterLane(a.id);
+}
+
+function _label(agentName) {
+  return agentName ? agentName.charAt(0).toUpperCase() + agentName.slice(1) : 'Agent';
+}
+
+function _basename(p) {
+  return p.split('/').pop() || p.split('\\').pop() || p;
+}
+
+module.exports = { init, recompute };

--- a/src/renderer/diffSection.js
+++ b/src/renderer/diffSection.js
@@ -1,0 +1,212 @@
+/**
+ * Diff Section Module
+ *
+ * Opens a git diff as a *section viewport* (a tab next to Home / Frames),
+ * replacing the old read-only overlay. One diff tab is reused and navigated in
+ * place: clicking another changed file — or the ◀ / ▶ arrows in the header —
+ * switches the viewed file without spawning tabs. The arrow nav walks the same
+ * ordered set of changed files the Changes sidebar shows (via
+ * gitChangesPanel.getOrderedFiles()).
+ *
+ * Diff text comes from main (`GET_GIT_DIFF`) and is rendered with diff2html,
+ * reusing the shared `.frame-diff` dark-theme styling.
+ */
+
+const { ipcRenderer } = require('electron');
+const { html: renderDiffHtml } = require('diff2html');
+const { IPC } = require('../shared/ipcChannels');
+const { ChevronLeft, ChevronRight } = require('lucide');
+
+let host = null; // multiTerminalUI
+let seq = 0;
+
+function lucideIcon(data, size = 16) {
+  const children = data.map(([tag, attrs]) => {
+    const attrStr = Object.entries(attrs).map(([k, v]) => `${k}="${v}"`).join(' ');
+    return `<${tag} ${attrStr}/>`;
+  }).join('');
+  return `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">${children}</svg>`;
+}
+
+function setHost(h) {
+  host = h;
+}
+
+/**
+ * Open the diff for a changed file — reuses the open diff viewport (navigates
+ * it) or creates one if none.
+ * @param {{ projectPath: string, relPath: string, staged: boolean }} ref
+ */
+function open(ref) {
+  if (!host || !ref || !ref.relPath) return;
+  host.openSection('diff', ref, api, { newTab: false });
+}
+
+function createViewport() {
+  const key = `diff-vp:${++seq}`;
+  let cur = null;           // { projectPath, relPath, staged }
+  let files = [];           // ordered nav set (snapshot, refreshed on git status)
+  let mode = 'side-by-side';
+  let diffText = '';
+  let loading = false;
+  let message = '';         // empty/binary/error message in place of a diff
+  let reqId = 0;
+  let container = null;
+
+  // Keep the nav set + the current diff fresh as the working tree changes.
+  // Silent: the current diff stays on screen until the refreshed one arrives,
+  // so a background git refresh never flickers a "Loading…" over your scroll.
+  const onGitStatus = () => {
+    files = _orderedFiles();
+    if (cur) _load(true);
+    else if (host) host.notifySectionChanged();
+  };
+  ipcRenderer.on(IPC.GIT_STATUS_DATA, onGitStatus);
+
+  function navigate(ref) {
+    if (!ref) return;
+    cur = { projectPath: ref.projectPath, relPath: ref.relPath, staged: !!ref.staged };
+    files = _orderedFiles();
+    _load(false);
+  }
+
+  // Fetch the current file's diff, then re-render via the host.
+  async function _load(silent) {
+    if (!cur) return;
+    const id = ++reqId;
+    if (!silent) {
+      loading = true;
+      message = '';
+      diffText = '';
+      if (host) host.notifySectionChanged();
+    }
+
+    let result;
+    try {
+      result = await ipcRenderer.invoke(IPC.GET_GIT_DIFF, {
+        projectPath: cur.projectPath,
+        relPath: cur.relPath,
+        staged: cur.staged
+      });
+    } catch (err) {
+      if (id !== reqId) return;
+      loading = false;
+      message = `Failed to load diff: ${err && err.message ? err.message : err}`;
+      if (host) host.notifySectionChanged();
+      return;
+    }
+    if (id !== reqId) return; // superseded by a newer navigate
+
+    loading = false;
+    if (result && result.isBinary) {
+      message = 'Binary file — diff not shown';
+    } else {
+      diffText = (result && result.diff) || '';
+      if (!diffText.trim()) message = 'No changes to show';
+    }
+    if (host) host.notifySectionChanged();
+  }
+
+  function _currentIndex() {
+    if (!cur) return -1;
+    return files.findIndex((f) => f.relPath === cur.relPath && !!f.staged === !!cur.staged);
+  }
+
+  function _step(delta) {
+    const idx = _currentIndex();
+    if (idx === -1) return;
+    const next = files[idx + delta];
+    if (!next) return;
+    navigate({ projectPath: cur.projectPath, relPath: next.relPath, staged: next.staged });
+  }
+
+  function getChip() {
+    return { type: 'diff', title: cur ? _basename(cur.relPath) : 'Diff' };
+  }
+
+  function render(el) {
+    container = el;
+    const idx = _currentIndex();
+    const total = files.length;
+    const hasPrev = idx > 0;
+    const hasNext = idx >= 0 && idx < total - 1;
+    const pos = idx >= 0 && total > 1 ? `${idx + 1} / ${total}` : '';
+
+    el.innerHTML = `
+      <div class="diff-section">
+        <div class="diff-section-header">
+          <div class="diff-section-nav">
+            <button class="diff-section-arrow" data-step="-1" ${hasPrev ? '' : 'disabled'} title="Previous file">${lucideIcon(ChevronLeft, 18)}</button>
+            <button class="diff-section-arrow" data-step="1" ${hasNext ? '' : 'disabled'} title="Next file">${lucideIcon(ChevronRight, 18)}</button>
+          </div>
+          <div class="diff-section-title">
+            <span class="diff-section-filename">${_escape(cur ? cur.relPath : '')}</span>
+            <span class="diff-section-pill" data-pill="${cur && cur.staged ? 'staged' : 'working'}">${cur && cur.staged ? 'Staged' : 'Unstaged'}</span>
+            ${pos ? `<span class="diff-section-pos">${pos}</span>` : ''}
+          </div>
+          <div class="diff-section-modes" role="group" aria-label="Diff display mode">
+            <button class="diff-section-mode ${mode === 'side-by-side' ? 'active' : ''}" data-mode="side-by-side">Split</button>
+            <button class="diff-section-mode ${mode === 'line-by-line' ? 'active' : ''}" data-mode="line-by-line">Unified</button>
+          </div>
+        </div>
+        <div class="diff-section-body">
+          ${loading
+            ? '<div class="diff-section-empty">Loading diff…</div>'
+            : message
+              ? `<div class="diff-section-empty">${_escape(message)}</div>`
+              : `<div class="diff-section-host frame-diff"></div>`}
+        </div>
+      </div>
+    `;
+
+    if (!loading && !message && diffText) {
+      const hostEl = el.querySelector('.diff-section-host');
+      hostEl.innerHTML = renderDiffHtml(diffText, {
+        drawFileList: false,
+        matching: 'lines',
+        outputFormat: mode
+      });
+    }
+
+    el.querySelectorAll('.diff-section-arrow').forEach((btn) => {
+      btn.addEventListener('click', () => _step(parseInt(btn.dataset.step, 10)));
+    });
+    el.querySelectorAll('.diff-section-mode').forEach((btn) => {
+      btn.addEventListener('click', () => {
+        if (btn.dataset.mode === mode) return;
+        mode = btn.dataset.mode;
+        if (host) host.notifySectionChanged();
+      });
+    });
+  }
+
+  function dispose() {
+    ipcRenderer.removeListener(IPC.GIT_STATUS_DATA, onGitStatus);
+    container = null;
+  }
+
+  return { type: 'diff', key, viewClass: 'section-view', navigate, getChip, render, dispose };
+}
+
+function _orderedFiles() {
+  try {
+    return require('./gitChangesPanel').getOrderedFiles();
+  } catch (_) {
+    return [];
+  }
+}
+
+function _basename(p) {
+  if (!p) return '';
+  const i = p.lastIndexOf('/');
+  return i >= 0 ? p.slice(i + 1) : p;
+}
+
+function _escape(text) {
+  const div = document.createElement('div');
+  div.textContent = text == null ? '' : String(text);
+  return div.innerHTML;
+}
+
+const api = { setHost, open, createViewport };
+module.exports = api;

--- a/src/renderer/gitChangesPanel.js
+++ b/src/renderer/gitChangesPanel.js
@@ -18,6 +18,9 @@ let lists = { staged: null, changes: null, conflict: null };
 
 let currentProjectPath = null;
 let onRowClick = null;
+// Flat, display-order list of changed files ({ relPath, staged, group }) — the
+// diff section reads this for its prev/next navigation.
+let lastOrdered = [];
 
 function init(opts = {}) {
   emptyEl = document.getElementById('git-changes-empty');
@@ -54,12 +57,20 @@ function handleStatus(payload) {
   currentProjectPath = payload.projectPath || null;
 
   if (!payload.isRepo) {
+    lastOrdered = [];
     showMessage('Not a git repository');
     return;
   }
 
   const buckets = partition(payload.files || {});
   const total = buckets.staged.length + buckets.changes.length + buckets.conflict.length;
+
+  // Flat nav order matches the on-screen order: staged → changes → conflict.
+  lastOrdered = [
+    ...buckets.staged.map((e) => ({ relPath: e.relPath, staged: true, group: 'staged' })),
+    ...buckets.changes.map((e) => ({ relPath: e.relPath, staged: false, group: 'changes' })),
+    ...buckets.conflict.map((e) => ({ relPath: e.relPath, staged: false, group: 'conflict' }))
+  ];
 
   if (total === 0) {
     showMessage('Working tree clean');
@@ -198,4 +209,9 @@ function normalize(ch) {
   return ch;
 }
 
-module.exports = { init };
+/** Current changed files in display order (for the diff section's prev/next). */
+function getOrderedFiles() {
+  return lastOrdered.slice();
+}
+
+module.exports = { init, getOrderedFiles };

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -23,6 +23,10 @@ const specPanelResize = require('./specPanelResize');
 const specsDashboard = require('./specsDashboard');
 const state = require('./state');
 const projectListUI = require('./projectListUI');
+const openProjectModal = require('./openProjectModal');
+const projectSection = require('./projectSection');
+const projectStatusBadges = require('./projectStatusBadges');
+const agentPanel = require('./agentPanel');
 const editor = require('./editor');
 const sidebarResize = require('./sidebarResize');
 const aiToolSelector = require('./aiToolSelector');
@@ -49,7 +53,6 @@ function init() {
 
   // Initialize state management
   state.init({
-    pathElement: document.getElementById('project-path'),
     startClaudeBtn: document.getElementById('btn-start-ai'),
     fileExplorerHeader: document.getElementById('file-explorer-header'),
     initializeFrameBtn: document.getElementById('btn-initialize-frame')
@@ -70,6 +73,13 @@ function init() {
 
   // Load projects from workspace
   projectListUI.loadProjects();
+
+  // Surface background-project agent activity (needs-approval / waiting-for-input)
+  // as badges on the project rows.
+  projectStatusBadges.init(multiTerminalUI);
+
+  // Agent rail view: live list of running agents across all projects.
+  agentPanel.init(multiTerminalUI);
 
   // Initialize file tree UI
   fileTreeUI.init('file-tree', state.getProjectPath);
@@ -177,6 +187,12 @@ function init() {
     tasksPanel.loadTasks();
   });
 
+  // Initialize the Open Project modal (shell over the existing open flows)
+  openProjectModal.init();
+
+  // Initialize the pinned Projects section (root-level project switcher)
+  projectSection.init();
+
   // Setup button handlers
   setupButtonHandlers();
 
@@ -205,53 +221,19 @@ function init() {
  * Setup button click handlers
  */
 function setupButtonHandlers() {
-  // Select project folder
-  document.getElementById('btn-select-project').addEventListener('click', () => {
-    state.selectProjectFolder();
-  });
-
-  // Create new project
-  document.getElementById('btn-create-project').addEventListener('click', () => {
-    state.createNewProject();
-  });
-
-  // Clone GitHub repo
-  const cloneInputRow = document.getElementById('clone-github-input-row');
-  const cloneUrlInput = document.getElementById('clone-github-url');
-
-  document.getElementById('btn-clone-github').addEventListener('click', () => {
-    cloneInputRow.style.display = 'flex';
-    cloneUrlInput.focus();
-  });
-
-  document.getElementById('btn-clone-github-cancel').addEventListener('click', () => {
-    cloneInputRow.style.display = 'none';
-    cloneUrlInput.value = '';
-  });
-
-  document.getElementById('btn-clone-github-confirm').addEventListener('click', () => {
-    const url = cloneUrlInput.value.trim();
-    if (!url) return;
-    cloneInputRow.style.display = 'none';
-    cloneUrlInput.value = '';
-    ipcRenderer.send(IPC.CLONE_GITHUB_REPO, url);
-  });
-
-  cloneUrlInput.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') {
-      document.getElementById('btn-clone-github-confirm').click();
-    } else if (e.key === 'Escape') {
-      document.getElementById('btn-clone-github-cancel').click();
-    }
-  });
-
+  // Clone GitHub result. The clone request is sent from the Open Project modal
+  // (openProjectModal.js); here we just route the result back to it: on success
+  // open the project + close the modal, on failure show the error inline (or a
+  // dialog if the modal isn't open).
   ipcRenderer.on(IPC.CLONE_GITHUB_REPO_RESULT, (event, result) => {
     if (result.cancelled) return;
-    if (!result.success) {
-      alert('Clone failed:\n' + result.error);
+    if (result.success) {
+      state.setProjectPath(result.projectPath);
+      openProjectModal.handleCloneResult(result);
       return;
     }
-    state.setProjectPath(result.projectPath);
+    const consumed = openProjectModal.handleCloneResult(result);
+    if (!consumed) alert('Clone failed:\n' + result.error);
   });
 
   // Start AI Tool (Claude Code / Codex CLI / etc.)
@@ -274,6 +256,13 @@ function setupButtonHandlers() {
     }
   });
 
+  // Sidebar "Start default agent" shortcut — context decides whether it
+  // starts in the focused Frame, a new Frame, or after a kill-and-restart
+  // prompt (see agentDispatch.startDefaultAgent).
+  document.getElementById('sidebar-agent-launch').addEventListener('click', () => {
+    require('./agentDispatch').startDefaultAgent();
+  });
+
   // Refresh file tree
   document.getElementById('btn-refresh-tree').addEventListener('click', () => {
     fileTreeUI.refreshFileTree();
@@ -284,28 +273,114 @@ function setupButtonHandlers() {
     historyPanel.toggleHistoryPanel();
   });
 
-  // Add project to workspace
-  document.getElementById('btn-add-project').addEventListener('click', () => {
-    state.selectProjectFolder();
-  });
-
   // Initialize as Frame project
   document.getElementById('btn-initialize-frame').addEventListener('click', () => {
     state.initializeAsFrameProject();
   });
 
-  // Sidebar tabs
+  // Sidebar activity rail (Projects / Files / Changes). Bound to the button,
+  // not e.target — clicks land on the inner SVG/path otherwise.
   document.querySelectorAll('.sidebar-tab-btn').forEach(btn => {
-    btn.addEventListener('click', (e) => {
-      const tab = e.target.dataset.sidebarTab;
-      document.querySelectorAll('.sidebar-tab-btn').forEach(b => {
-        b.classList.toggle('active', b.dataset.sidebarTab === tab);
+    btn.addEventListener('click', () => revealSidebarTab(btn.dataset.sidebarTab));
+  });
+
+  // Current-project switcher (Files / Changes views): reflects the active
+  // project and opens a dropdown to switch project without leaving the view.
+  const currentProjectNameEl = document.getElementById('sidebar-current-project-name');
+  const renderCurrentProject = () => {
+    if (!currentProjectNameEl) return;
+    const path = state.getProjectPath();
+    const name = path ? (path.split('/').pop() || path.split('\\').pop()) : null;
+    currentProjectNameEl.textContent = name || 'No project';
+  };
+  state.onProjectChange(renderCurrentProject);
+  renderCurrentProject();
+  setupProjectSwitcher();
+}
+
+/**
+ * Wire the current-project dropdown: build the project list on open, switch on
+ * select (reuses projectListUI.selectProject, the same path as clicking a row),
+ * and close on outside click / Escape.
+ */
+function setupProjectSwitcher() {
+  const btn = document.getElementById('sidebar-current-project');
+  const menu = document.getElementById('sidebar-project-menu');
+  if (!btn || !menu) return;
+
+  const CHECK = '<svg class="sidebar-project-menu-item-check" width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><polyline points="20 6 9 17 4 12"/></svg>';
+
+  const close = () => {
+    if (menu.hidden) return;
+    menu.hidden = true;
+    btn.setAttribute('aria-expanded', 'false');
+    document.removeEventListener('click', onDocClick, true);
+    document.removeEventListener('keydown', onKeydown, true);
+  };
+
+  const onDocClick = (e) => {
+    if (!menu.contains(e.target) && !btn.contains(e.target)) close();
+  };
+  const onKeydown = (e) => {
+    if (e.key === 'Escape') close();
+  };
+
+  const open = () => {
+    const projects = projectListUI.getProjects();
+    const active = projectListUI.getActiveProject();
+    menu.innerHTML = '';
+
+    if (!projects.length) {
+      const empty = document.createElement('div');
+      empty.className = 'sidebar-project-menu-empty';
+      empty.textContent = 'No projects yet';
+      menu.appendChild(empty);
+    } else {
+      projects.forEach((p) => {
+        const isActive = p.path === active;
+        const item = document.createElement('button');
+        item.type = 'button';
+        item.className = 'sidebar-project-menu-item' + (isActive ? ' active' : '');
+        item.setAttribute('role', 'menuitem');
+        item.innerHTML = '<span class="sidebar-project-menu-item-name"></span>'
+          + (p.isFrameProject ? '<span class="sidebar-project-menu-tag">Frame</span>' : '')
+          + (isActive ? CHECK : '');
+        item.querySelector('.sidebar-project-menu-item-name').textContent = p.name;
+        item.addEventListener('click', () => {
+          close();
+          if (!isActive) projectListUI.selectProject(p.path);
+        });
+        menu.appendChild(item);
       });
-      document.querySelectorAll('[data-sidebar-tab-content]').forEach(el => {
-        el.style.display = el.dataset.sidebarTabContent === tab ? '' : 'none';
-      });
-      if (tab === 'changes') ipcRenderer.send(IPC.REFRESH_GIT_STATUS);
+    }
+
+    const sep = document.createElement('div');
+    sep.className = 'sidebar-project-menu-sep';
+    menu.appendChild(sep);
+
+    const add = document.createElement('button');
+    add.type = 'button';
+    add.className = 'sidebar-project-menu-item sidebar-project-menu-add';
+    add.setAttribute('role', 'menuitem');
+    add.innerHTML = '<span class="sidebar-project-menu-item-name">+ Open a project…</span>';
+    add.addEventListener('click', () => {
+      close();
+      openProjectModal.open();
     });
+    menu.appendChild(add);
+
+    menu.hidden = false;
+    btn.setAttribute('aria-expanded', 'true');
+    // Defer so this opening click doesn't immediately close via the doc listener.
+    setTimeout(() => {
+      document.addEventListener('click', onDocClick, true);
+      document.addEventListener('keydown', onKeydown, true);
+    }, 0);
+  };
+
+  btn.addEventListener('click', (e) => {
+    e.stopPropagation();
+    if (menu.hidden) open(); else close();
   });
 }
 
@@ -359,7 +434,14 @@ function revealSidebarTab(tabName) {
   document.querySelectorAll('[data-sidebar-tab-content]').forEach((el) => {
     el.style.display = el.dataset.sidebarTabContent === tabName ? '' : 'none';
   });
+  // The current-project switcher shows (and changes) the active project for
+  // Files / Changes and the Agent view's Start target. It's hidden only on
+  // Projects, which highlights its own active row. (The Agent view's Running
+  // Agents list stays cross-project regardless of this selection.)
+  const cp = document.getElementById('sidebar-current-project-wrap');
+  if (cp) cp.style.display = tabName === 'projects' ? 'none' : '';
   if (tabName === 'changes') ipcRenderer.send(IPC.REFRESH_GIT_STATUS);
+  if (tabName === 'agent') agentPanel.recompute();
 }
 
 /**
@@ -492,9 +574,10 @@ function registerCommands() {
     category: 'Focus',
     shortcut: 'CmdOrCtrl+E',
     run: () => {
+      // Projects is its own rail view now — reveal it, then focus the list.
       revealSidebarTab('projects');
       fileTreeUI.blur();
-      projectListUI.focus();
+      projectSection.focusList();
     }
   });
   r({
@@ -528,13 +611,13 @@ function registerCommands() {
     id: 'project.add',
     title: 'Add Project to Workspace…',
     category: 'Project',
-    run: () => state.selectProjectFolder()
+    run: () => openProjectModal.open()
   });
   r({
     id: 'project.create',
     title: 'Create New Project…',
     category: 'Project',
-    run: () => state.createNewProject()
+    run: () => openProjectModal.open()
   });
   r({
     id: 'project.initializeFrame',

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -8,7 +8,7 @@ const { IPC } = require('../shared/ipcChannels');
 const terminal = require('./terminal');
 const fileTreeUI = require('./fileTreeUI');
 const gitChangesPanel = require('./gitChangesPanel');
-const diffViewer = require('./diffViewer');
+const diffSection = require('./diffSection');
 const historyPanel = require('./historyPanel');
 const tasksPanel = require('./tasksPanel');
 const tasksDashboard = require('./tasksDashboard');
@@ -85,15 +85,12 @@ function init() {
   fileTreeUI.init('file-tree', state.getProjectPath);
   fileTreeUI.setProjectPathGetter(state.getProjectPath);
 
-  // Initialize Diff Viewer overlay (read-only, opened from Changes panel)
-  diffViewer.init();
-
-  // Initialize Git Changes panel (Changes sidebar tab); row clicks open the
-  // diff viewer for that file.
+  // Git Changes panel (Changes sidebar tab); a row click opens that file's
+  // diff as a section tab (next to Home / Frames), navigable with ◀ / ▶.
   gitChangesPanel.init({
     onRowClick: ({ projectPath, relPath, staged }) => {
       if (!projectPath || !relPath) return;
-      diffViewer.open({ projectPath, relPath, staged });
+      diffSection.open({ projectPath, relPath, staged });
     }
   });
 

--- a/src/renderer/laneBoard.js
+++ b/src/renderer/laneBoard.js
@@ -241,14 +241,15 @@ class LaneBoard {
     empty.className = 'lane-board-empty';
     empty.innerHTML = `
       <div class="lane-board-empty-icon">${lucideIcon(FolderOpen, 26)}</div>
-      <p class="lane-board-empty-title">No project selected</p>
-      <p class="lane-board-empty-hint">Frames belong to a project. Pick one from the sidebar, or select a folder to get started.</p>
-      <button class="lane-board-empty-cta">Select Project Folder</button>
+      <p class="lane-board-empty-title">No project added yet</p>
+      <p class="lane-board-empty-hint">Add a project to get started — open a folder, create a new project, or clone a repo.</p>
+      <button class="lane-board-empty-cta">Add New Project</button>
     `;
     empty.querySelector('.lane-board-empty-cta').addEventListener('click', () => {
-      // Same entry point as the sidebar button (idiom: ai.startSession does this too)
-      const btn = document.getElementById('btn-select-project');
-      if (btn) btn.click();
+      // Same flow as the sidebar Projects "Add new Project" button — the Open
+      // Project modal (open folder / create / clone). Lazy-required to avoid
+      // load-order coupling.
+      require('./openProjectModal').open();
     });
     return empty;
   }

--- a/src/renderer/laneDetailRail.js
+++ b/src/renderer/laneDetailRail.js
@@ -13,7 +13,7 @@
 
 const laneStatus = require('./laneStatus');
 const { formatRelativeTime, cleanCommand, assignmentIcon, assignmentText } = require('./laneBoard');
-const { PanelRightClose, PanelRightOpen, Terminal, Bot } = require('lucide');
+const { PanelRightClose, PanelRightOpen, Terminal, Bot, Plus } = require('lucide');
 
 const STORAGE_KEY = 'frame-detail-lanes-rail';
 
@@ -173,6 +173,18 @@ function _renderInto() {
   });
 
   container.appendChild(body);
+
+  // New Frame — the top-bar "+" is retired; creating a Frame lives here, next
+  // to the list it adds to.
+  const addBtn = document.createElement('button');
+  addBtn.className = 'lane-rail-add-btn';
+  addBtn.title = 'New Frame';
+  addBtn.innerHTML = `${lucideIcon(Plus, 14)}<span>Add new Frame</span>`;
+  addBtn.addEventListener('click', () => {
+    if (callbacks.onNewLane) callbacks.onNewLane();
+  });
+  container.appendChild(addBtn);
+
   _startTicker();
 }
 

--- a/src/renderer/multiTerminalUI.js
+++ b/src/renderer/multiTerminalUI.js
@@ -333,7 +333,12 @@ class MultiTerminalUI {
   _detailRailCallbacks() {
     return {
       onEnterLane: (terminalId) => this.enterLane(terminalId),
-      onLayoutChange: () => setTimeout(() => this.manager.fitAll(), 60)
+      onLayoutChange: () => setTimeout(() => this.manager.fitAll(), 60),
+      onNewLane: () => {
+        this.createTerminalForCurrentProject().then((id) => {
+          if (id) this.enterLane(id);
+        });
+      }
     };
   }
 
@@ -529,6 +534,18 @@ class MultiTerminalUI {
    */
   getManager() {
     return this.manager;
+  }
+
+  /**
+   * True only when a Frame's terminal is the surface on screen — not the lane
+   * board, an open section (task/spec) viewport, or the overview. Used by the
+   * sidebar launch shortcut to decide between "start in the focused Frame" and
+   * "open a new Frame".
+   */
+  isViewingFrame() {
+    return this.manager.viewMode === 'detail'
+      && !this.isSectionVisible
+      && !this.isOverviewVisible;
   }
 
   /**

--- a/src/renderer/multiTerminalUI.js
+++ b/src/renderer/multiTerminalUI.js
@@ -19,6 +19,7 @@ const laneDetailRail = require('./laneDetailRail');
 const overviewPanel = require('./overviewPanel');
 const taskSection = require('./taskSection');
 const specSection = require('./specSection');
+const diffSection = require('./diffSection');
 
 class MultiTerminalUI {
   constructor(containerId) {
@@ -94,6 +95,7 @@ class MultiTerminalUI {
     // collection and what the content area shows. Several can be open at once.
     taskSection.setHost(this);
     specSection.setHost(this);
+    diffSection.setHost(this);
 
     // Listen for state changes
     this.manager.onStateChange = (state) => this._onStateChange(state);

--- a/src/renderer/openProjectModal.js
+++ b/src/renderer/openProjectModal.js
@@ -1,0 +1,179 @@
+/**
+ * Open Project Modal
+ *
+ * A UI shell over the existing project-opening IPC flows. It does NOT own any
+ * business logic — Select Folder and Create New delegate straight to `state`,
+ * and Clone GitHub sends `CLONE_GITHUB_REPO` exactly as the old inline sidebar
+ * row did. The `CLONE_GITHUB_REPO_RESULT` listener stays in `index.js`; it
+ * calls back into `handleCloneResult()` here for in-modal feedback.
+ *
+ * Visibility follows the codebase modal convention (`.visible` on the overlay),
+ * and Escape is gated on `classList.contains('visible')` so it never leaks a
+ * key to the terminal (the b649542 fix).
+ */
+
+const { ipcRenderer } = require('electron');
+const { IPC } = require('../shared/ipcChannels');
+const state = require('./state');
+
+let modal = null;
+let cloneForm = null;
+let cloneFooter = null;
+let cloneUrlInput = null;
+let cloneError = null;
+
+/**
+ * Show the modal. Pass `{ clone: true }` to open straight into the clone form
+ * (used by the welcome overlay's "Clone GitHub" entry point).
+ */
+function open(opts = {}) {
+  if (!modal) return;
+  resetCloneForm();
+  modal.classList.add('visible');
+  if (opts && opts.clone) showCloneForm();
+}
+
+/**
+ * Hide the modal and reset the clone form.
+ */
+function close() {
+  if (!modal) return;
+  modal.classList.remove('visible');
+  resetCloneForm();
+}
+
+function isVisible() {
+  return !!modal && modal.classList.contains('visible');
+}
+
+/**
+ * Collapse the clone form back to the option list and clear its state.
+ */
+function resetCloneForm() {
+  if (cloneForm) cloneForm.style.display = 'none';
+  if (cloneFooter) cloneFooter.style.display = 'none';
+  if (cloneError) {
+    cloneError.style.display = 'none';
+    cloneError.textContent = '';
+  }
+  if (cloneUrlInput) cloneUrlInput.value = '';
+}
+
+/**
+ * Reveal the in-modal clone URL form and focus the input.
+ */
+function showCloneForm() {
+  if (cloneForm) cloneForm.style.display = '';
+  if (cloneFooter) cloneFooter.style.display = '';
+  if (cloneError) {
+    cloneError.style.display = 'none';
+    cloneError.textContent = '';
+  }
+  if (cloneUrlInput) {
+    cloneUrlInput.focus();
+  }
+}
+
+/**
+ * Send the clone request for the current URL value (if any).
+ */
+function submitClone() {
+  if (!cloneUrlInput) return;
+  const url = cloneUrlInput.value.trim();
+  if (!url) return;
+  ipcRenderer.send(IPC.CLONE_GITHUB_REPO, url);
+}
+
+/**
+ * Called by the `CLONE_GITHUB_REPO_RESULT` listener in index.js. Shows the
+ * error inline when the clone form is active, otherwise the caller handles it.
+ * Returns true if it consumed the result (modal handled the feedback).
+ */
+function handleCloneResult(result) {
+  if (!isVisible()) return false;
+  if (!result.success) {
+    if (cloneError) {
+      cloneError.textContent = result.error || 'Clone failed.';
+      cloneError.style.display = '';
+    }
+    return true;
+  }
+  // Success: the listener applies setProjectPath; we just close.
+  close();
+  return true;
+}
+
+/**
+ * Wire all modal controls. Safe to call once at startup.
+ */
+function init() {
+  modal = document.getElementById('open-project-modal');
+  if (!modal) return;
+
+  cloneForm = document.getElementById('open-project-clone-form');
+  cloneFooter = document.getElementById('open-project-clone-footer');
+  cloneUrlInput = document.getElementById('open-project-clone-url');
+  cloneError = document.getElementById('open-project-clone-error');
+
+  const closeBtn = document.getElementById('open-project-modal-close');
+  const selectBtn = document.getElementById('open-project-select');
+  const createBtn = document.getElementById('open-project-create');
+  const cloneToggle = document.getElementById('open-project-clone-toggle');
+  const cloneConfirm = document.getElementById('open-project-clone-confirm');
+  const cloneCancel = document.getElementById('open-project-clone-cancel');
+
+  if (closeBtn) closeBtn.addEventListener('click', close);
+
+  if (selectBtn) {
+    selectBtn.addEventListener('click', () => {
+      state.selectProjectFolder();
+      close();
+    });
+  }
+
+  if (createBtn) {
+    createBtn.addEventListener('click', () => {
+      state.createNewProject();
+      close();
+    });
+  }
+
+  if (cloneToggle) cloneToggle.addEventListener('click', showCloneForm);
+  if (cloneCancel) cloneCancel.addEventListener('click', resetCloneForm);
+  if (cloneConfirm) cloneConfirm.addEventListener('click', submitClone);
+
+  if (cloneUrlInput) {
+    cloneUrlInput.addEventListener('keydown', (e) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        submitClone();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        resetCloneForm();
+      }
+    });
+  }
+
+  // Click on the backdrop closes.
+  modal.addEventListener('click', (e) => {
+    if (e.target === modal) close();
+  });
+
+  // Escape-to-close, gated on visibility so it never leaks to the terminal.
+  document.addEventListener('keydown', (e) => {
+    if (e.key === 'Escape' && isVisible()) {
+      // If the clone form is open, first Escape collapses it (handled by the
+      // input's own listener when focused); here we close the whole modal.
+      if (document.activeElement === cloneUrlInput) return;
+      close();
+    }
+  });
+}
+
+module.exports = {
+  init,
+  open,
+  close,
+  isVisible,
+  handleCloneResult
+};

--- a/src/renderer/projectListUI.js
+++ b/src/renderer/projectListUI.js
@@ -5,12 +5,26 @@
 
 const { ipcRenderer } = require('electron');
 const { IPC } = require('../shared/ipcChannels');
+const { Bot } = require('lucide');
 
 let projectsListElement = null;
 let activeProjectPath = null;
 let onProjectSelectCallback = null;
 let projects = []; // Store projects list for navigation
 let focusedIndex = -1; // Currently focused project index
+// On first launch, open the first project automatically. One-shot so later
+// workspace updates never yank the user to the top of the list.
+let didInitialAutoSelect = false;
+// projectPath -> { approval, input } counts, from projectStatusBadges.
+let agentStatusMap = new Map();
+
+function lucideIcon(data, size = 12) {
+  const children = data.map(([tag, attrs]) => {
+    const attrStr = Object.entries(attrs).map(([k, v]) => `${k}="${v}"`).join(' ');
+    return `<${tag} ${attrStr}/>`;
+  }).join('');
+  return `<svg width="${size}" height="${size}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:block;flex-shrink:0">${children}</svg>`;
+}
 
 /**
  * Initialize project list UI
@@ -18,7 +32,58 @@ let focusedIndex = -1; // Currently focused project index
 function init(containerId, onSelectCallback) {
   projectsListElement = document.getElementById(containerId);
   onProjectSelectCallback = onSelectCallback;
+  setupStatusTooltip();
   setupIPC();
+}
+
+// ---- Custom hover tooltip for the agent-status badges ----
+// The native `title` tooltip is slow and faint; a fixed-positioned element
+// reads clearly and escapes the list's `overflow-y: auto` clipping.
+let statusTooltipEl = null;
+
+function ensureStatusTooltip() {
+  if (!statusTooltipEl) {
+    statusTooltipEl = document.createElement('div');
+    statusTooltipEl.className = 'project-status-tooltip';
+    document.body.appendChild(statusTooltipEl);
+  }
+  return statusTooltipEl;
+}
+
+function showStatusTooltip(badge) {
+  const text = badge.dataset.tip;
+  if (!text) return;
+  const tip = ensureStatusTooltip();
+  tip.textContent = text;
+  tip.classList.add('visible');
+
+  const r = badge.getBoundingClientRect();
+  const tr = tip.getBoundingClientRect();
+  // Right-align to the badge, clamped to the viewport; sit above when there's
+  // room, otherwise flip below.
+  let left = Math.max(8, Math.min(r.right - tr.width, window.innerWidth - tr.width - 8));
+  let top = r.top - tr.height - 6;
+  if (top < 8) top = r.bottom + 6;
+  tip.style.left = `${left}px`;
+  tip.style.top = `${top}px`;
+}
+
+function hideStatusTooltip() {
+  if (statusTooltipEl) statusTooltipEl.classList.remove('visible');
+}
+
+function setupStatusTooltip() {
+  if (!projectsListElement) return;
+  projectsListElement.addEventListener('mouseover', (e) => {
+    const badge = e.target.closest('.project-status-badge');
+    if (badge && projectsListElement.contains(badge)) showStatusTooltip(badge);
+  });
+  projectsListElement.addEventListener('mouseout', (e) => {
+    const badge = e.target.closest('.project-status-badge');
+    if (badge && !badge.contains(e.relatedTarget)) hideStatusTooltip();
+  });
+  // The hovered badge may scroll out or be re-rendered without a mouseout.
+  projectsListElement.addEventListener('scroll', hideStatusTooltip, { passive: true });
 }
 
 /**
@@ -45,23 +110,25 @@ function renderProjects(projectsList) {
     return;
   }
 
-  // Sort by lastOpenedAt (most recent first), then by name
-  const sortedProjects = [...projectsList].sort((a, b) => {
-    if (a.lastOpenedAt && b.lastOpenedAt) {
-      return new Date(b.lastOpenedAt) - new Date(a.lastOpenedAt);
-    }
-    if (a.lastOpenedAt) return -1;
-    if (b.lastOpenedAt) return 1;
-    return a.name.localeCompare(b.name);
-  });
+  // Render in the workspace's stored order — the user controls it by dragging
+  // (persisted via REORDER_WORKSPACE_PROJECTS). No recency auto-sort.
+  projects = [...projectsList];
 
-  // Store sorted projects for navigation
-  projects = sortedProjects;
-
-  sortedProjects.forEach((project, index) => {
+  projects.forEach((project, index) => {
     const projectItem = createProjectItem(project, index);
     projectsListElement.appendChild(projectItem);
   });
+
+  // First launch with nothing selected yet: open the top project so the app
+  // doesn't start on an empty context. Skipped if a project is already active
+  // (e.g. restored), and only ever runs once.
+  if (!didInitialAutoSelect && !activeProjectPath && projects.length > 0) {
+    didInitialAutoSelect = true;
+    selectProject(projects[0].path);
+  }
+
+  // Keep the active project visible even if it sits below the 3-row fold.
+  scrollActiveIntoView();
 
   // Update focused index based on active project
   focusedIndex = projects.findIndex(p => p.path === activeProjectPath);
@@ -76,16 +143,27 @@ function createProjectItem(project, index) {
   item.dataset.path = project.path;
   item.dataset.index = index;
   item.tabIndex = 0; // Make focusable
+  item.draggable = true; // Reorderable via drag
 
   if (project.path === activeProjectPath) {
     item.classList.add('active');
   }
 
-  // Project icon
-  const icon = document.createElement('span');
-  icon.className = 'project-icon';
-  icon.textContent = project.isFrameProject ? '📦' : '📁';
-  item.appendChild(icon);
+  attachDragHandlers(item);
+
+  // Leading marker: Frame projects get a FRAME tag in place of the icon;
+  // everything else keeps the file icon. (No separate right-side badge.)
+  if (project.isFrameProject) {
+    const tag = document.createElement('span');
+    tag.className = 'project-frame-tag';
+    tag.textContent = 'FRAME';
+    item.appendChild(tag);
+  } else {
+    const icon = document.createElement('span');
+    icon.className = 'project-icon';
+    icon.textContent = '📁';
+    item.appendChild(icon);
+  }
 
   // Project name
   const name = document.createElement('span');
@@ -94,13 +172,12 @@ function createProjectItem(project, index) {
   name.title = project.path;
   item.appendChild(name);
 
-  // Frame badge
-  if (project.isFrameProject) {
-    const badge = document.createElement('span');
-    badge.className = 'frame-badge';
-    badge.textContent = 'Frame';
-    item.appendChild(badge);
-  }
+  // Agent status badges (needs-approval / waiting-for-input in this project's
+  // background terminals). Populated from the latest status map.
+  const status = document.createElement('span');
+  status.className = 'project-status';
+  renderItemStatus(status, agentStatusMap.get(project.path));
+  item.appendChild(status);
 
   // Remove button (visible on hover)
   const removeBtn = document.createElement('button');
@@ -119,6 +196,105 @@ function createProjectItem(project, index) {
   });
 
   return item;
+}
+
+/**
+ * Render the agent status badges for one project into its status container.
+ * `counts` is { approval, input } or undefined (no attention-worthy agents).
+ */
+function renderItemStatus(container, counts) {
+  const approval = counts ? counts.approval : 0;
+  const input = counts ? counts.input : 0;
+  let html = '';
+  if (approval > 0) {
+    const label = `${approval} agent${approval > 1 ? 's' : ''} need approval`;
+    html += `<span class="project-status-badge approval" data-tip="${label}" aria-label="${label}">`
+      + `${lucideIcon(Bot, 12)}<span class="project-status-count">${approval}</span></span>`;
+  }
+  if (input > 0) {
+    const label = `${input} agent${input > 1 ? 's' : ''} waiting for input`;
+    html += `<span class="project-status-badge input" data-tip="${label}" aria-label="${label}">`
+      + `${lucideIcon(Bot, 12)}<span class="project-status-count">${input}</span></span>`;
+  }
+  container.innerHTML = html;
+}
+
+/**
+ * Apply per-project agent status counts (from projectStatusBadges) to the
+ * currently-rendered items. Stored so re-renders keep the badges.
+ */
+function applyAgentStatuses(map) {
+  agentStatusMap = map || new Map();
+  if (!projectsListElement) return;
+  hideStatusTooltip();
+  projectsListElement.querySelectorAll('.project-item').forEach((item) => {
+    const status = item.querySelector('.project-status');
+    if (status) renderItemStatus(status, agentStatusMap.get(item.dataset.path));
+  });
+}
+
+/**
+ * Wire HTML5 drag-and-drop reordering onto a project item. Dragging an item
+ * live-reorders the DOM; on drop the new order is persisted to the workspace.
+ */
+function attachDragHandlers(item) {
+  item.addEventListener('dragstart', (e) => {
+    item.classList.add('dragging');
+    e.dataTransfer.effectAllowed = 'move';
+    // setData is required for the drag to initiate in some Chromium builds.
+    try { e.dataTransfer.setData('text/plain', item.dataset.path); } catch (_) {}
+  });
+
+  item.addEventListener('dragend', () => {
+    item.classList.remove('dragging');
+    persistOrder();
+  });
+
+  item.addEventListener('dragover', (e) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'move';
+    const dragging = projectsListElement.querySelector('.project-item.dragging');
+    if (!dragging || dragging === item) return;
+    const rect = item.getBoundingClientRect();
+    const after = (e.clientY - rect.top) / rect.height > 0.5;
+    if (after) {
+      item.after(dragging);
+    } else {
+      item.before(dragging);
+    }
+  });
+}
+
+/**
+ * Read the current DOM order, sync the in-memory list, and persist it.
+ */
+function persistOrder() {
+  if (!projectsListElement) return;
+  const order = [...projectsListElement.querySelectorAll('.project-item')]
+    .map((el) => el.dataset.path);
+  if (order.length === 0) return;
+
+  // Re-sync the local `projects` array (used for keyboard nav) to the new order.
+  const rank = new Map(order.map((p, i) => [p, i]));
+  projects.sort((a, b) => (rank.get(a.path) ?? 0) - (rank.get(b.path) ?? 0));
+  projects.forEach((p, i) => {
+    const el = projectsListElement.querySelector(`.project-item[data-path="${CSS.escape(p.path)}"]`);
+    if (el) el.dataset.index = i;
+  });
+  focusedIndex = projects.findIndex((p) => p.path === activeProjectPath);
+
+  ipcRenderer.send(IPC.REORDER_WORKSPACE_PROJECTS, order);
+}
+
+/**
+ * Scroll the active project item into view within the (max-3-row) list.
+ */
+function scrollActiveIntoView() {
+  if (!projectsListElement || !activeProjectPath) return;
+  const el = projectsListElement.querySelector(
+    `.project-item[data-path="${CSS.escape(activeProjectPath)}"]`
+  );
+  if (el) el.scrollIntoView({ block: 'nearest' });
 }
 
 /**
@@ -175,6 +351,8 @@ function setActiveProject(projectPath) {
       }
     });
   }
+
+  scrollActiveIntoView();
 }
 
 /**
@@ -303,6 +481,14 @@ function blur() {
   items?.forEach(item => item.classList.remove('focused'));
 }
 
+/**
+ * Snapshot of the workspace projects (used by the current-project dropdown in
+ * the Files/Changes panel). Copy so callers can't mutate internal state.
+ */
+function getProjects() {
+  return [...projects];
+}
+
 module.exports = {
   init,
   loadProjects,
@@ -310,10 +496,12 @@ module.exports = {
   selectProject,
   setActiveProject,
   getActiveProject,
+  getProjects,
   addProject,
   removeProject,
   selectNextProject,
   selectPrevProject,
   focus,
-  blur
+  blur,
+  applyAgentStatuses
 };

--- a/src/renderer/projectSection.js
+++ b/src/renderer/projectSection.js
@@ -1,0 +1,34 @@
+/**
+ * Projects Section
+ *
+ * The Projects rail view. It is a thin wrapper: a "Projects" header above the
+ * workspace list (rendered/owned by `projectListUI`, drag-to-reorder) and an
+ * "Add new Project" button below that opens the Open Project modal. The active
+ * project is shown by list highlight (no separate summary row).
+ */
+
+const openProjectModal = require('./openProjectModal');
+const projectListUI = require('./projectListUI');
+
+let section = null;
+
+/**
+ * Move keyboard focus into the project list. Used by the "Focus Project List"
+ * command.
+ */
+function focusList() {
+  projectListUI.focus();
+}
+
+function init() {
+  section = document.getElementById('project-section');
+  if (!section) return;
+
+  const addBtn = document.getElementById('project-add-btn');
+  if (addBtn) addBtn.addEventListener('click', () => openProjectModal.open());
+}
+
+module.exports = {
+  init,
+  focusList
+};

--- a/src/renderer/projectStatusBadges.js
+++ b/src/renderer/projectStatusBadges.js
@@ -1,0 +1,77 @@
+/**
+ * Project Status Badges
+ *
+ * Surfaces background-project agent activity in the sidebar's project list.
+ * `laneStatus` already classifies every terminal across every project
+ * (terminals of non-active projects stay alive, so their status keeps
+ * updating). Here we roll those per-terminal statuses up per project and hand
+ * the counts to `projectListUI`, which renders the badges:
+ *
+ *   - agent-approval → "needs approval"      (red, most urgent)
+ *   - agent-input    → "waiting for input"   (amber)
+ *
+ * Other statuses (working / running / idle) are intentionally not surfaced —
+ * the list only flags projects that need the user's attention.
+ */
+
+const { ipcRenderer } = require('electron');
+const { IPC } = require('../shared/ipcChannels');
+const laneStatus = require('./laneStatus');
+const projectListUI = require('./projectListUI');
+
+let getStates = null;
+let scheduled = false;
+
+/**
+ * @param {object} multiTerminalUI - the live MultiTerminalUI (for getManager()).
+ */
+function init(multiTerminalUI) {
+  getStates = () => multiTerminalUI.getManager().getTerminalStates(true);
+
+  // Status transitions emit through laneStatus; a destroyed terminal does not,
+  // so recompute on destroy too. Both paths are debounced to one rAF.
+  laneStatus.onChange(() => schedule());
+  ipcRenderer.on(IPC.TERMINAL_DESTROYED, () => schedule());
+
+  recompute();
+}
+
+function schedule() {
+  if (scheduled) return;
+  scheduled = true;
+  requestAnimationFrame(() => {
+    scheduled = false;
+    recompute();
+  });
+}
+
+/**
+ * Tally attention-worthy agent statuses per project and push to the list.
+ */
+function recompute() {
+  if (!getStates) return;
+
+  let states;
+  try {
+    states = getStates();
+  } catch (_) {
+    states = [];
+  }
+
+  const map = new Map(); // projectPath -> { approval, input }
+  for (const s of states) {
+    const projectPath = s.projectPath;
+    if (!projectPath) continue; // global/unscoped terminals have no row
+    const status = laneStatus.getStatus(s.id).status;
+    if (status !== 'agent-approval' && status !== 'agent-input') continue;
+
+    const counts = map.get(projectPath) || { approval: 0, input: 0 };
+    if (status === 'agent-approval') counts.approval += 1;
+    else counts.input += 1;
+    map.set(projectPath, counts);
+  }
+
+  projectListUI.applyAgentStatuses(map);
+}
+
+module.exports = { init, recompute };

--- a/src/renderer/sidebarResize.js
+++ b/src/renderer/sidebarResize.js
@@ -7,7 +7,7 @@ const STORAGE_KEY = 'sidebar-width';
 const HIDDEN_KEY = 'sidebar-hidden';
 const MIN_WIDTH = 180;
 const MAX_WIDTH = 500;
-const DEFAULT_WIDTH = 260;
+const DEFAULT_WIDTH = 280;
 
 let sidebar = null;
 let isHidden = false;

--- a/src/renderer/state.js
+++ b/src/renderer/state.js
@@ -18,6 +18,10 @@ let onFrameInitializedCallbacks = [];
 let onSampleChangeCallbacks = [];
 let multiTerminalUI = null; // Reference to MultiTerminalUI instance
 
+// Project paths the user chose to stop being prompted about ("Don't ask again").
+// In-memory only — cleared on restart, so the prompt returns next launch.
+const frameInitPromptSuppressed = new Set();
+
 // UI Elements
 let pathElement = null;
 let startClaudeBtn = null;
@@ -36,6 +40,10 @@ function init(elements) {
   setupIPC();
   setupInitFrameModalListeners();
   setupSpotlightListeners();
+
+  // Render the initial (no-project) state so the section shows its empty-state
+  // CTA and hides the body until a project is opened.
+  updateProjectUI();
 
   // Cache the sample project path so we can detect when the user is
   // inside the sample without an IPC round-trip on every project switch.
@@ -121,6 +129,14 @@ function setIsFrameProject(isFrame) {
 
   // Notify listeners
   onFrameStatusChangeCallbacks.forEach(cb => cb(isFrame));
+
+  // When we land on a non-Frame project, offer to initialize it — unless it's
+  // the bundled sample or the user already said "Don't ask again" this session.
+  if (!isFrame && currentProjectPath
+      && !isCurrentProjectSample
+      && !frameInitPromptSuppressed.has(currentProjectPath)) {
+    showInitializeFrameModal();
+  }
 }
 
 /**
@@ -167,6 +183,9 @@ function initializeAsFrameProject() {
 function showInitializeFrameModal() {
   const modal = document.getElementById('initialize-frame-modal');
   if (modal) {
+    // Reset the "Don't ask again" checkbox each time the prompt opens.
+    const dontAsk = document.getElementById('init-frame-dontask');
+    if (dontAsk) dontAsk.checked = false;
     modal.classList.add('visible');
   }
 }
@@ -179,6 +198,19 @@ function hideInitializeFrameModal() {
   if (modal) {
     modal.classList.remove('visible');
   }
+}
+
+/**
+ * Dismiss the prompt without initializing ("Not Now" / close / Escape /
+ * backdrop). If "Don't ask again" is checked, suppress the prompt for the
+ * current project for the rest of this session.
+ */
+function dismissInitPrompt() {
+  const dontAsk = document.getElementById('init-frame-dontask');
+  if (dontAsk && dontAsk.checked && currentProjectPath) {
+    frameInitPromptSuppressed.add(currentProjectPath);
+  }
+  hideInitializeFrameModal();
 }
 
 /**
@@ -205,18 +237,18 @@ function setupInitFrameModalListeners() {
   const cancelBtn = document.getElementById('init-frame-cancel');
   const confirmBtn = document.getElementById('init-frame-confirm');
 
-  if (closeBtn) closeBtn.addEventListener('click', hideInitializeFrameModal);
-  if (cancelBtn) cancelBtn.addEventListener('click', hideInitializeFrameModal);
+  if (closeBtn) closeBtn.addEventListener('click', dismissInitPrompt);
+  if (cancelBtn) cancelBtn.addEventListener('click', dismissInitPrompt);
   if (confirmBtn) confirmBtn.addEventListener('click', handleInitializeFrame);
 
   if (modal) {
     modal.addEventListener('click', (e) => {
-      if (e.target === modal) hideInitializeFrameModal();
+      if (e.target === modal) dismissInitPrompt();
     });
 
     document.addEventListener('keydown', (e) => {
       if (e.key === 'Escape' && modal.classList.contains('visible')) {
-        hideInitializeFrameModal();
+        dismissInitPrompt();
       }
     });
   }
@@ -230,6 +262,9 @@ function showInitSpotlight() {
 
   const overlay = document.getElementById('spotlight-overlay');
   if (!overlay || !initializeFrameBtn) return;
+  // The init-frame button is currently parked in a hidden holder; don't try to
+  // spotlight an off-screen element (offsetParent is null when hidden).
+  if (!initializeFrameBtn.offsetParent) return;
 
   // Wait for button to render and be positioned
   setTimeout(() => {
@@ -317,31 +352,22 @@ function setupSpotlightListeners() {
  * Update project UI elements
  */
 function updateProjectUI() {
+  const filesEmpty = document.getElementById('files-empty-state');
   if (currentProjectPath) {
-    if (pathElement) {
-      pathElement.textContent = currentProjectPath;
-      pathElement.style.color = '#569cd6';
-    }
     if (startClaudeBtn) {
       startClaudeBtn.disabled = false;
     }
     if (fileExplorerHeader) {
       fileExplorerHeader.style.display = 'block';
     }
-    const filesEmpty = document.getElementById('files-empty-state');
     if (filesEmpty) filesEmpty.style.display = 'none';
   } else {
-    if (pathElement) {
-      pathElement.textContent = 'No project selected';
-      pathElement.style.color = '#666';
-    }
     if (startClaudeBtn) {
       startClaudeBtn.disabled = true;
     }
     if (fileExplorerHeader) {
       fileExplorerHeader.style.display = 'none';
     }
-    const filesEmpty = document.getElementById('files-empty-state');
     if (filesEmpty) filesEmpty.style.display = '';
   }
 }

--- a/src/renderer/styles/components/diff-viewer.css
+++ b/src/renderer/styles/components/diff-viewer.css
@@ -5,6 +5,158 @@
 
 @import '../../../../node_modules/diff2html/bundles/css/diff2html.min.css';
 
+/* =========================
+   Diff Section (the diff opened as a tab, with prev/next file nav)
+   ========================= */
+.diff-section {
+  /* The section content container (.terminal-content.section-view) is a flex
+     row — grow to fill it, otherwise the section sizes to the diff content. */
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+
+.diff-section-header {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  padding: var(--space-sm) var(--space-md);
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-secondary);
+}
+
+/* Prev/next file arrows — deliberately prominent and easy to hit. */
+.diff-section-nav {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 4px;
+}
+
+.diff-section-arrow {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.diff-section-arrow:hover:not(:disabled) {
+  color: var(--text-primary);
+  border-color: var(--accent-primary);
+  background: var(--bg-hover);
+}
+
+.diff-section-arrow:disabled {
+  opacity: 0.35;
+  cursor: default;
+}
+
+.diff-section-title {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.diff-section-filename {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.diff-section-pill {
+  flex: 0 0 auto;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+  padding: 2px 7px;
+  border-radius: 99px;
+}
+
+.diff-section-pill[data-pill="working"] {
+  color: var(--warning, #e5a50a);
+  background: color-mix(in srgb, var(--warning, #e5a50a) 16%, transparent);
+}
+
+.diff-section-pill[data-pill="staged"] {
+  color: var(--success, #7cb382);
+  background: color-mix(in srgb, var(--success, #7cb382) 16%, transparent);
+}
+
+.diff-section-pos {
+  flex: 0 0 auto;
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  color: var(--text-tertiary);
+}
+
+.diff-section-modes {
+  flex: 0 0 auto;
+  display: flex;
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  overflow: hidden;
+}
+
+.diff-section-mode {
+  padding: 5px 10px;
+  border: none;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.diff-section-mode + .diff-section-mode {
+  border-left: 1px solid var(--border-default);
+}
+
+.diff-section-mode:hover {
+  color: var(--text-primary);
+}
+
+.diff-section-mode.active {
+  background: var(--accent-subtle);
+  color: var(--accent-primary);
+}
+
+.diff-section-body {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+
+.diff-section-host {
+  padding: var(--space-md);
+}
+
+.diff-section-empty {
+  padding: 32px;
+  text-align: center;
+  color: var(--text-tertiary);
+  font-size: 12px;
+}
+
 #diff-viewer-overlay {
   display: none;
   position: fixed;
@@ -128,84 +280,101 @@
 }
 
 /* ----- diff2html dark-theme overrides ----- */
-#diff-viewer-host .d2h-wrapper {
+.frame-diff .d2h-wrapper {
   background: transparent;
 }
 
-#diff-viewer-host .d2h-file-header,
-#diff-viewer-host .d2h-files-diff,
-#diff-viewer-host .d2h-file-wrapper {
+.frame-diff .d2h-file-header,
+.frame-diff .d2h-files-diff,
+.frame-diff .d2h-file-wrapper {
   background: var(--bg-secondary);
   border-color: var(--border-subtle);
   color: var(--text-primary);
 }
 
-#diff-viewer-host .d2h-file-name {
+/* Always fill the available width, regardless of how small the diff is —
+   diff2html otherwise shrinks the wrapper/tables to their content. */
+.frame-diff .d2h-wrapper,
+.frame-diff .d2h-file-wrapper,
+.frame-diff .d2h-files-diff,
+.frame-diff .d2h-file-diff,
+.frame-diff .d2h-diff-table,
+.frame-diff .d2h-diff-tbody {
+  width: 100%;
+  box-sizing: border-box;
+}
+
+/* Side-by-side: two equal halves that fill the row. */
+.frame-diff .d2h-file-side-diff {
+  width: 50%;
+}
+
+.frame-diff .d2h-file-name {
   color: var(--text-primary);
 }
 
-#diff-viewer-host .d2h-tag,
-#diff-viewer-host .d2h-file-stats {
+.frame-diff .d2h-tag,
+.frame-diff .d2h-file-stats {
   color: var(--text-secondary);
 }
 
-#diff-viewer-host .d2h-code-line,
-#diff-viewer-host .d2h-code-side-line,
-#diff-viewer-host .d2h-diff-table {
+.frame-diff .d2h-code-line,
+.frame-diff .d2h-code-side-line,
+.frame-diff .d2h-diff-table {
   color: var(--text-primary);
   font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
   font-size: 12px;
 }
 
-#diff-viewer-host .d2h-code-linenumber,
-#diff-viewer-host .d2h-code-side-linenumber {
+.frame-diff .d2h-code-linenumber,
+.frame-diff .d2h-code-side-linenumber {
   background: var(--bg-tertiary);
   color: var(--text-tertiary);
   border-color: var(--border-subtle);
 }
 
-#diff-viewer-host .d2h-ins,
-#diff-viewer-host .d2h-ins.d2h-change {
+.frame-diff .d2h-ins,
+.frame-diff .d2h-ins.d2h-change {
   background: var(--diff-ins-bg);
   color: var(--diff-ins-fg);
 }
 
-#diff-viewer-host .d2h-ins .d2h-code-line-ctn,
-#diff-viewer-host .d2h-ins .d2h-code-side-line {
+.frame-diff .d2h-ins .d2h-code-line-ctn,
+.frame-diff .d2h-ins .d2h-code-side-line {
   color: var(--diff-ins-fg);
 }
 
-#diff-viewer-host .d2h-del,
-#diff-viewer-host .d2h-del.d2h-change {
+.frame-diff .d2h-del,
+.frame-diff .d2h-del.d2h-change {
   background: var(--diff-del-bg);
   color: var(--diff-del-fg);
 }
 
-#diff-viewer-host .d2h-del .d2h-code-line-ctn,
-#diff-viewer-host .d2h-del .d2h-code-side-line {
+.frame-diff .d2h-del .d2h-code-line-ctn,
+.frame-diff .d2h-del .d2h-code-side-line {
   color: var(--diff-del-fg);
 }
 
-#diff-viewer-host .d2h-cntx,
-#diff-viewer-host .d2h-cntx .d2h-code-line-ctn,
-#diff-viewer-host .d2h-cntx .d2h-code-side-line {
+.frame-diff .d2h-cntx,
+.frame-diff .d2h-cntx .d2h-code-line-ctn,
+.frame-diff .d2h-cntx .d2h-code-side-line {
   background: transparent;
   color: var(--text-secondary);
 }
 
-#diff-viewer-host .d2h-info {
+.frame-diff .d2h-info {
   background: var(--bg-tertiary);
   color: var(--text-tertiary);
   border-color: var(--border-subtle);
 }
 
-#diff-viewer-host .d2h-code-line-prefix {
+.frame-diff .d2h-code-line-prefix {
   color: var(--text-tertiary);
 }
 
-#diff-viewer-host .d2h-emptyplaceholder,
-#diff-viewer-host .d2h-code-line.d2h-emptyplaceholder,
-#diff-viewer-host .d2h-code-side-line.d2h-emptyplaceholder {
+.frame-diff .d2h-emptyplaceholder,
+.frame-diff .d2h-code-line.d2h-emptyplaceholder,
+.frame-diff .d2h-code-side-line.d2h-emptyplaceholder {
   background: var(--bg-deep);
   border-color: var(--border-subtle);
 }
@@ -213,15 +382,15 @@
 /* Inline change markers (diff2html wraps the changed substring of a line in
    <ins>/<del>). Default styles ship light-theme colors only; theme tokens
    in variables.css drive both dark and light. */
-#diff-viewer-host .d2h-code-line ins,
-#diff-viewer-host .d2h-code-side-line ins {
+.frame-diff .d2h-code-line ins,
+.frame-diff .d2h-code-side-line ins {
   background-color: var(--diff-ins-mark-bg);
   color: var(--diff-ins-mark-fg);
   text-decoration: none;
 }
 
-#diff-viewer-host .d2h-code-line del,
-#diff-viewer-host .d2h-code-side-line del {
+.frame-diff .d2h-code-line del,
+.frame-diff .d2h-code-side-line del {
   background-color: var(--diff-del-mark-bg);
   color: var(--diff-del-mark-fg);
   text-decoration: none;

--- a/src/renderer/styles/components/file-tree.css
+++ b/src/renderer/styles/components/file-tree.css
@@ -1,9 +1,19 @@
 /* File Tree — search filter + context menu */
 
 .file-tree-search {
-  position: relative;
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
   margin: var(--space-sm) 0 var(--space-sm);
   flex-shrink: 0;
+}
+
+/* Wraps the input + clear button so the absolutely-positioned clear stays
+   anchored to the input, with the refresh button as a flex sibling. */
+.file-tree-search-field {
+  position: relative;
+  flex: 1;
+  min-width: 0;
 }
 
 .file-tree-search input {
@@ -51,7 +61,7 @@
   background: var(--bg-hover);
 }
 
-.file-tree-search.has-query .file-tree-search-clear {
+.file-tree-search-field.has-query .file-tree-search-clear {
   display: block;
 }
 

--- a/src/renderer/styles/components/lane-board.css
+++ b/src/renderer/styles/components/lane-board.css
@@ -921,6 +921,39 @@
   padding: 4px 10px 10px;
 }
 
+/* New Frame CTA in the Frames rail — same accent treatment as Add new Project. */
+.lane-rail-add-btn {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  margin: 0 10px 10px;
+  padding: 8px;
+  background: var(--accent-primary);
+  border: 1px solid var(--accent-primary);
+  border-radius: var(--radius-md);
+  color: var(--bg-deep);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter var(--transition-fast), transform 0.08s, box-shadow var(--transition-fast);
+}
+
+.lane-rail-add-btn:hover {
+  filter: brightness(1.08);
+  box-shadow: var(--shadow-sm);
+}
+
+.lane-rail-add-btn:active {
+  transform: scale(0.99);
+}
+
+.lane-rail-add-btn svg {
+  flex-shrink: 0;
+}
+
 .lane-detail-item.active-lane {
   background: var(--bg-hover);
   border-color: var(--border-subtle);

--- a/src/renderer/styles/components/panels.css
+++ b/src/renderer/styles/components/panels.css
@@ -2336,10 +2336,33 @@
 }
 
 /* Initialize Frame Modal */
+.init-modal-lead {
+  margin: 0 0 var(--space-md) 0;
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--text-primary);
+}
+
 .init-modal-description {
   margin: 0 0 var(--space-md) 0;
   font-size: 13px;
   color: var(--text-secondary);
+}
+
+/* "Don't ask again" checkbox sits left of the footer buttons. */
+.init-modal-dontask {
+  margin-right: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  color: var(--text-tertiary);
+  cursor: pointer;
+  user-select: none;
+}
+
+.init-modal-dontask input {
+  cursor: pointer;
 }
 
 .init-modal-file-list {

--- a/src/renderer/styles/components/project-section.css
+++ b/src/renderer/styles/components/project-section.css
@@ -1,0 +1,260 @@
+/* ==================== PROJECTS SECTION ==================== */
+/*
+ * The workspace project list shown in the Projects rail view: a "Projects"
+ * header above the drag-reorderable list, with an "Add new Project" button
+ * pinned below (see .sidebar-view-projects in layout.css). The Open Project
+ * modal styles live at the bottom of this file.
+ */
+
+.project-section {
+  /* No left/right inset so the header + items align to the sidebar's own
+     padding edge. */
+  padding: var(--space-xs) 0 var(--space-sm);
+}
+
+/* ---- Header: "Projects" + add ---- */
+.project-section-header {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: var(--space-xs);
+}
+
+.project-section-title {
+  /* Same heading colour/weight as the Home/Frames right-panel section titles
+     (.lane-rail-section-title) — readable in dark mode. */
+  color: var(--text-secondary);
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.8px;
+}
+
+/* Header help (i) — same colour as the title, with a hover tooltip. */
+.project-section-help {
+  display: inline-flex;
+  align-items: center;
+  padding: 0;
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  cursor: help;
+  transition: color var(--transition-fast);
+}
+
+.project-section-help:hover {
+  color: var(--text-primary);
+}
+
+.project-section-help-tip {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  z-index: 60;
+  padding: 7px 10px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 400;
+  line-height: 1.45;
+  text-transform: none;
+  letter-spacing: 0;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--transition-fast);
+  pointer-events: none;
+}
+
+.project-section-help:hover ~ .project-section-help-tip {
+  opacity: 1;
+  visibility: visible;
+}
+
+/* ---- Workspace list ----
+   Lives in the Projects rail view; .sidebar-view-projects lets it grow to fill
+   and scroll, so no max-height cap here. */
+.project-section-list {
+  padding: var(--space-xs) 0;
+  overflow-y: auto;
+}
+
+/* Drag-to-reorder: the item being dragged dims to read as "in flight". */
+.project-item.dragging {
+  opacity: 0.45;
+  background: var(--bg-elevated);
+}
+
+/* Agent status badges — right side of a project row. Flag projects whose
+   background agents need attention (red = needs approval, amber = waiting). */
+.project-status {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+  flex: 0 0 auto;
+  margin-left: var(--space-xs);
+}
+
+.project-status:empty {
+  margin-left: 0;
+}
+
+/* Filled pills (matching the app-wide agent badge shape) so the status reads
+   clearly against the warm sidebar background instead of getting lost as a
+   bare tinted icon. The agent (Bot) logo signals these are agent statuses;
+   colour carries the meaning — red = needs approval, amber = waiting. */
+.project-status-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 0 6px;
+  font-size: 11px;
+  font-weight: 700;
+  line-height: 17px;
+  border-radius: 99px;
+  font-variant-numeric: tabular-nums;
+}
+
+.project-status-badge.approval {
+  color: #fff;
+  background: var(--error, #d45555);
+}
+
+.project-status-badge.input {
+  color: var(--bg-deep, #1a1410);
+  background: var(--warning, #e5a50a);
+}
+
+/* Gentle pulse for the urgent (needs-approval) badge. */
+.project-status-badge.approval {
+  animation: project-status-pulse 1.8s ease-in-out infinite;
+}
+
+/* Custom hover tooltip for the status badges — replaces the faint native
+   `title`. Fixed position (set in JS) so it escapes the list's scroll clip. */
+.project-status-tooltip {
+  position: fixed;
+  z-index: 1000;
+  max-width: 240px;
+  padding: 5px 9px;
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1.3;
+  color: var(--text-primary);
+  background: var(--bg-elevated, #2a2018);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.45);
+  pointer-events: none;
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.project-status-tooltip.visible {
+  opacity: 1;
+}
+
+@keyframes project-status-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.55; }
+}
+
+/* Leading FRAME tag — replaces the box icon for Frame-initialized projects. */
+.project-item .project-frame-tag {
+  flex: 0 0 auto;
+  margin-right: var(--space-sm);
+  padding: 2px 6px;
+  font-size: 9px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+  color: var(--bg-deep);
+  background: var(--accent-primary);
+  border-radius: 4px;
+}
+
+/* ==================== OPEN PROJECT MODAL ==================== */
+
+.open-project-options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+.open-project-option {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md);
+  width: 100%;
+  text-align: left;
+  padding: var(--space-md);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  cursor: pointer;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+
+.open-project-option:hover {
+  background: var(--bg-hover);
+  border-color: var(--accent-primary);
+}
+
+.open-project-option-icon {
+  flex: 0 0 auto;
+  font-size: 18px;
+  line-height: 1;
+}
+
+.open-project-option-text {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+
+.open-project-option-title {
+  font-size: 13px;
+  font-weight: 500;
+}
+
+.open-project-option-desc {
+  font-size: 12px;
+  color: var(--text-tertiary);
+}
+
+/* ---- In-modal clone form ---- */
+.open-project-clone-form {
+  margin-top: var(--space-md);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm);
+}
+
+#open-project-clone-url {
+  width: 100%;
+  padding: var(--space-sm) var(--space-md);
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  color: var(--text-primary);
+  font-size: 13px;
+  outline: none;
+  transition: border-color var(--transition-fast);
+}
+
+#open-project-clone-url:focus {
+  border-color: var(--accent-primary);
+}
+
+.open-project-clone-error {
+  font-size: 12px;
+  color: var(--danger, #f85149);
+  white-space: pre-wrap;
+}

--- a/src/renderer/styles/components/terminal.css
+++ b/src/renderer/styles/components/terminal.css
@@ -39,7 +39,9 @@
 .terminal-tab-actions button {
   background: transparent;
   border: none;
-  color: var(--text-tertiary);
+  /* Match the sidebar rail / right-panel strip icons: secondary at rest,
+     primary on hover (below). */
+  color: var(--text-secondary);
   cursor: pointer;
   width: 32px;
   height: 32px;

--- a/src/renderer/styles/layout.css
+++ b/src/renderer/styles/layout.css
@@ -1,6 +1,6 @@
 /* ==================== SIDEBAR ==================== */
 #sidebar {
-  width: 260px;
+  width: 280px;
   min-width: 180px;
   max-width: 500px;
   background: linear-gradient(180deg, var(--bg-secondary) 0%, var(--bg-primary) 100%);
@@ -75,7 +75,9 @@ body.sidebar-resizing * {
   font-size: 15px;
   font-weight: 600;
   letter-spacing: -0.3px;
-  margin-bottom: var(--space-xl);
+  /* Tightened so the Projects section lines up with the bottom edge of the
+     main panel's "Home" top bar (~62px from the top). */
+  margin-bottom: 16px;
   padding: var(--space-xs) 0;
   display: flex;
   align-items: center;
@@ -118,6 +120,93 @@ body.sidebar-resizing * {
 @keyframes update-dot-pulse {
   0%, 100% { opacity: 1; }
   50% { opacity: 0.45; }
+}
+
+/* Default-agent card — sidebar footer. The active AI tool is a global,
+   low-frequency preference, so it lives at the bottom of the sidebar (out of
+   the project list / file tree) and stays reachable on any tab. Styled as a
+   small card with a labelled header + full-width selector so it reads clearly
+   as a setting. */
+.sidebar-agent-footer {
+  flex-shrink: 0;
+  margin-top: var(--space-md);
+  padding: var(--space-sm) var(--space-sm) 10px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+}
+
+.sidebar-agent-footer-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.sidebar-agent-footer-icon {
+  display: flex;
+  flex-shrink: 0;
+  color: var(--accent-primary);
+}
+
+.sidebar-agent-footer-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  color: var(--text-secondary);
+}
+
+/* Selector + Start button on one row. */
+.sidebar-agent-footer-row {
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-xs);
+}
+
+/* The selector reuses .ai-tool-select for its theming, but here it stands
+   alone (not glued to a button via shared borders), so restore its full
+   border + radius and let it grow. */
+.sidebar-agent-footer .ai-tool-select {
+  flex: 1;
+  min-width: 0;
+  border-left: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  padding-top: 6px;
+  padding-bottom: 6px;
+}
+
+/* Start button — the launch shortcut; accent-filled so the primary action
+   reads clearly. */
+.sidebar-agent-launch {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 10px;
+  border: 1px solid var(--accent-primary);
+  border-radius: var(--radius-sm);
+  background: var(--accent-primary);
+  color: var(--bg-deep);
+  font-family: var(--font-sans);
+  font-size: 11px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter var(--transition-fast), transform 0.08s;
+}
+
+.sidebar-agent-launch svg {
+  flex-shrink: 0;
+}
+
+.sidebar-agent-launch:hover {
+  filter: brightness(1.08);
+}
+
+.sidebar-agent-launch:active {
+  transform: scale(0.97);
 }
 
 /* Update banner — sidebar footer card, primary signal when an update is available */
@@ -207,7 +296,7 @@ body.sidebar-resizing * {
 .sidebar-tabs {
   display: flex;
   gap: 0;
-  margin-bottom: var(--space-md);
+  margin-bottom: var(--space-sm);
   border-bottom: 1px solid var(--border-subtle);
   flex-shrink: 0;
 }
@@ -241,6 +330,488 @@ body.sidebar-resizing * {
   flex: 1;
   overflow-y: auto;
   min-height: 0;
+}
+
+/* ---- Activity rail + panel ----
+   The sidebar body is split into a thin vertical icon rail (Projects / Files /
+   Changes) and the active view's panel, editor-style. */
+#sidebar-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  gap: var(--space-sm);
+}
+
+.sidebar-rail {
+  flex: 0 0 auto;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding-right: var(--space-xs);
+  border-right: 1px solid var(--border-subtle);
+}
+
+/* Rail buttons reuse .sidebar-tab-btn theming hooks but are square icons in a
+   column — override the horizontal-tab geometry. */
+.sidebar-rail-btn {
+  flex: 0 0 auto;
+  width: 34px;
+  height: 34px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-md);
+  /* Same treatment as the right-panel strip icons (.lane-rail-strip-btn):
+     secondary at rest, primary on hover — readable in both themes. */
+  color: var(--text-secondary);
+}
+
+.sidebar-rail-btn svg {
+  display: block;
+}
+
+.sidebar-rail-btn:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.sidebar-rail-btn.active {
+  color: var(--accent-primary);
+  background: var(--accent-subtle);
+  border-bottom: none;
+}
+
+.sidebar-panel {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Current-project dropdown — compact switcher at the top of Files / Changes. */
+.sidebar-current-project-wrap {
+  position: relative;
+  flex: 0 0 auto;
+  margin-bottom: var(--space-sm);
+}
+
+.sidebar-current-project {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 6px var(--space-sm);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.sidebar-current-project:hover {
+  border-color: var(--accent-primary);
+  color: var(--text-primary);
+}
+
+.sidebar-current-project-icon {
+  flex-shrink: 0;
+  color: var(--accent-primary);
+}
+
+.sidebar-current-project-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-current-project-caret {
+  flex-shrink: 0;
+  color: var(--text-tertiary);
+  transition: transform var(--transition-fast);
+}
+
+.sidebar-current-project[aria-expanded="true"] .sidebar-current-project-caret {
+  transform: rotate(180deg);
+}
+
+/* Dropdown menu of projects to switch to. */
+.sidebar-project-menu {
+  position: absolute;
+  top: calc(100% + 4px);
+  left: 0;
+  right: 0;
+  z-index: 50;
+  max-height: 260px;
+  overflow-y: auto;
+  padding: 4px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+
+.sidebar-project-menu[hidden] {
+  display: none;
+}
+
+.sidebar-project-menu-item {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: 100%;
+  padding: 6px var(--space-sm);
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-secondary);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  transition: background var(--transition-fast), color var(--transition-fast);
+}
+
+.sidebar-project-menu-item:hover {
+  background: var(--bg-hover);
+  color: var(--text-primary);
+}
+
+.sidebar-project-menu-item.active {
+  color: var(--accent-primary);
+}
+
+.sidebar-project-menu-item-name {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-project-menu-item-check {
+  flex-shrink: 0;
+  color: var(--accent-primary);
+}
+
+.sidebar-project-menu-tag {
+  flex-shrink: 0;
+  font-size: 8px;
+  font-weight: 700;
+  letter-spacing: 0.3px;
+  text-transform: uppercase;
+  color: var(--bg-deep);
+  background: var(--accent-primary);
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+
+.sidebar-project-menu-sep {
+  height: 1px;
+  margin: 4px 2px;
+  background: var(--border-subtle);
+}
+
+.sidebar-project-menu-add {
+  color: var(--text-tertiary);
+}
+
+.sidebar-project-menu-empty {
+  padding: 8px;
+  font-size: 11px;
+  color: var(--text-muted);
+  text-align: center;
+}
+
+/* ---- Agent view: default-agent controls + running-agents list ---- */
+/* The controls card sits at the top of this view (not a footer), with the
+   selector and a full-width Start stacked for breathing room. */
+.sidebar-view-agent .sidebar-agent-footer {
+  margin-top: 0;
+  margin-bottom: var(--space-lg);
+  padding: var(--space-md);
+  gap: var(--space-sm);
+}
+
+.sidebar-view-agent .sidebar-agent-footer-row {
+  flex-direction: column;
+  align-items: stretch;
+  gap: var(--space-sm);
+}
+
+.sidebar-view-agent .sidebar-agent-footer-row .ai-tool-select {
+  flex: 0 0 auto;
+  width: 100%;
+}
+
+.sidebar-view-agent .sidebar-agent-launch {
+  width: 100%;
+  justify-content: center;
+  padding: 8px;
+}
+
+.agent-running-header {
+  position: relative;
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  margin-bottom: var(--space-sm);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.8px;
+  text-transform: uppercase;
+  /* Match the Home/Frames right-panel section titles — readable in dark mode. */
+  color: var(--text-secondary);
+}
+
+/* Header help (i) — distinct class from the per-row .agent-running-info
+   wrapper (which is flex:1 and would otherwise shove this to the right). */
+.agent-running-help {
+  display: inline-flex;
+  align-items: center;
+  padding: 0;
+  border: none;
+  background: transparent;
+  /* Same colour as the heading text it sits beside. */
+  color: inherit;
+  cursor: help;
+  transition: color var(--transition-fast);
+}
+
+.agent-running-help:hover {
+  color: var(--text-primary);
+}
+
+.agent-running-help-tip {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  right: 0;
+  z-index: 60;
+  padding: 7px 10px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  box-shadow: 0 6px 20px rgba(0, 0, 0, 0.4);
+  color: var(--text-secondary);
+  font-size: 11px;
+  font-weight: 400;
+  line-height: 1.45;
+  letter-spacing: 0;
+  text-transform: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity var(--transition-fast);
+  pointer-events: none;
+}
+
+.agent-running-help:hover ~ .agent-running-help-tip {
+  opacity: 1;
+  visibility: visible;
+}
+
+.agent-running-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-md);
+}
+
+/* Agents grouped under their project heading. */
+.agent-running-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.agent-running-group-title {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+  padding: 0 2px;
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.agent-running-group-icon {
+  flex-shrink: 0;
+  color: var(--accent-primary);
+}
+
+.agent-running-group-name {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-running-empty {
+  padding: var(--space-md) var(--space-sm);
+  font-size: 12px;
+  font-style: italic;
+  line-height: 1.5;
+  color: var(--text-secondary);
+}
+
+.agent-running-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  width: 100%;
+  padding: var(--space-sm);
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  text-align: left;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.agent-running-item:hover {
+  border-color: var(--accent-primary);
+  background: var(--bg-hover);
+}
+
+.agent-running-dot {
+  flex-shrink: 0;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--text-tertiary);
+}
+
+.agent-running-dot.working {
+  background: var(--accent-primary);
+  animation: spec-dot-pulse 1.2s ease-in-out infinite;
+}
+
+.agent-running-dot.approval {
+  background: var(--error, #d45555);
+  animation: spec-dot-pulse 0.7s ease-in-out infinite;
+}
+
+.agent-running-dot.input {
+  background: var(--warning, #e5a50a);
+}
+
+.agent-running-dot.ready {
+  background: var(--success, #7cb382);
+}
+
+.agent-running-info {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+
+.agent-running-name {
+  font-size: 12px;
+  font-weight: 600;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-running-sub {
+  font-size: 11px;
+  color: var(--text-tertiary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.agent-running-status {
+  flex-shrink: 0;
+  font-size: 10px;
+  font-weight: 600;
+  color: var(--text-tertiary);
+}
+
+.agent-running-status.working {
+  color: var(--accent-primary);
+}
+
+.agent-running-status.approval {
+  color: var(--error, #d45555);
+}
+
+.agent-running-status.input {
+  color: var(--warning, #e5a50a);
+}
+
+/* ---- Projects view: full list that scrolls, with a pinned Add button ---- */
+.sidebar-view-projects {
+  overflow: hidden; /* the inner list scrolls; the Add button stays pinned */
+}
+
+.sidebar-view-projects #project-section {
+  /* Size to content so the Add button sits right where the list ends; shrink
+     + scroll only when the list is long enough to fill the view. */
+  flex: 0 1 auto;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  border-bottom: none;
+}
+
+.sidebar-view-projects .project-section-list {
+  flex: 0 1 auto;
+  min-height: 0;
+  max-height: none;
+}
+
+/* Primary CTA — accent-filled, sits just below the project list (Frame's
+   primary colour, matching the Agent Start button / FRAME tag). */
+.project-add-btn {
+  flex: 0 0 auto;
+  margin-top: var(--space-md);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  padding: 9px var(--space-sm);
+  background: var(--accent-primary);
+  border: 1px solid var(--accent-primary);
+  border-radius: var(--radius-md);
+  color: var(--bg-deep);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter var(--transition-fast), transform 0.08s, box-shadow var(--transition-fast);
+}
+
+.project-add-btn:hover {
+  filter: brightness(1.08);
+  box-shadow: var(--shadow-sm);
+}
+
+.project-add-btn:active {
+  transform: scale(0.99);
+}
+
+.project-add-btn-icon {
+  font-size: 16px;
+  line-height: 1;
 }
 
 /* Files tab empty state */
@@ -291,22 +862,6 @@ body.sidebar-resizing * {
   margin-bottom: var(--space-lg);
 }
 
-/* File Explorer Header */
-.file-explorer-title {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin: var(--space-lg) 0 var(--space-sm) 0;
-}
-
-.file-explorer-title span {
-  color: var(--text-tertiary);
-  font-size: 10px;
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.8px;
-}
-
 #file-tree {
   flex: 1;
   overflow-y: auto;
@@ -347,12 +902,12 @@ body.sidebar-resizing * {
 }
 
 .project-item {
-  padding: var(--space-sm) var(--space-md);
+  padding: 9px var(--space-sm);
   cursor: pointer;
   display: flex;
   align-items: center;
   border-radius: var(--radius-md);
-  margin-bottom: 2px;
+  margin-bottom: 4px;
   color: var(--text-secondary);
   transition: all var(--transition-fast);
   border: 1px solid transparent;

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -58,3 +58,6 @@
 
 /* 17. Task Section (pinned task detail surface) */
 @import 'components/task-section.css';
+
+/* 18. Projects Section (pinned project switcher + Open Project modal) */
+@import 'components/project-section.css';

--- a/src/renderer/terminalTabBar.js
+++ b/src/renderer/terminalTabBar.js
@@ -181,9 +181,6 @@ class TerminalTabBar {
             <span class="usage-reset"></span>
           </div>
         </div>
-        <button class="btn-new-terminal" title="New Frame - Click to select shell, Right-click for default">
-          ${lucideIcon(Plus)}
-        </button>
         <select class="grid-layout-select" title="Layout">
           <option value="1x1" selected>1×1</option>
           <option value="1x2">1×2</option>
@@ -198,9 +195,6 @@ class TerminalTabBar {
         <button class="btn-update-notify" title="Check for updates" style="display:none;position:relative;">
           ${lucideIcon(Bell)}
           <span class="update-badge"></span>
-        </button>
-        <button class="btn-tasks-toggle" title="Tasks dashboard">
-          ${lucideIcon(CheckSquare)}
         </button>
         <button class="btn-more-toggle" title="More panels">
           ${lucideIcon(MoreHorizontal)}
@@ -225,16 +219,6 @@ class TerminalTabBar {
     const layoutSelect = this.element.querySelector('.grid-layout-select');
     layoutSelect.style.display = state.viewMode === 'detail' ? 'inline-block' : 'none';
     layoutSelect.value = state.gridLayout || '1x1';
-
-    // Disable new lane button when no project is selected or at max
-    const newBtn = this.element.querySelector('.btn-new-terminal');
-    const noProject = !state.currentProjectPath;
-    newBtn.disabled = noProject || state.terminals.length >= this.manager.maxTerminals;
-    newBtn.title = noProject
-      ? 'Select a project first'
-      : newBtn.disabled
-        ? `Maximum frames (${this.manager.maxTerminals}) reached for this project`
-        : 'New Frame (Ctrl+Shift+T)';
   }
 
   /**
@@ -306,21 +290,6 @@ class TerminalTabBar {
       }
     });
 
-    // New lane button - click to show shell selection, or right-click for default shell
-    const newTerminalBtn = this.element.querySelector('.btn-new-terminal');
-    newTerminalBtn.addEventListener('click', (e) => {
-      e.stopPropagation();
-      const rect = newTerminalBtn.getBoundingClientRect();
-      this._showShellMenu(rect.left, rect.bottom + 4);
-    });
-
-    // Right-click on + button to create lane with default shell quickly
-    newTerminalBtn.addEventListener('contextmenu', (e) => {
-      e.preventDefault();
-      e.stopPropagation();
-      this._createLane();
-    });
-
     // Layout selector (1×1 single terminal ↔ multi-cell layouts)
     this.element.querySelector('.grid-layout-select').addEventListener('change', (e) => {
       this.manager.setGridLayout(e.target.value);
@@ -330,16 +299,6 @@ class TerminalTabBar {
     this.element.querySelector('.claude-usage-bars').addEventListener('click', () => {
       ipcRenderer.send(IPC.REFRESH_CLAUDE_USAGE);
     });
-
-    // Standalone Tasks button — opens the full Tasks dashboard (the side
-    // panel is retired; Home's lane rail already covers the at-a-glance view)
-    const tasksBtn = this.element.querySelector('.btn-tasks-toggle');
-    if (tasksBtn) {
-      tasksBtn.addEventListener('click', (e) => {
-        e.stopPropagation();
-        tasksDashboard.toggle();
-      });
-    }
 
     // More menu toggle button
     const moreBtn = this.element.querySelector('.btn-more-toggle');
@@ -546,6 +505,12 @@ class TerminalTabBar {
         icon: `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/><polyline points="14 2 14 8 20 8"/><line x1="9" y1="13" x2="15" y2="13"/><line x1="9" y1="17" x2="13" y2="17"/></svg>`,
         action: () => specsDashboard.toggle(),
         key: 'specs'
+      },
+      {
+        label: 'Tasks',
+        icon: `<svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="9 11 12 14 22 4"/><path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"/></svg>`,
+        action: () => tasksDashboard.toggle(),
+        key: 'tasks'
       },
       {
         label: 'Claude',

--- a/src/renderer/terminalTabBar.js
+++ b/src/renderer/terminalTabBar.js
@@ -17,7 +17,7 @@ const pluginsPanel = require('./pluginsPanel');
 const githubPanel = require('./githubPanel');
 const promptsPanel = require('./promptsPanel');
 const specsDashboard = require('./specsDashboard');
-const { Plus, MoreHorizontal, Bell, CheckSquare, Home, X, Boxes, FileText } = require('lucide');
+const { Plus, MoreHorizontal, Bell, CheckSquare, Home, X, Boxes, FileText, FileDiff } = require('lucide');
 
 function lucideIcon(data, size = 18) {
   const children = data.map(([tag, attrs]) => {
@@ -258,7 +258,7 @@ class TerminalTabBar {
         <span class="lane-bar-divider"></span>
         ${sections.map(sec => `
           <button class="lane-bar-section ${sec.key === activeKey ? 'current' : ''}" data-key="${this._escapeHtml(sec.key)}" title="${this._escapeHtml(sec.title)}">
-            ${lucideIcon(sec.type === 'spec' ? FileText : CheckSquare, 13)}
+            ${lucideIcon(sec.type === 'spec' ? FileText : sec.type === 'diff' ? FileDiff : CheckSquare, 13)}
             <span class="lane-bar-section-label">${this._escapeHtml(sec.title)}</span>
             <span class="lane-bar-section-close" title="Close tab">${lucideIcon(X, 12)}</span>
           </button>

--- a/src/renderer/welcomeOverlay.js
+++ b/src/renderer/welcomeOverlay.js
@@ -10,6 +10,7 @@
 const { ipcRenderer } = require('electron');
 const { IPC } = require('../shared/ipcChannels');
 const state = require('./state');
+const openProjectModal = require('./openProjectModal');
 
 const DISMISSED_KEY = 'onboardingDismissed';
 
@@ -94,8 +95,8 @@ function setupListeners() {
     .getElementById('welcome-clone-github')
     .addEventListener('click', () => {
       close();
-      const cloneBtn = document.getElementById('btn-clone-github');
-      if (cloneBtn) cloneBtn.click();
+      // Old inline clone row is gone; open the Open Project modal's clone form.
+      openProjectModal.open({ clone: true });
     });
 
   document.getElementById('welcome-close').addEventListener('click', () => {

--- a/src/shared/ipcChannels.js
+++ b/src/shared/ipcChannels.js
@@ -38,6 +38,7 @@ const IPC = {
   WORKSPACE_UPDATED: 'workspace-updated',
   ADD_PROJECT_TO_WORKSPACE: 'add-project-to-workspace',
   REMOVE_PROJECT_FROM_WORKSPACE: 'remove-project-from-workspace',
+  REORDER_WORKSPACE_PROJECTS: 'reorder-workspace-projects',
 
   // Frame Project
   INITIALIZE_FRAME_PROJECT: 'initialize-frame-project',

--- a/tasks.json
+++ b/tasks.json
@@ -7,7 +7,7 @@
   },
   "project": "Frame",
   "version": "2.0",
-  "lastUpdated": "2026-06-12T11:03:56.545Z",
+  "lastUpdated": "2026-06-12T12:13:56.094Z",
   "taskSchema": {
     "_comment": "This schema shows the expected structure for each task",
     "id": "unique-id (task-xxx format)",
@@ -570,12 +570,12 @@
       "userRequest": "User's original ultimate vision: dangerously skip permissions seçeneğini de ui a yedirip, onu seçip claude code un bu yöntemle ben el sürmeden geliştirmesini sağlayacağım.",
       "acceptanceCriteria": "Toggle visible per-spec. Off by default. Each ON requires safety modal confirmation. AUTOPILOT badge prominently visible while active. Toggle OFF immediately stops the loop runner. Confirmation does not persist — every new app session re-asks.",
       "notes": "Friction is the feature here. Don't make it a one-click toggle that's easy to flip by mistake. Modal should be explicit about what's dangerous.",
-      "status": "pending",
+      "status": "in_progress",
       "priority": "high",
       "category": "feature",
       "context": "Session 2026-04-29 — Slice 4 design (autopilot)",
       "createdAt": "2026-05-02T00:00:00Z",
-      "updatedAt": "2026-05-02T00:00:00Z",
+      "updatedAt": "2026-06-12T12:13:56.093Z",
       "completedAt": null
     },
     {
@@ -1531,117 +1531,117 @@
       "title": "Add the Open Project modal markup to `index.html` (a `.modal-overlay` block following the `initialize-frame-modal` pattern) with Select Folder / Create New / Clone GitHub options and an in-modal clone URL form.",
       "description": "",
       "source": "spec:sidebar-project-section:T01",
-      "status": "pending",
+      "status": "completed",
       "priority": "medium",
       "category": "feature",
       "context": "From spec: sidebar-project-section",
       "createdAt": "2026-06-12T08:56:22.285Z",
-      "updatedAt": "2026-06-12T08:56:22.285Z",
-      "completedAt": null
+      "updatedAt": "2026-06-12T13:49:14.138Z",
+      "completedAt": "2026-06-12T13:49:14.138Z"
     },
     {
       "id": "task-spec-sidebar-project-section-T02",
       "title": "Create `src/renderer/openProjectModal.js`: open/close via `.visible` class with Escape-to-close gated on visibility (no key leak to terminal), wire folder/create options to `state.selectProjectFolder`/`state.createNewProject`, and move the clone form wiring (URL input, Enter submit, `CLONE_GITHUB_REPO` send) out of `index.js`.",
       "description": "",
       "source": "spec:sidebar-project-section:T02",
-      "status": "pending",
+      "status": "completed",
       "priority": "medium",
       "category": "feature",
       "context": "From spec: sidebar-project-section",
       "createdAt": "2026-06-12T08:56:22.285Z",
-      "updatedAt": "2026-06-12T08:56:22.285Z",
-      "completedAt": null
+      "updatedAt": "2026-06-12T14:07:42.952Z",
+      "completedAt": "2026-06-12T14:07:42.952Z"
     },
     {
       "id": "task-spec-sidebar-project-section-T03",
       "title": "Add the Projects section block to `index.html` under `#sidebar-header` (collapsed header row with active-project name, collapse chevron, `+` button, and an \"Open a project +\" empty-state CTA) and create `src/renderer/projectSection.js` for collapse/expand toggle and wiring `+`/CTA to the Open Project modal.",
       "description": "",
       "source": "spec:sidebar-project-section:T03",
-      "status": "pending",
+      "status": "completed",
       "priority": "medium",
       "category": "feature",
       "context": "From spec: sidebar-project-section",
       "createdAt": "2026-06-12T08:56:22.285Z",
-      "updatedAt": "2026-06-12T08:56:22.285Z",
-      "completedAt": null
+      "updatedAt": "2026-06-12T14:07:42.952Z",
+      "completedAt": "2026-06-12T14:07:42.952Z"
     },
     {
       "id": "task-spec-sidebar-project-section-T04",
       "title": "Add `src/renderer/styles/components/project-section.css` (section header, chevron, collapsed/expanded states, empty-state CTA, rehomed actions, modal options/clone form) using theme variables, and register it via `@import` in `src/renderer/styles/main.css`.",
       "description": "",
       "source": "spec:sidebar-project-section:T04",
-      "status": "pending",
+      "status": "completed",
       "priority": "medium",
       "category": "feature",
       "context": "From spec: sidebar-project-section",
       "createdAt": "2026-06-12T08:56:22.285Z",
-      "updatedAt": "2026-06-12T08:56:22.285Z",
-      "completedAt": null
+      "updatedAt": "2026-06-12T14:07:42.952Z",
+      "completedAt": "2026-06-12T14:07:42.952Z"
     },
     {
       "id": "task-spec-sidebar-project-section-T05",
       "title": "Move `#projects-list`, the `#btn-initialize-frame` button + `#init-frame-tooltip`, and the AI tool row (`#btn-start-ai` + `#ai-tool-selector`) into the Projects section body in `index.html`, keeping their existing ids so `projectListUI`, `updateFrameUI`, and the AI start handler keep working.",
       "description": "",
       "source": "spec:sidebar-project-section:T05",
-      "status": "pending",
+      "status": "completed",
       "priority": "medium",
       "category": "feature",
       "context": "From spec: sidebar-project-section",
       "createdAt": "2026-06-12T08:56:22.285Z",
-      "updatedAt": "2026-06-12T08:56:22.285Z",
-      "completedAt": null
+      "updatedAt": "2026-06-12T14:07:42.952Z",
+      "completedAt": "2026-06-12T14:07:42.952Z"
     },
     {
       "id": "task-spec-sidebar-project-section-T06",
       "title": "Repoint active-project display in `src/renderer/state.js`: set `pathElement` to the section's name element, render the project name with full path as `title`, and drive empty-state/CTA visibility from both branches of `updateProjectUI()`.",
       "description": "",
       "source": "spec:sidebar-project-section:T06",
-      "status": "pending",
+      "status": "completed",
       "priority": "medium",
       "category": "feature",
       "context": "From spec: sidebar-project-section",
       "createdAt": "2026-06-12T08:56:22.285Z",
-      "updatedAt": "2026-06-12T08:56:22.285Z",
-      "completedAt": null
+      "updatedAt": "2026-06-12T14:07:42.952Z",
+      "completedAt": "2026-06-12T14:07:42.952Z"
     },
     {
       "id": "task-spec-sidebar-project-section-T07",
       "title": "Remove the `projects` tab button and its `data-sidebar-tab-content=\"projects\"` panel from `index.html`, delete the old `#project-actions` stacked buttons (`btn-select-project`/`btn-create-project`/`btn-clone-github` + `clone-github-input-row`) and the duplicate `btn-add-project`, and remove their dead handlers in `src/renderer/index.js`.",
       "description": "",
       "source": "spec:sidebar-project-section:T07",
-      "status": "pending",
+      "status": "completed",
       "priority": "medium",
       "category": "feature",
       "context": "From spec: sidebar-project-section",
       "createdAt": "2026-06-12T08:56:22.285Z",
-      "updatedAt": "2026-06-12T08:56:22.285Z",
-      "completedAt": null
+      "updatedAt": "2026-06-12T14:07:42.952Z",
+      "completedAt": "2026-06-12T14:07:42.952Z"
     },
     {
       "id": "task-spec-sidebar-project-section-T08",
       "title": "Remap commands in `src/renderer/index.js`: change `focus.projectList` to expand the section and call `projectListUI.focus()` instead of `revealSidebarTab('projects')`, and route `project.add`/`project.create` through the Open Project modal.",
       "description": "",
       "source": "spec:sidebar-project-section:T08",
-      "status": "pending",
+      "status": "completed",
       "priority": "medium",
       "category": "feature",
       "context": "From spec: sidebar-project-section",
       "createdAt": "2026-06-12T08:56:22.285Z",
-      "updatedAt": "2026-06-12T08:56:22.285Z",
-      "completedAt": null
+      "updatedAt": "2026-06-12T14:07:42.952Z",
+      "completedAt": "2026-06-12T14:07:42.952Z"
     },
     {
       "id": "task-spec-sidebar-project-section-T09",
       "title": "Verify sample-project and welcome-overlay interplay (opening the sample selects/highlights it in the section, empty state does not fight the overlay) and register `renderer/projectSection` and `renderer/openProjectModal` in `STRUCTURE.json`.",
       "description": "",
       "source": "spec:sidebar-project-section:T09",
-      "status": "pending",
+      "status": "completed",
       "priority": "medium",
       "category": "feature",
       "context": "From spec: sidebar-project-section",
       "createdAt": "2026-06-12T08:56:22.285Z",
-      "updatedAt": "2026-06-12T08:56:22.285Z",
-      "completedAt": null
+      "updatedAt": "2026-06-12T14:07:42.952Z",
+      "completedAt": "2026-06-12T14:07:42.952Z"
     },
     {
       "id": "task-spec-agent-dispatch-T12",


### PR DESCRIPTION
 ## Summary

  This PR adds two changes that were part of the lane-orchestrator work but didn't
  make it into `main`: the previous PR (#86) was merged before these final two commits
  were pushed, so they were left behind on the original branch. This PR brings them in
  cleanly on a fresh branch.

  ## What's included
  - **Sidebar overhaul** — new activity rail, Agent view, project switcher, and a
    cleaned-up top bar for a more focused navigation layout.
  - **Navigable diff tabs** — file diffs now open as a dedicated, navigable tab
    instead of an inline panel.

  ## Changes at a glance
  - 33 files changed (~3.3k insertions / ~450 deletions)
  - New modules: `agentPanel.js`, `openProjectModal.js`, `projectSection.js`,
    `projectStatusBadges.js`, `diffSection.js`, `project-section.css`
  - Updated: sidebar / project list UI, lane board, diff viewer, and layout styles

  ## Notes
  These commits are identical to the original work on the lane-orchestrator branch
  (cherry-picked, no new code), so the diff reflects only the two missing commits on
  top of current `main`.