### PR TITLE
fix(usage): raise Claude usage poll interval to 5 minutes

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -208,7 +208,7 @@
         "startPolling": {
           "line": 176,
           "params": [
-            "interval = 60000"
+            "interval = 300000"
           ],
           "purpose": "Start periodic polling for usage updates"
         },

--- a/src/main/claudeUsageManager.js
+++ b/src/main/claudeUsageManager.js
@@ -171,9 +171,9 @@ async function sendUsageToRenderer() {
 
 /**
  * Start periodic polling for usage updates
- * @param {number} interval - Polling interval in ms (default: 60000 = 1 minute)
+ * @param {number} interval - Polling interval in ms (default: 300000 = 5 minutes)
  */
-function startPolling(interval = 60000) {
+function startPolling(interval = 300000) {
   // Stop any existing polling
   stopPolling();
 


### PR DESCRIPTION
## Summary

The Claude usage indicator (Session / Weekly bars in the terminal tab bar) intermittently failed with `API error: 429` from `/api/oauth/usage`. `claudeUsageManager.js` polled that endpoint every **60s**, which is far more aggressive than the slowly-changing usage figures need and the most likely cause of the rate-limit responses.

This raises `startPolling`'s default interval from `60000` → `300000` (5 minutes).

## Scope (per spec `reduce-claude-usage-polling`)

- ✅ Default poll interval 60s → 5 min
- ✅ Initial startup fetch (`setTimeout`) unchanged — bars still populate on launch
- ✅ Manual click-refresh (`REFRESH_CLAUDE_USAGE`) unchanged
- ❌ Out of scope: 429/`Retry-After` backoff, cached-value-on-error, renderer error UX (deferred)

## Files

- `src/main/claudeUsageManager.js` — interval default + JSDoc
- `STRUCTURE.json` — auto-updated by pre-commit hook

🤖 Generated with [Claude Code](https://claude.com/claude-code)