### PR TITLE
docs(agents): steer users toward specs for significant work

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,6 +46,51 @@ This searches STRUCTURE.json's intentIndex and returns the exact files you need.
 
 ---
 
+## Spec-Driven Development (steer the conversation)
+
+Frame is built around **spec-driven development**: significant work flows
+through a spec (`spec.md` → `plan.md` → `tasks.md`) before code is written. This
+is Frame's core way of working, so when a user describes meaningful new work
+**mid-conversation**, gently steer them toward a spec instead of silently diving
+into code.
+
+### When to suggest a spec
+
+Suggest a spec only for **significant work** — don't make this a reflex on every
+message. Good triggers:
+
+- A new **feature** or capability ("users should be able to …", "add a … system")
+- A change that will touch **multiple files / modules** or affect architecture
+- Anything that clearly benefits from a **plan and ordered tasks** before coding
+- Work the user describes vaguely/largely and would benefit from being scoped first
+
+**Do NOT suggest a spec for:**
+- Typos, one-line fixes, small tweaks, renames → just do it
+- Small, discrete tracked work → that's a **task** (see Task Management below)
+- Questions, debugging, explanations, experiments
+- Anything the user explicitly says to "just do" / "do directly"
+
+Rough ladder: *trivial → just do it · small but worth tracking → task · sizable
+feature or multi-file change → spec.*
+
+### How to suggest
+
+When a significant request appears, ask once, in plain language, before coding:
+
+> "This is a sizable feature. Want me to handle it as a **spec** — I'll draft
+> `spec.md`, then we plan it and generate tasks — or should I just implement it
+> directly?"
+
+- If the user agrees → start the spec flow (create the spec, then plan, then
+  tasks). If they have the slash commands set up, point them at `/spec` etc.;
+  otherwise scaffold `.frame/specs/<slug>/` per the existing structure.
+- If the user says "just do it" / declines → proceed directly and **don't ask
+  again for that same piece of work** in the session.
+- Never force it. The spec is an offer, not a gate. The user's stated preference
+  always wins.
+
+---
+
 ## Task Management (tasks.json)
 
 ### Task Recognition Rules

