### PR TITLE
fix(orchestration): per-project sessions — switching projects no longer loses them

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Auto-generated module structure",
-  "lastUpdated": "2026-06-18",
+  "lastUpdated": "2026-06-22",
   "architecture": {},
   "modules": {
     "main/aiToolManager": {
@@ -7163,6 +7163,7 @@
         "envForLane",
         "publishState",
         "drainBus",
+        "sessionFor",
         "getSession"
       ],
       "depends": [
@@ -7177,69 +7178,77 @@
       ],
       "functions": {
         "init": {
-          "line": 57,
+          "line": 62,
           "params": [
             "window"
           ]
         },
+        "sessionFor": {
+          "line": 66,
+          "params": [
+            "projectPath"
+          ]
+        },
         "busDirFor": {
-          "line": 63,
+          "line": 72,
           "params": [
             "projectPath"
           ],
           "purpose": "─── path helpers ─────────────────────────────────────────"
         },
         "binDirFor": {
-          "line": 66,
+          "line": 75,
           "params": [
             "projectPath"
           ]
         },
         "worktreeDirFor": {
-          "line": 69,
+          "line": 78,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "envForLane": {
-          "line": 75,
+          "line": 84,
           "params": [
+            "session",
             "slug"
           ],
           "purpose": "worktree, regardless of its own .frame/ copy."
         },
         "toPrefix": {
-          "line": 89,
+          "line": 98,
           "params": [
             "entry"
           ],
           "purpose": "equality; a glob/dir entry (`src/foo/**`, `src/foo/*`) matches by prefix."
         },
         "entriesOverlap": {
-          "line": 94,
+          "line": 103,
           "params": [
             "a",
             "b"
           ]
         },
         "footprintsOverlap": {
-          "line": 106,
+          "line": 115,
           "params": [
             "fa",
             "fb"
           ]
         },
         "findFootprintConflict": {
-          "line": 117,
+          "line": 126,
           "params": [
+            "session",
             "slug",
             "footprint"
           ],
           "purpose": "workers don't block (their work is already integrated or abandoned)."
         },
         "buildWorkerPrompt": {
-          "line": 129,
+          "line": 138,
           "params": [
             "projectPath",
             "slug"
@@ -7247,119 +7256,152 @@
           "purpose": "from inside the worktree."
         },
         "relayToConductor": {
-          "line": 151,
+          "line": 160,
           "params": [
+            "session",
             "text"
           ]
         },
         "drainRelayQueue": {
-          "line": 157
+          "line": 166,
+          "params": [
+            "session"
+          ]
         },
         "materializeBinScripts": {
-          "line": 175,
+          "line": 184,
           "params": [
             "projectPath"
           ],
           "purpose": "Materialize the .frame/bin command scripts for this project."
         },
         "serializeState": {
-          "line": 187,
+          "line": 196,
+          "params": [
+            "session"
+          ],
           "purpose": "─── state publish ────────────────────────────────────────"
         },
         "publishState": {
-          "line": 210
+          "line": 219,
+          "params": [
+            "session"
+          ]
         },
         "startBusWatcher": {
-          "line": 228,
+          "line": 237,
+          "params": [
+            "session"
+          ],
           "purpose": "─── bus watcher ──────────────────────────────────────────"
         },
         "drainBus": {
-          "line": 241
+          "line": 250,
+          "params": [
+            "session"
+          ]
         },
         "handleRequest": {
-          "line": 265,
+          "line": 274,
           "params": [
+            "session",
             "req"
           ]
         },
         "handleDispatch": {
-          "line": 285,
+          "line": 294,
           "params": [
+            "session",
             "slug"
           ],
           "purpose": "T10 (worktree + worker spawn) + T13 (conflict guard). Cap check is T24."
         },
         "registerWorkerLane": {
-          "line": 353,
+          "line": 365,
           "params": [
+            "projectPath",
             "slug",
             "terminalId"
           ],
           "purpose": "manager can track status, relay, and tear it down."
         },
         "handleReportDone": {
-          "line": 365,
+          "line": 378,
           "params": [
+            "session",
             "slug"
           ],
           "purpose": "the conductor with the merge command."
         },
         "handleMerge": {
-          "line": 382,
+          "line": 395,
           "params": [
+            "session",
             "slug",
             "args = []"
           ],
           "purpose": "reminder; the conductor performs the actual reconcile per CONDUCTOR.md)."
         },
         "mergeWorker": {
-          "line": 421,
+          "line": 434,
           "params": [
+            "projectPath",
             "slug",
             "force = false"
           ],
           "purpose": "Per-worker merge trigger from the board UI (mirrors a conductor merge.js call)."
         },
         "removeWorker": {
-          "line": 427,
+          "line": 442,
           "params": [
+            "projectPath",
             "slug"
           ],
           "purpose": "prune the work branch ONLY if merged (un-merged work is kept — no data loss)."
         },
         "pollStatuses": {
-          "line": 451,
+          "line": 467,
+          "params": [
+            "session"
+          ],
           "purpose": "additionally overlays its richer laneStatus (processing/waiting) per lane."
         },
         "startOrchestration": {
-          "line": 491,
+          "line": 507,
           "params": [
             "args = {}"
           ],
           "purpose": "─── session lifecycle ────────────────────────────────────"
         },
         "stopOrchestration": {
-          "line": 540,
+          "line": 572,
+          "params": [
+            "projectPath"
+          ],
           "purpose": "work branches (un-merged work is kept on its branch), leave main untouched."
         },
         "rehydrate": {
-          "line": 575,
+          "line": 610,
           "params": [
-            "projectPath"
+            "session"
           ],
           "purpose": "board/status reflect prior work. Statuses come from git: merged ⇒ done."
         },
         "assignSpecs": {
-          "line": 611,
+          "line": 645,
           "params": [
+            "projectPath",
             "slugs"
           ]
         },
         "getState": {
-          "line": 618
+          "line": 653,
+          "params": [
+            "projectPath"
+          ]
         },
         "setupIPC": {
-          "line": 624,
+          "line": 659,
           "params": [
             "ipcMain"
           ],
@@ -7396,30 +7438,45 @@
         "agentDispatch"
       ],
       "functions": {
+        "_sess": {
+          "line": 39,
+          "params": [
+            "projectPath",
+            "create = false"
+          ]
+        },
+        "_curSess": {
+          "line": 50,
+          "params": [
+            "create = false"
+          ],
+          "purpose": "belongs to the current project). null when no project / no session yet."
+        },
         "setHost": {
-          "line": 37,
+          "line": 54,
           "params": [
             "h"
           ]
         },
         "open": {
-          "line": 63,
+          "line": 90,
           "purpose": "Open (or focus) the orchestrator section tab."
         },
         "orchEnv": {
-          "line": 74,
+          "line": 101,
           "params": [
             "projectPath"
           ],
           "purpose": "─── session ──────────────────────────────────────────────"
         },
         "ensureSession": {
-          "line": 81
+          "line": 108
         },
         "spawnWorkerLane": {
-          "line": 120,
+          "line": 155,
           "params": [
-            "{ slug",
+            "{ projectPath",
+            "slug",
             "worktreePath",
             "env",
             "promptInstruction } = {}"
@@ -7427,93 +7484,96 @@
           "purpose": "─── worker lane bridge ───────────────────────────────────"
         },
         "createViewport": {
-          "line": 147,
+          "line": 184,
           "purpose": "─── section viewport ─────────────────────────────────────"
         },
         "stopSession": {
-          "line": 200,
+          "line": 237,
           "purpose": "un-merged work kept), reset local state, close the tab."
         },
         "renderConductorZone": {
-          "line": 213,
+          "line": 248,
           "params": [
             "root"
           ],
           "purpose": "─── zones ────────────────────────────────────────────────"
         },
         "stageOf": {
-          "line": 246,
+          "line": 282,
           "params": [
             "w"
           ]
         },
         "renderPipeline": {
-          "line": 258,
+          "line": 294,
           "params": [
             "root"
           ]
         },
         "renderWorkerZone": {
-          "line": 300,
+          "line": 337,
           "params": [
             "root"
           ]
         },
         "mergeWorkerAction": {
-          "line": 346,
+          "line": 384,
           "params": [
             "slug"
           ]
         },
         "removeWorkerAction": {
-          "line": 364,
+          "line": 403,
           "params": [
             "slug"
           ]
         },
         "_shortPath": {
-          "line": 373,
+          "line": 412,
           "params": [
             "p"
           ]
         },
         "_relTime": {
-          "line": 379,
+          "line": 418,
           "params": [
             "ts"
           ]
         },
         "loadSpecs": {
-          "line": 390,
+          "line": 429,
           "params": [
             "root"
           ]
         },
         "renderSpecRail": {
-          "line": 405,
+          "line": 444,
           "params": [
             "root",
             "specs"
           ]
         },
         "assignSpec": {
-          "line": 437,
+          "line": 478,
           "params": [
             "slug"
           ]
         },
         "nudgeConductor": {
-          "line": 449
+          "line": 492,
+          "params": [
+            "projectPath"
+          ]
         },
         "_esc": {
-          "line": 462,
+          "line": 506,
           "params": [
             "s"
           ],
           "purpose": "─── helpers ──────────────────────────────────────────────"
         },
         "_toast": {
-          "line": 468,
+          "line": 512,
           "params": [
             "message",
             "type = 'info'"

--- a/src/main/orchestrationManager.js
+++ b/src/main/orchestrationManager.js
@@ -15,7 +15,11 @@
  * Runtime state is ephemeral; git branches + .frame/specs are the source of
  * truth, so a session can be rebuilt from them (rehydration, T26).
  *
- * V1: a single active orchestration session at a time, claude-code conductor.
+ * Sessions are PER-PROJECT: each project keeps its own conductor + workers +
+ * bus watcher, so switching projects never tears down or hides another
+ * project's orchestration. `sessions` is keyed by projectPath; core helpers
+ * take an explicit `session` so a background project's bus events resolve to
+ * the right state. claude-code conductor.
  */
 
 const fs = require('fs');
@@ -47,15 +51,20 @@ const SOFT_DONE_MS = 45000;    // idle this long + commits, no report ⇒ soft-d
 
 let mainWindow = null;
 
-// Single active session (V1). Shape:
-// { projectPath, conductorTerminalId, busDir, assignedSlugs:Set<string>,
-//   workers: Map<slug, worker>, cap, watcher, debounce }
+// Active sessions, keyed by projectPath (one per project). Session shape:
+// { projectPath, conductorTerminalId, conductorDocPath, busDir,
+//   assignedSlugs:Set<string>, workers: Map<slug, worker>, cap, watcher,
+//   debounce, statusPoll, relayQueue, relayDraining }
 // worker = { slug, branch, worktreePath, terminalId, status, diffStat,
 //            declaredFootprint, lastActivityAt }
-let session = null;
+const sessions = new Map();
 
 function init(window) {
   mainWindow = window;
+}
+
+function sessionFor(projectPath) {
+  return (projectPath && sessions.get(projectPath)) || null;
 }
 
 // ─── path helpers ─────────────────────────────────────────
@@ -72,7 +81,7 @@ function worktreeDirFor(projectPath, slug) {
 
 // Inject the bus path (+ optional slug) so a lane can reach Frame from any
 // worktree, regardless of its own .frame/ copy.
-function envForLane(slug) {
+function envForLane(session, slug) {
   const env = {
     [ORCH_BUS_ENV]: session.busDir,
     FRAME_ORCH_BIN: binDirFor(session.projectPath) // absolute path to .frame/bin (worktrees lack their own)
@@ -114,7 +123,7 @@ function footprintsOverlap(fa, fb) {
 
 // An in-flight spec whose footprint overlaps `footprint`, or null. done/failed
 // workers don't block (their work is already integrated or abandoned).
-function findFootprintConflict(slug, footprint) {
+function findFootprintConflict(session, slug, footprint) {
   for (const w of session.workers.values()) {
     if (w.slug === slug) continue;
     if (!['running', 'idle'].includes(w.status)) continue; // only in-flight workers block
@@ -148,17 +157,17 @@ function buildWorkerPrompt(projectPath, slug) {
 //      and submits before the next starts.
 const relaySleep = (ms) => new Promise((r) => setTimeout(r, ms));
 
-function relayToConductor(text) {
+function relayToConductor(session, text) {
   if (!session || !session.conductorTerminalId) return;
   session.relayQueue.push(text);
-  drainRelayQueue();
+  drainRelayQueue(session);
 }
 
-async function drainRelayQueue() {
+async function drainRelayQueue(session) {
   if (!session || session.relayDraining) return;
   session.relayDraining = true;
   try {
-    while (session && session.conductorTerminalId && session.relayQueue.length) {
+    while (session.conductorTerminalId && session.relayQueue.length) {
       const id = session.conductorTerminalId;
       const text = session.relayQueue.shift();
       try { ptyManager.writeToTerminal(id, text); } catch (e) {}
@@ -167,7 +176,7 @@ async function drainRelayQueue() {
       await relaySleep(400);                                  // gap before next message
     }
   } finally {
-    if (session) session.relayDraining = false;
+    session.relayDraining = false;
   }
 }
 
@@ -184,8 +193,8 @@ function materializeBinScripts(projectPath) {
 
 // ─── state publish ────────────────────────────────────────
 
-function serializeState() {
-  if (!session) return {};
+function serializeState(session) {
+  if (!session) return { active: false, workers: [] };
   return {
     active: true,
     projectPath: session.projectPath,
@@ -207,9 +216,9 @@ function serializeState() {
   };
 }
 
-function publishState() {
+function publishState(session) {
   if (!session) return;
-  const state = serializeState();
+  const state = serializeState(session);
   if (mainWindow && !mainWindow.isDestroyed()) {
     mainWindow.webContents.send(IPC.ORCH_STATE, state);
   }
@@ -225,21 +234,21 @@ function publishState() {
 
 // ─── bus watcher ──────────────────────────────────────────
 
-function startBusWatcher() {
+function startBusWatcher(session) {
   fs.mkdirSync(session.busDir, { recursive: true });
-  drainBus(); // pick up anything queued before the watcher attached
+  drainBus(session); // pick up anything queued before the watcher attached
   try {
     session.watcher = fs.watch(session.busDir, () => {
       clearTimeout(session.debounce);
-      session.debounce = setTimeout(drainBus, WATCH_DEBOUNCE_MS);
+      session.debounce = setTimeout(() => drainBus(session), WATCH_DEBOUNCE_MS);
     });
   } catch (e) {
     console.error('[orch] failed to watch bus dir:', e.message);
   }
 }
 
-function drainBus() {
-  if (!session) return;
+function drainBus(session) {
+  if (!session || !sessions.has(session.projectPath)) return;
   let files;
   try {
     files = fs.readdirSync(session.busDir);
@@ -258,21 +267,21 @@ function drainBus() {
       continue; // partial/corrupt — atomic writers shouldn't cause this; skip
     }
     try { fs.unlinkSync(full); } catch (e) {}
-    handleRequest(req);
+    handleRequest(session, req);
   }
 }
 
-function handleRequest(req) {
+function handleRequest(session, req) {
   if (!req || !req.type) return;
   switch (req.type) {
     case 'dispatch':
-      handleDispatch(req.slug).catch((e) => console.error('[orch] dispatch error:', e));
+      handleDispatch(session, req.slug).catch((e) => console.error('[orch] dispatch error:', e));
       return;
     case 'report-done':
-      handleReportDone(req.slug).catch((e) => console.error('[orch] report-done error:', e));
+      handleReportDone(session, req.slug).catch((e) => console.error('[orch] report-done error:', e));
       return;
     case 'merge':
-      handleMerge(req.slug, req.args).catch((e) => console.error('[orch] merge error:', e));
+      handleMerge(session, req.slug, req.args).catch((e) => console.error('[orch] merge error:', e));
       return;
     default:
       console.warn('[orch] unknown bus request type:', req.type);
@@ -282,7 +291,7 @@ function handleRequest(req) {
 // ─── request handlers ─────────────────────────────────────
 
 // T10 (worktree + worker spawn) + T13 (conflict guard). Cap check is T24.
-async function handleDispatch(slug) {
+async function handleDispatch(session, slug) {
   if (!session || !slug) return;
 
   const existing = session.workers.get(slug);
@@ -300,28 +309,28 @@ async function handleDispatch(slug) {
       slug, branch: orchWorkBranch(slug), worktreePath: null, terminalId: null,
       status: 'queued', declaredFootprint: footprint, lastActivityAt: Date.now()
     });
-    relayToConductor(`QUEUED: "${slug}" — worker cap (${session.cap}) reached. Re-dispatch after a slot frees.`);
-    publishState();
+    relayToConductor(session, `QUEUED: "${slug}" — worker cap (${session.cap}) reached. Re-dispatch after a slot frees.`);
+    publishState(session);
     return;
   }
 
   // T13 — code-enforced conflict guard (independent of the conductor's reasoning)
-  const conflict = findFootprintConflict(slug, footprint);
+  const conflict = findFootprintConflict(session, slug, footprint);
   if (conflict) {
     session.workers.set(slug, {
       slug, branch: orchWorkBranch(slug), worktreePath: null, terminalId: null,
       status: 'blocked', declaredFootprint: footprint, blockedBy: conflict,
       lastActivityAt: Date.now()
     });
-    relayToConductor(`BLOCKED: "${slug}" conflicts with in-flight "${conflict}" (overlapping footprint). Dispatch it after "${conflict}" merges.`);
-    publishState();
+    relayToConductor(session, `BLOCKED: "${slug}" conflicts with in-flight "${conflict}" (overlapping footprint). Dispatch it after "${conflict}" merges.`);
+    publishState(session);
     return;
   }
 
   // Create the isolated worktree (fresh base from current HEAD)
   const wt = await gitBranches.createOrchWorktree(session.projectPath, slug);
   if (wt.error) {
-    relayToConductor(`DISPATCH FAILED: "${slug}" — worktree error: ${wt.error}`);
+    relayToConductor(session, `DISPATCH FAILED: "${slug}" — worktree error: ${wt.error}`);
     return;
   }
 
@@ -337,32 +346,36 @@ async function handleDispatch(slug) {
   // Hand off to the renderer: it owns xterm, so it creates the lane (in the
   // worktree, with our orch env), then runs agentDispatch (start agent, wait
   // agent-ready, inject the worker prompt). See orchestrator.js (T12).
+  // projectPath travels with the request so the renderer files the lane under
+  // the right project even if the user is currently viewing another one.
   if (mainWindow && !mainWindow.isDestroyed()) {
     mainWindow.webContents.send(IPC.ORCH_SPAWN_WORKER, {
+      projectPath: session.projectPath,
       slug,
       worktreePath: wt.path,
-      env: envForLane(slug),
+      env: envForLane(session, slug),
       promptInstruction: instruction
     });
   }
-  publishState();
+  publishState(session);
 }
 
 // The renderer reports the terminalId it created for a worker lane, so the
 // manager can track status, relay, and tear it down.
-function registerWorkerLane(slug, terminalId) {
+function registerWorkerLane(projectPath, slug, terminalId) {
+  const session = sessionFor(projectPath);
   if (!session || !slug || !terminalId) return { error: 'invalid' };
   const w = session.workers.get(slug);
   if (!w) return { error: 'no such worker' };
   w.terminalId = terminalId;
   w.lastActivityAt = Date.now();
-  publishState();
+  publishState(session);
   return { success: true };
 }
 
 // T15 — a worker reported completion: mark done, attach a diff stat, relay to
 // the conductor with the merge command.
-async function handleReportDone(slug) {
+async function handleReportDone(session, slug) {
   if (!session || !slug) return;
   const w = session.workers.get(slug);
   if (!w) return;
@@ -373,17 +386,17 @@ async function handleReportDone(slug) {
     n = (await gitBranches.worktreeChangedFiles(session.projectPath, slug, w.baseSha || 'HEAD')).length;
   } catch (e) {}
   w.diffStat = { files: n };
-  relayToConductor(`WORKER DONE: "${slug}" — branch ${w.branch} (${n} file${n === 1 ? '' : 's'} changed). Review it (git log/diff) and tell the USER it's ready for their approval (board → Approve). Do NOT merge it yourself — approval is the user's call, unless they explicitly ask you to merge.`);
-  publishState();
+  relayToConductor(session, `WORKER DONE: "${slug}" — branch ${w.branch} (${n} file${n === 1 ? '' : 's'} changed). Review it (git log/diff) and tell the USER it's ready for their approval (board → Approve). Do NOT merge it yourself — approval is the user's call, unless they explicitly ask you to merge.`);
+  publishState(session);
 }
 
 // T22 (drift check + fast-forward merge into integration) + T23 (meta reconcile
 // reminder; the conductor performs the actual reconcile per CONDUCTOR.md).
-async function handleMerge(slug, args = []) {
-  if (!session || !slug) return;
+async function handleMerge(session, slug, args = []) {
+  if (!session || !slug) return { status: 'failed', error: 'no session' };
   const w = session.workers.get(slug);
   if (!w) {
-    relayToConductor(`MERGE FAILED: no worker found for "${slug}".`);
+    relayToConductor(session, `MERGE FAILED: no worker found for "${slug}".`);
     return { status: 'failed', error: 'no worker' };
   }
   const force = Array.isArray(args) && args.includes('--force');
@@ -395,7 +408,7 @@ async function handleMerge(slug, args = []) {
     (f) => !ORCH_META_FILES.includes(f.split('/').pop()) && !declared.some((d) => entriesOverlap(d, f))
   );
   if (drift.length && !force) {
-    relayToConductor(
+    relayToConductor(session,
       `DRIFT: "${slug}" changed files outside its declared footprint:\n  - ${drift.join('\n  - ')}\n` +
       `Review, then merge anyway with: node "$FRAME_ORCH_BIN/merge.js" ${slug} --force`
     );
@@ -404,27 +417,30 @@ async function handleMerge(slug, args = []) {
 
   const res = await gitBranches.mergeWorkToIntegration(session.projectPath, slug);
   if (res.error) {
-    relayToConductor(`MERGE FAILED: "${slug}" — ${res.error}`);
+    relayToConductor(session, `MERGE FAILED: "${slug}" — ${res.error}`);
     return { status: 'failed', error: res.error };
   }
   w.status = 'done';
   w.merged = true;
   w.lastActivityAt = Date.now();
-  relayToConductor(
+  relayToConductor(session,
     `MERGED: "${slug}" → ${res.branch}. Reconcile meta now (npm run structure; mark ${slug} tasks done in tasks.json; append PROJECT_NOTES if useful), then advance to the next spec.`
   );
-  publishState();
+  publishState(session);
   return { status: 'merged', branch: res.branch };
 }
 
 // Per-worker merge trigger from the board UI (mirrors a conductor merge.js call).
-async function mergeWorker(slug, force = false) {
-  return handleMerge(slug, force ? ['--force'] : []);
+async function mergeWorker(projectPath, slug, force = false) {
+  const session = sessionFor(projectPath);
+  if (!session) return { status: 'failed', error: 'no session' };
+  return handleMerge(session, slug, force ? ['--force'] : []);
 }
 
 // Per-worker cleanup from the board UI: stop its lane, remove the worktree, and
 // prune the work branch ONLY if merged (un-merged work is kept — no data loss).
-async function removeWorker(slug) {
+async function removeWorker(projectPath, slug) {
+  const session = sessionFor(projectPath);
   if (!session || !slug) return { error: 'no session' };
   const w = session.workers.get(slug);
   if (!w) return { error: 'no such worker' };
@@ -437,7 +453,7 @@ async function removeWorker(slug) {
     try { await gitBranches.removeOrchWorktree(session.projectPath, slug, { deleteBranch: merged }); } catch (e) {}
   }
   session.workers.delete(slug);
-  publishState();
+  publishState(session);
   return { success: true, branchKept: !merged };
 }
 
@@ -448,8 +464,8 @@ async function removeWorker(slug) {
 // nudge when a worker goes idle with commits but never reported. The renderer
 // additionally overlays its richer laneStatus (processing/waiting) per lane.
 
-function pollStatuses() {
-  if (!session) return;
+function pollStatuses(session) {
+  if (!session || !sessions.has(session.projectPath)) return;
   let changed = false;
   for (const w of session.workers.values()) {
     if (!w.terminalId) continue;                       // blocked/queued/detached — no lane
@@ -459,7 +475,7 @@ function pollStatuses() {
     if (!info) {
       w.status = 'failed';
       w.lastActivityAt = Date.now();
-      relayToConductor(`WORKER FAILED: "${w.slug}" — its lane exited unexpectedly.`);
+      relayToConductor(session, `WORKER FAILED: "${w.slug}" — its lane exited unexpectedly.`);
       changed = true;
       continue;
     }
@@ -472,18 +488,18 @@ function pollStatuses() {
     if (next === 'idle' && idleFor >= SOFT_DONE_MS && !w.softDoneNudged) {
       gitBranches.worktreeChangedFiles(session.projectPath, w.slug, w.baseSha || 'HEAD')
         .then((files) => {
-          if (!session) return;
+          if (!sessions.has(session.projectPath)) return;
           const ww = session.workers.get(w.slug);
           if (ww && !ww.softDoneNudged && files.length && ['idle', 'running'].includes(ww.status)) {
             ww.softDoneNudged = true;
-            relayToConductor(`SOFT-DONE? "${w.slug}" is idle with ${files.length} file(s) committed but sent no done report — verify it (finished, or waiting on input?).`);
-            publishState();
+            relayToConductor(session, `SOFT-DONE? "${w.slug}" is idle with ${files.length} file(s) committed but sent no done report — verify it (finished, or waiting on input?).`);
+            publishState(session);
           }
         })
         .catch(() => {});
     }
   }
-  if (changed) publishState();
+  if (changed) publishState(session);
 }
 
 // ─── session lifecycle ────────────────────────────────────
@@ -491,11 +507,28 @@ function pollStatuses() {
 async function startOrchestration(args = {}) {
   const { projectPath, conductorTerminalId, cap } = args;
   if (!projectPath) return { error: 'projectPath required' };
-  if (session) await stopOrchestration(); // one session at a time
 
-  session = {
+  // Idempotent: returning to a project that already has a live session must
+  // re-attach, not restart. The renderer reuses its existing conductor lane —
+  // but if it had to spin up a fresh one (the old terminal was closed), adopt
+  // the new id so relays reach a live terminal.
+  const existing = sessions.get(projectPath);
+  if (existing) {
+    if (conductorTerminalId && conductorTerminalId !== existing.conductorTerminalId) {
+      existing.conductorTerminalId = conductorTerminalId;
+    }
+    return {
+      success: true,
+      reattached: true,
+      busDir: existing.busDir,
+      conductorDocPath: existing.conductorDocPath
+    };
+  }
+
+  const session = {
     projectPath,
     conductorTerminalId: conductorTerminalId || null,
+    conductorDocPath: null,
     busDir: busDirFor(projectPath),
     assignedSlugs: new Set(),
     workers: new Map(),
@@ -506,6 +539,7 @@ async function startOrchestration(args = {}) {
     relayQueue: [],
     relayDraining: false
   };
+  sessions.set(projectPath, session);
 
   try {
     materializeBinScripts(projectPath);
@@ -513,34 +547,36 @@ async function startOrchestration(args = {}) {
     console.error('[orch] failed to materialize bin scripts:', e.message);
   }
   // Materialize the conductor protocol doc so the conductor lane can read it.
-  let conductorDocPath = null;
   try {
     let tpl = '';
     try { tpl = fs.readFileSync(CONDUCTOR_TEMPLATE_PATH, 'utf8'); } catch (e) {}
     const dir = path.join(projectPath, FRAME_DIR, 'orchestration');
     fs.mkdirSync(dir, { recursive: true });
-    conductorDocPath = path.join(dir, 'CONDUCTOR.md');
-    fs.writeFileSync(conductorDocPath, tpl || '# Conductor\nCoordinate specs; use $FRAME_ORCH_BIN/{dispatch,merge,status}.js.');
+    session.conductorDocPath = path.join(dir, 'CONDUCTOR.md');
+    fs.writeFileSync(session.conductorDocPath, tpl || '# Conductor\nCoordinate specs; use $FRAME_ORCH_BIN/{dispatch,merge,status}.js.');
   } catch (e) {
     console.error('[orch] failed to materialize CONDUCTOR.md:', e.message);
   }
-  session.conductorDocPath = conductorDocPath;
 
-  startBusWatcher();
-  session.statusPoll = setInterval(pollStatuses, STATUS_POLL_MS);
+  startBusWatcher(session);
+  session.statusPoll = setInterval(() => pollStatuses(session), STATUS_POLL_MS);
   // Recover any worktrees/branches left by a prior (e.g. app-closed) session so
   // they reappear on the board instead of being orphaned.
-  try { await rehydrate(projectPath); } catch (e) {}
-  publishState();
-  return { success: true, busDir: session.busDir, conductorDocPath };
+  try { await rehydrate(session); } catch (e) {}
+  publishState(session);
+  return { success: true, busDir: session.busDir, conductorDocPath: session.conductorDocPath };
 }
 
 // T25 — teardown: stop worker lanes, remove their worktrees, prune only MERGED
 // work branches (un-merged work is kept on its branch), leave main untouched.
-async function stopOrchestration() {
+async function stopOrchestration(projectPath) {
+  const session = sessionFor(projectPath);
   if (!session) return { success: true };
   const proj = session.projectPath;
   const workers = Array.from(session.workers.values());
+
+  // Remove from the registry first so any in-flight bus/poll callbacks bail.
+  sessions.delete(proj);
 
   try { if (session.watcher) session.watcher.close(); } catch (e) {}
   clearTimeout(session.debounce);
@@ -562,9 +598,8 @@ async function stopOrchestration() {
     }
   }
 
-  session = null;
   if (mainWindow && !mainWindow.isDestroyed()) {
-    mainWindow.webContents.send(IPC.ORCH_STATE, { active: false, workers: [] });
+    mainWindow.webContents.send(IPC.ORCH_STATE, { active: false, projectPath: proj, workers: [] });
   }
   return { success: true };
 }
@@ -572,10 +607,9 @@ async function stopOrchestration() {
 // T26 — best-effort rehydration from frame/<slug>/* branches after a restart.
 // Rebuilds worker entries (no live terminals; agents are ephemeral) so the
 // board/status reflect prior work. Statuses come from git: merged ⇒ done.
-async function rehydrate(projectPath) {
-  if (!session || session.projectPath !== projectPath) {
-    return { error: 'no matching active session' };
-  }
+async function rehydrate(session) {
+  if (!session) return { error: 'no session' };
+  const projectPath = session.projectPath;
   const branches = await gitBranches.listOrchBranches(projectPath);
   let recovered = 0;
   for (const [slug, kinds] of Object.entries(branches)) {
@@ -604,31 +638,32 @@ async function rehydrate(projectPath) {
     });
     recovered++;
   }
-  publishState();
+  publishState(session);
   return { success: true, recovered };
 }
 
-function assignSpecs(slugs) {
+function assignSpecs(projectPath, slugs) {
+  const session = sessionFor(projectPath);
   if (!session) return { error: 'no active orchestration' };
   session.assignedSlugs = new Set(Array.isArray(slugs) ? slugs : []);
-  publishState();
+  publishState(session);
   return { success: true, assigned: Array.from(session.assignedSlugs) };
 }
 
-function getState() {
-  return serializeState();
+function getState(projectPath) {
+  return serializeState(sessionFor(projectPath));
 }
 
 // ─── IPC ──────────────────────────────────────────────────
 
 function setupIPC(ipcMain) {
   ipcMain.handle(IPC.START_ORCHESTRATION, (e, args) => startOrchestration(args || {}));
-  ipcMain.handle(IPC.STOP_ORCHESTRATION, () => stopOrchestration());
-  ipcMain.handle(IPC.GET_ORCH_STATE, () => getState());
-  ipcMain.handle(IPC.ORCH_ASSIGN_SPECS, (e, args) => assignSpecs((args || {}).slugs));
-  ipcMain.on(IPC.ORCH_WORKER_LANE, (e, args) => registerWorkerLane((args || {}).slug, (args || {}).terminalId));
-  ipcMain.handle(IPC.ORCH_MERGE_WORKER, (e, args) => mergeWorker((args || {}).slug, (args || {}).force));
-  ipcMain.handle(IPC.ORCH_REMOVE_WORKER, (e, args) => removeWorker((args || {}).slug));
+  ipcMain.handle(IPC.STOP_ORCHESTRATION, (e, args) => stopOrchestration((args || {}).projectPath));
+  ipcMain.handle(IPC.GET_ORCH_STATE, (e, args) => getState((args || {}).projectPath));
+  ipcMain.handle(IPC.ORCH_ASSIGN_SPECS, (e, args) => assignSpecs((args || {}).projectPath, (args || {}).slugs));
+  ipcMain.on(IPC.ORCH_WORKER_LANE, (e, args) => registerWorkerLane((args || {}).projectPath, (args || {}).slug, (args || {}).terminalId));
+  ipcMain.handle(IPC.ORCH_MERGE_WORKER, (e, args) => mergeWorker((args || {}).projectPath, (args || {}).slug, (args || {}).force));
+  ipcMain.handle(IPC.ORCH_REMOVE_WORKER, (e, args) => removeWorker((args || {}).projectPath, (args || {}).slug));
 }
 
 module.exports = {
@@ -648,6 +683,7 @@ module.exports = {
     envForLane,
     publishState,
     drainBus,
-    getSession: () => session
+    sessionFor,
+    getSession: (projectPath) => sessionFor(projectPath)
   }
 };

--- a/src/renderer/orchestrator.js
+++ b/src/renderer/orchestrator.js
@@ -26,13 +26,30 @@ const agentDispatch = require('./agentDispatch');
 
 let host = null;             // MultiTerminalUI
 let seq = 0;
-let sessionStarted = false;
-let conductorId = null;
-let latestState = { workers: [] };
-const assigned = new Set();  // slugs assigned to the conductor
 let liveContainer = null;    // current rendered root, for in-place worker updates
 let activeVpKey = null;      // current section viewport key (for Stop → close tab)
 let spawnChain = Promise.resolve(); // serializes worker-lane creation (see setHost)
+
+// Sessions are PER-PROJECT: switching projects must not lose another project's
+// conductor/workers. Each entry holds that project's view state; the live
+// terminals themselves survive project switches in the terminal manager.
+// Map<projectPath, { started, conductorId, latestState, assigned:Set<slug> }>
+const sessions = new Map();
+
+function _sess(projectPath, create = false) {
+  let s = projectPath ? sessions.get(projectPath) : null;
+  if (!s && create && projectPath) {
+    s = { started: false, conductorId: null, latestState: { workers: [] }, assigned: new Set() };
+    sessions.set(projectPath, s);
+  }
+  return s || null;
+}
+
+// The session for the project currently on screen (the visible viewport always
+// belongs to the current project). null when no project / no session yet.
+function _curSess(create = false) {
+  return _sess(state.getProjectPath(), create);
+}
 
 function setHost(h) {
   host = h;
@@ -48,11 +65,21 @@ function setHost(h) {
       .catch((err) => console.error('orchestrator: spawn failed', err));
   });
 
-  // Live worker state → update the workers zone in place (don't disturb the
-  // mounted conductor terminal).
+  // Live worker state → route to the right project's session, then update the
+  // workers zone in place ONLY if that project is the one on screen (don't
+  // disturb the mounted conductor terminal, and don't let a background
+  // project's state bleed into the visible board).
   ipcRenderer.on(IPC.ORCH_STATE, (event, st) => {
-    latestState = st || { workers: [] };
-    if (liveContainer && document.body.contains(liveContainer)) {
+    const projectPath = st && st.projectPath;
+    if (!projectPath) return;
+    if (st.active === false) {
+      // Main tore this project's session down (Stop). Drop our view state.
+      sessions.delete(projectPath);
+    } else {
+      const s = _sess(projectPath, true);
+      s.latestState = st;
+    }
+    if (projectPath === state.getProjectPath() && liveContainer && document.body.contains(liveContainer)) {
       renderPipeline(liveContainer);
       renderWorkerZone(liveContainer);
     }
@@ -79,15 +106,22 @@ function orchEnv(projectPath) {
 }
 
 async function ensureSession() {
-  if (sessionStarted) return true;
   const projectPath = state.getProjectPath();
   if (!projectPath) return false;
+  const s = _sess(projectPath, true);
 
+  // Re-attach: this project already has a live session and its conductor
+  // terminal survived the project switch — reuse it, don't spin up a second
+  // conductor or restart main's session.
+  if (s.started && s.conductorId && host.getManager().getTerminal(s.conductorId)) {
+    return true;
+  }
+
+  let conductorId = null;
   try {
-    conductorId = await host.createTerminalForCurrentProject({ extraEnv: orchEnv(projectPath) });
+    conductorId = await host.createTerminalForCurrentProject({ projectPath, extraEnv: orchEnv(projectPath) });
   } catch (err) {
     console.error('orchestrator: conductor lane creation failed', err);
-    conductorId = null;
   }
   if (!conductorId) {
     _toast('Could not create the conductor Frame (terminal limit reached?)', 'error');
@@ -103,7 +137,8 @@ async function ensureSession() {
   }
   const docPath = (res && res.conductorDocPath) || path.join(projectPath, FRAME_DIR, 'orchestration', 'CONDUCTOR.md');
 
-  sessionStarted = true;
+  s.started = true;
+  s.conductorId = conductorId;
   // Start the conductor agent in the background (enter:false → stay on the tab).
   agentDispatch.dispatch({
     terminalId: conductorId,
@@ -117,11 +152,13 @@ async function ensureSession() {
 
 // ─── worker lane bridge ───────────────────────────────────
 
-async function spawnWorkerLane({ slug, worktreePath, env, promptInstruction } = {}) {
+async function spawnWorkerLane({ projectPath, slug, worktreePath, env, promptInstruction } = {}) {
   if (!host || !slug) return;
   let terminalId = null;
   try {
-    terminalId = await host.createTerminalForCurrentProject({ cwd: worktreePath, extraEnv: env });
+    // File the lane under its own project (not "current") — a background
+    // project may dispatch a worker while the user is viewing another one.
+    terminalId = await host.createTerminalForCurrentProject({ projectPath, cwd: worktreePath, extraEnv: env });
   } catch (err) {
     console.error('orchestrator: worker lane creation failed', err);
   }
@@ -129,7 +166,7 @@ async function spawnWorkerLane({ slug, worktreePath, env, promptInstruction } = 
     _toast(`Could not open a worker Frame for "${slug}"`, 'error');
     return;
   }
-  ipcRenderer.send(IPC.ORCH_WORKER_LANE, { slug, terminalId });
+  ipcRenderer.send(IPC.ORCH_WORKER_LANE, { projectPath, slug, terminalId });
 
   // The lane is already created above (so it exists + joins the frame switcher).
   // enter:false → don't steal focus into it; the user stays on the orchestrator
@@ -199,11 +236,9 @@ function createViewport() {
 // un-merged work kept), reset local state, close the tab.
 async function stopSession() {
   if (!window.confirm('Stop orchestration?\nWorker worktrees are removed and the conductor lane is closed. Un-merged work stays on its branch.')) return;
-  try { await ipcRenderer.invoke(IPC.STOP_ORCHESTRATION); } catch (e) { console.error('orchestrator: stop failed', e); }
-  sessionStarted = false;
-  conductorId = null;
-  latestState = { workers: [] };
-  assigned.clear();
+  const projectPath = state.getProjectPath();
+  try { await ipcRenderer.invoke(IPC.STOP_ORCHESTRATION, { projectPath }); } catch (e) { console.error('orchestrator: stop failed', e); }
+  sessions.delete(projectPath); // drop this project's view state (others untouched)
   if (host && activeVpKey) host.closeSection(activeVpKey);
   _toast('Orchestration stopped — worktrees cleaned up', 'info');
 }
@@ -213,6 +248,7 @@ async function stopSession() {
 function renderConductorZone(root) {
   const zone = root.querySelector('[data-zone="conductor"]');
   if (!zone) return;
+  const conductorId = _curSess() && _curSess().conductorId;
   zone.innerHTML = `
     <div class="orch-zone-head">
       <span class="orch-zone-title">Conductor</span>
@@ -258,7 +294,8 @@ function stageOf(w) {
 function renderPipeline(root) {
   const bar = root.querySelector('[data-zone="pipeline"]');
   if (!bar) return;
-  const workers = (latestState && latestState.workers) || [];
+  const cur = _curSess();
+  const workers = (cur && cur.latestState && cur.latestState.workers) || [];
   if (!workers.length) { bar.innerHTML = ''; return; } // hidden via :empty until there's activity
   const byStage = {};
   for (const w of workers) (byStage[stageOf(w)] = byStage[stageOf(w)] || []).push(w);
@@ -300,7 +337,8 @@ const WORKER_STATUS_LABEL = {
 function renderWorkerZone(root) {
   const zone = root.querySelector('[data-zone="workers"]');
   if (!zone) return;
-  const workers = (latestState && latestState.workers) || [];
+  const cur = _curSess();
+  const workers = (cur && cur.latestState && cur.latestState.workers) || [];
   zone.innerHTML = `<div class="orch-zone-head"><span class="orch-zone-title">Workers</span><span class="orch-zone-count">${workers.length}</span></div>`;
   if (!workers.length) {
     zone.insertAdjacentHTML('beforeend', '<div class="orch-empty">No workers running. Assign a spec to begin.</div>');
@@ -344,8 +382,9 @@ function renderWorkerZone(root) {
 }
 
 async function mergeWorkerAction(slug) {
+  const projectPath = state.getProjectPath();
   let res;
-  try { res = await ipcRenderer.invoke(IPC.ORCH_MERGE_WORKER, { slug }); }
+  try { res = await ipcRenderer.invoke(IPC.ORCH_MERGE_WORKER, { projectPath, slug }); }
   catch (e) { res = { status: 'failed', error: e.message }; }
   if (!res) return;
   if (res.status === 'merged') {
@@ -353,7 +392,7 @@ async function mergeWorkerAction(slug) {
   } else if (res.status === 'drift') {
     const ok = window.confirm(`"${slug}" changed files outside its declared footprint:\n\n${(res.drift || []).join('\n')}\n\nApprove anyway?`);
     if (ok) {
-      const f = await ipcRenderer.invoke(IPC.ORCH_MERGE_WORKER, { slug, force: true }).catch((e) => ({ status: 'failed', error: e.message }));
+      const f = await ipcRenderer.invoke(IPC.ORCH_MERGE_WORKER, { projectPath, slug, force: true }).catch((e) => ({ status: 'failed', error: e.message }));
       _toast(f && f.status === 'merged' ? `Approved "${slug}" (forced)` : `Approve failed: ${(f && f.error) || 'unknown'}`, f && f.status === 'merged' ? 'info' : 'error');
     }
   } else {
@@ -364,7 +403,7 @@ async function mergeWorkerAction(slug) {
 async function removeWorkerAction(slug) {
   if (!window.confirm(`Remove worker "${slug}"?\nIts worktree is deleted; un-merged work stays on its branch.`)) return;
   let res;
-  try { res = await ipcRenderer.invoke(IPC.ORCH_REMOVE_WORKER, { slug }); }
+  try { res = await ipcRenderer.invoke(IPC.ORCH_REMOVE_WORKER, { projectPath: state.getProjectPath(), slug }); }
   catch (e) { res = { error: e.message }; }
   if (res && res.success) _toast(`Removed "${slug}"${res.branchKept ? ' (branch kept — un-merged)' : ''}`, 'info');
   else _toast(`Remove failed: ${(res && res.error) || 'unknown'}`, 'error');
@@ -410,12 +449,14 @@ function renderSpecRail(root, specs) {
     zone.insertAdjacentHTML('beforeend', '<div class="orch-empty">No specs yet.</div>');
     return;
   }
+  const cur = _curSess();
+  const assignedSet = (cur && cur.assigned) || new Set();
   for (const spec of specs) {
     const slug = specSlug(spec);
     if (!slug) continue;
     const phase = specPhase(spec);
     const assignable = ASSIGNABLE_PHASES.includes(phase);
-    const isAssigned = assigned.has(slug);
+    const isAssigned = assignedSet.has(slug);
     const row = document.createElement('div');
     row.className = 'orch-spec-row' + (assignable ? '' : ' disabled');
     row.innerHTML = `
@@ -435,23 +476,26 @@ function renderSpecRail(root, specs) {
 let nudgeTimer = null;
 
 function assignSpec(slug) {
-  assigned.add(slug);
-  ipcRenderer.invoke(IPC.ORCH_ASSIGN_SPECS, { slugs: Array.from(assigned) })
+  const projectPath = state.getProjectPath();
+  const s = _sess(projectPath, true);
+  s.assigned.add(slug);
+  ipcRenderer.invoke(IPC.ORCH_ASSIGN_SPECS, { projectPath, slugs: Array.from(s.assigned) })
     .catch((err) => console.error('orchestrator: assign failed', err));
   // Coalesce rapid Assign clicks into ONE batch nudge to the conductor — per-spec
   // nudges pushed it into single-spec mode and could interleave in the terminal,
   // dropping the last one. One set-reconcile message keeps it in wave mode.
   clearTimeout(nudgeTimer);
-  nudgeTimer = setTimeout(nudgeConductor, 600);
+  nudgeTimer = setTimeout(() => nudgeConductor(projectPath), 600);
   if (liveContainer && document.body.contains(liveContainer)) loadSpecs(liveContainer);
 }
 
-function nudgeConductor() {
-  if (!conductorId) return;
-  const set = Array.from(assigned);
+function nudgeConductor(projectPath) {
+  const s = _sess(projectPath);
+  if (!s || !s.conductorId) return;
+  const set = Array.from(s.assigned);
   if (!set.length) return;
   agentDispatch.dispatch({
-    terminalId: conductorId,
+    terminalId: s.conductorId,
     prompt: `Assigned specs are now: ${set.join(', ')}. Per CONDUCTOR.md, treat this set as the source of truth: validate each is ready, build the conflict graph, and dispatch ALL ready, non-conflicting specs now (in waves). Do not wait for per-spec confirmation; re-check the full set, not just the newest one.`,
     enter: false
   }).catch((err) => console.error('orchestrator: assign-nudge failed', err));
@@ -476,5 +520,16 @@ function _toast(message, type = 'info') {
   setTimeout(() => { toast.classList.remove('visible'); setTimeout(() => toast.remove(), 300); }, 3000);
 }
 
-const api = { setHost, open, createViewport, isActive: () => sessionStarted };
+// Active only when the CURRENT project has a live session — the Home card shows
+// "Open Orchestrator" for a project with a running session and "Start
+// Orchestrator" for one without, independent of other projects' sessions.
+const api = {
+  setHost,
+  open,
+  createViewport,
+  isActive: () => {
+    const s = _curSess();
+    return !!(s && s.started);
+  }
+};
 module.exports = api;


### PR DESCRIPTION
## Problem

Orchestration kept a **single global session** in both the main process and the renderer. Switching projects had two failure modes:

1. **Original bug:** another project's orchestrator showed up — the Home card said *"Open Orchestrator"* instead of *"Start"*, and opening it reattached to the **wrong** project's running session.
2. **First fix attempt:** resetting on switch instead lost the previous project's session entirely (A → B → A wiped A).

Root cause: the session was global, not keyed by project — so there could only ever be one.

## Fix

Make orchestration sessions **per-project**, end to end. Returning to a project re-attaches to its still-running conductor + workers; other projects keep running in the background untouched.

### main — `orchestrationManager.js`
- Replace the single `session` global with a `sessions` Map keyed by `projectPath`. Core helpers take an explicit `session`, so a background project's bus/poll events resolve to the right state.
- `startOrchestration` is now **idempotent**: returning to a project with a live session re-attaches (adopting a fresh conductor id if the old lane was closed) instead of restarting and wiping work.
- `stopOrchestration` / `getState` / `assignSpecs` / `mergeWorker` / `removeWorker` / `registerWorkerLane` are scoped by `projectPath`; `ORCH_SPAWN_WORKER` and `ORCH_STATE` now carry `projectPath`.
- Bus watcher, status poll, and relay queue are per-session.

### renderer — `orchestrator.js`
- Replace global session vars with a per-project `sessions` Map (`started`, `conductorId`, `latestState`, `assigned`).
- `ORCH_STATE` is routed to the owning project's session and only repaints the board when that project is on screen (no background bleed).
- `ensureSession` re-attaches to a surviving conductor terminal instead of spawning a second one; worker lanes are filed under their **own** project (a background project can dispatch while you view another).
- `isActive()` reflects only the current project's session, so the Home card shows Start/Open correctly per project.

## Verification

Headless test (two temp git repos, concurrent sessions):
- Two sessions stay isolated — distinct bus dirs, conductors, and assignments.
- Re-attach is idempotent (returning to a project keeps its conductor, doesn't restart).
- Stopping one session leaves the other fully intact.

Renderer bundle builds clean; both files pass `node --check`.

## Behavior now

A running in background while you view B → B shows *"Start Orchestrator"* and gets its own session; A keeps working; return to A → *"Open Orchestrator"*, session is exactly as you left it.

> Note: this resolves the **project-switch** bug only. The separate Windows issue (conductor prompt not injected; bus scripts assuming POSIX `\$FRAME_ORCH_BIN`) is tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)