--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Auto-generated module structure",
-  "lastUpdated": "2026-06-17",
+  "lastUpdated": "2026-06-18",
   "architecture": {},
   "modules": {
     "main/aiToolManager": {
@@ -5910,7 +5910,7 @@
           "purpose": "Get current ISO timestamp"
         },
         "getAgentsTemplate": {
-          "line": 80,
+          "line": 102,
           "params": [
             "projectName",
             "options"
@@ -5918,46 +5918,46 @@
           "purpose": "which we re-emit AGENTS.md (or append the section to it)."
         },
         "getStructureTemplate": {
-          "line": 259,
+          "line": 281,
           "params": [
             "projectName"
           ],
           "purpose": "STRUCTURE.json template"
         },
         "getNotesTemplate": {
-          "line": 283,
+          "line": 305,
           "params": [
             "projectName"
           ],
           "purpose": "PROJECT_NOTES.md template"
         },
         "getTasksTemplate": {
-          "line": 303,
+          "line": 325,
           "params": [
             "projectName"
           ],
           "purpose": "tasks.json template"
         },
         "getQuickstartTemplate": {
-          "line": 349,
+          "line": 371,
           "params": [
             "projectName"
           ],
           "purpose": "QUICKSTART.md template"
         },
         "getFrameConfigTemplate": {
-          "line": 415,
+          "line": 437,
           "params": [
             "projectName"
           ],
           "purpose": ".frame/config.json template"
         },
         "getCodexWrapperTemplate": {
-          "line": 454,
+          "line": 476,
           "purpose": "Instructs Codex to read AGENTS.md as initial prompt"
         },
         "getGenericWrapperTemplate": {
-          "line": 491,
+          "line": 513,
           "params": [
             "toolCommand",
             "promptFlag = ''"
@@ -5965,27 +5965,27 @@
           "purpose": "Can be customized for other AI tools in the future"
         },
         "getStructureHookSnippet": {
-          "line": 537
+          "line": 559
         },
         "getStructurePreCommitHookTemplate": {
-          "line": 558,
+          "line": 580,
           "purpose": "Husky/lefthook get the snippet appended into their own files instead."
         },
         "getOrchBusHeader": {
-          "line": 581,
+          "line": 603,
           "purpose": "wrappers above."
         },
         "getOrchRequestScript": {
-          "line": 593,
+          "line": 615,
           "params": [
             "type"
           ]
         },
         "getOrchStatusScript": {
-          "line": 613
+          "line": 635
         },
         "getOrchBinScripts": {
-          "line": 631,
+          "line": 653,
           "purpose": "project when an orchestration session starts."
         }
       }

--- a/src/shared/frameTemplates.js
+++ b/src/shared/frameTemplates.js
@@ -62,11 +62,33 @@ After \`/spec.tasks\`, **do not** also write entries to \`tasks.json\` — Frame
 
 Spec-generated tasks carry a \`source\` field. Treat them like any other task — start them, complete them, update status. User-set status is preserved across spec re-imports; only title/description sync from \`tasks.md\`.
 
-### When to suggest a spec
+### When to suggest a spec (steer the conversation)
 
-If the user describes work bigger than a one-shot edit (a new feature, a multi-file refactor, a cross-cutting fix), suggest a spec first: *"This sounds like a spec — want me to draft \`.frame/specs/<slug>/spec.md\`?"*
+Spec-driven is Frame's core way of working, so when a user describes meaningful
+new work **mid-conversation**, gently steer them toward a spec instead of
+silently diving into code. Suggest a spec only for **significant work** — don't
+make this a reflex on every message.
 
-For one-line typo fixes, build errors, or clarifying questions, skip the spec — go direct.`;
+**Suggest a spec for:**
+- A new **feature** or capability ("users should be able to …", "add a … system")
+- A change that will touch **multiple files / modules** or affect architecture
+- Anything that clearly benefits from a **plan and ordered tasks** before coding
+- Work the user describes vaguely/largely that would benefit from being scoped first
+
+**Do NOT suggest a spec for:**
+- Typos, one-line fixes, small tweaks, renames → just do it
+- Small, discrete tracked work → that's a task (\`tasks.json\`)
+- Questions, debugging, explanations, experiments
+- Anything the user explicitly says to "just do" / "do directly"
+
+Rough ladder: *trivial → just do it · small but worth tracking → task · sizable
+feature or multi-file change → spec.*
+
+Ask once, in plain language, before coding. If they agree, start the spec flow
+(\`/spec.new\` → \`/spec.plan\` → \`/spec.tasks\`). If they decline or say "just do
+it", proceed directly and **don't ask again for that same piece of work** in the
+session. Never force it — the spec is an offer, not a gate; the user's stated
+preference always wins.`;
 
 /**
  * AGENTS.md template - Main instructions file for AI assistants

--- a/src/templates/sample-project/AGENTS.md
+++ b/src/templates/sample-project/AGENTS.md
@@ -92,11 +92,25 @@ After `/spec.tasks`, **do not** also write entries to `tasks.json` — Frame's w
 
 Spec-generated tasks carry a `source` field. Treat them like any other task — start them, complete them, update status. User-set status is preserved across spec re-imports; only title/description sync from `tasks.md`.
 
-### When to suggest a spec
+### When to suggest a spec (steer the conversation)
 
-If the user describes work bigger than a one-shot edit (a new feature, a multi-file refactor, a cross-cutting fix), suggest a spec first: *"This sounds like a spec — want me to draft `.frame/specs/<slug>/spec.md`?"*
+Spec-driven is Frame's core way of working, so when a user describes meaningful new work **mid-conversation**, gently steer them toward a spec instead of silently diving into code. Suggest a spec only for **significant work** — don't make this a reflex on every message.
 
-For one-line typo fixes, build errors, or clarifying questions, skip the spec — go direct.
+**Suggest a spec for:**
+- A new **feature** or capability ("users should be able to …", "add a … system")
+- A change that will touch **multiple files / modules** or affect architecture
+- Anything that clearly benefits from a **plan and ordered tasks** before coding
+- Work the user describes vaguely/largely that would benefit from being scoped first
+
+**Do NOT suggest a spec for:**
+- Typos, one-line fixes, small tweaks, renames → just do it
+- Small, discrete tracked work → that's a task (`tasks.json`)
+- Questions, debugging, explanations, experiments
+- Anything the user explicitly says to "just do" / "do directly"
+
+Rough ladder: *trivial → just do it · small but worth tracking → task · sizable feature or multi-file change → spec.*
+
+Ask once, in plain language, before coding — e.g. *"This is a sizable feature. Want me to handle it as a spec? I'll draft `.frame/specs/<slug>/spec.md`, then we plan it and generate tasks."* If they agree, start the spec flow (`/spec.new` → `/spec.plan` → `/spec.tasks`). If they decline or say "just do it", proceed directly and **don't ask again for that same piece of work** in the session. Never force it — the spec is an offer, not a gate; the user's stated preference always wins.
 
 ---
 

--- a/src/templates/sample-project/CLAUDE.md
+++ b/src/templates/sample-project/CLAUDE.md
@@ -92,11 +92,25 @@ After `/spec.tasks`, **do not** also write entries to `tasks.json` — Frame's w
 
 Spec-generated tasks carry a `source` field. Treat them like any other task — start them, complete them, update status. User-set status is preserved across spec re-imports; only title/description sync from `tasks.md`.
 
-### When to suggest a spec
+### When to suggest a spec (steer the conversation)
 
-If the user describes work bigger than a one-shot edit (a new feature, a multi-file refactor, a cross-cutting fix), suggest a spec first: *"This sounds like a spec — want me to draft `.frame/specs/<slug>/spec.md`?"*
+Spec-driven is Frame's core way of working, so when a user describes meaningful new work **mid-conversation**, gently steer them toward a spec instead of silently diving into code. Suggest a spec only for **significant work** — don't make this a reflex on every message.
 
-For one-line typo fixes, build errors, or clarifying questions, skip the spec — go direct.
+**Suggest a spec for:**
+- A new **feature** or capability ("users should be able to …", "add a … system")
+- A change that will touch **multiple files / modules** or affect architecture
+- Anything that clearly benefits from a **plan and ordered tasks** before coding
+- Work the user describes vaguely/largely that would benefit from being scoped first
+
+**Do NOT suggest a spec for:**
+- Typos, one-line fixes, small tweaks, renames → just do it
+- Small, discrete tracked work → that's a task (`tasks.json`)
+- Questions, debugging, explanations, experiments
+- Anything the user explicitly says to "just do" / "do directly"
+
+Rough ladder: *trivial → just do it · small but worth tracking → task · sizable feature or multi-file change → spec.*
+
+Ask once, in plain language, before coding — e.g. *"This is a sizable feature. Want me to handle it as a spec? I'll draft `.frame/specs/<slug>/spec.md`, then we plan it and generate tasks."* If they agree, start the spec flow (`/spec.new` → `/spec.plan` → `/spec.tasks`). If they decline or say "just do it", proceed directly and **don't ask again for that same piece of work** in the session. Never force it — the spec is an offer, not a gate; the user's stated preference always wins.
 
 ---
 

--- a/src/templates/sample-project/GEMINI.md
+++ b/src/templates/sample-project/GEMINI.md
@@ -92,11 +92,25 @@ After `/spec.tasks`, **do not** also write entries to `tasks.json` — Frame's w
 
 Spec-generated tasks carry a `source` field. Treat them like any other task — start them, complete them, update status. User-set status is preserved across spec re-imports; only title/description sync from `tasks.md`.
 
-### When to suggest a spec
+### When to suggest a spec (steer the conversation)
 
-If the user describes work bigger than a one-shot edit (a new feature, a multi-file refactor, a cross-cutting fix), suggest a spec first: *"This sounds like a spec — want me to draft `.frame/specs/<slug>/spec.md`?"*
+Spec-driven is Frame's core way of working, so when a user describes meaningful new work **mid-conversation**, gently steer them toward a spec instead of silently diving into code. Suggest a spec only for **significant work** — don't make this a reflex on every message.
 
-For one-line typo fixes, build errors, or clarifying questions, skip the spec — go direct.
+**Suggest a spec for:**
+- A new **feature** or capability ("users should be able to …", "add a … system")
+- A change that will touch **multiple files / modules** or affect architecture
+- Anything that clearly benefits from a **plan and ordered tasks** before coding
+- Work the user describes vaguely/largely that would benefit from being scoped first
+
+**Do NOT suggest a spec for:**
+- Typos, one-line fixes, small tweaks, renames → just do it
+- Small, discrete tracked work → that's a task (`tasks.json`)
+- Questions, debugging, explanations, experiments
+- Anything the user explicitly says to "just do" / "do directly"
+
+Rough ladder: *trivial → just do it · small but worth tracking → task · sizable feature or multi-file change → spec.*
+
+Ask once, in plain language, before coding — e.g. *"This is a sizable feature. Want me to handle it as a spec? I'll draft `.frame/specs/<slug>/spec.md`, then we plan it and generate tasks."* If they agree, start the spec flow (`/spec.new` → `/spec.plan` → `/spec.tasks`). If they decline or say "just do it", proceed directly and **don't ask again for that same piece of work** in the session. Never force it — the spec is an offer, not a gate; the user's stated preference always wins.
 
 ---
 


### PR DESCRIPTION
## What

Adds a **"When to suggest a spec"** directive so the agent proactively steers users toward Frame's spec-driven workflow (`spec → plan → tasks`) when they describe **significant** new work mid-conversation — while staying out of the way for trivial fixes and small tracked work.

## Why

Spec-driven development is now central to Frame, but the instruction files never told the agent to *guide users into it*. The agent would either dive straight into code or only offer a task. This closes that gap so the conversation itself nudges toward specs when it's worth it.

## Threshold (kept deliberately non-spammy)

Rough ladder: *trivial → just do it · small but worth tracking → task · sizable feature or multi-file change → spec.*

- **Suggest a spec** for: new features/capabilities, multi-file / architectural changes, work that benefits from a plan + ordered tasks.
- **Don't** for: typos/one-line fixes, small tracked work (that's a task), questions/debugging, or anything the user says to "just do".
- Ask **once**, never force it — the spec is an offer, not a gate; the user's preference always wins.

## Scope

Applied everywhere so it reaches new projects and users too:
- `AGENTS.md` — this project's own instructions
- `src/shared/frameTemplates.js` — the generated `AGENTS.md` template (in `SPEC_DRIVEN_SECTION`, so it ships when spec-driven is enabled)
- `src/templates/sample-project/{AGENTS,CLAUDE,GEMINI}.md` — the bundled sample project

`STRUCTURE.json` change is the pre-commit hook's auto-regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)