### PR TITLE
fix(lane-status): detect agents on Windows via the TUI fingerprint

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -3453,8 +3453,16 @@
           ],
           "purpose": "Returns { status, lastActivityAt, foreground, commandLine, agentName }."
         },
+        "_agentNameFor": {
+          "line": 124,
+          "params": [
+            "terminalId",
+            "entry"
+          ],
+          "purpose": "the fingerprint branch is gated off, so getStatus does no extra buffer reads."
+        },
         "detectAgentName": {
-          "line": 123,
+          "line": 138,
           "params": [
             "foreground",
             "commandLine"
@@ -3462,27 +3470,27 @@
           "purpose": "Live data only — a failed launch or an exited agent leaves nothing."
         },
         "remove": {
-          "line": 137,
+          "line": 152,
           "params": [
             "terminalId"
           ],
           "purpose": "Drop tracking for a closed terminal."
         },
         "_isShellProcess": {
-          "line": 153,
+          "line": 177,
           "params": [
             "processName",
             "shellName"
           ]
         },
         "_ensureEntry": {
-          "line": 160,
+          "line": 184,
           "params": [
             "terminalId"
           ]
         },
         "_isAgentMode": {
-          "line": 179,
+          "line": 203,
           "params": [
             "entry",
             "tail"
@@ -3490,25 +3498,25 @@
           "purpose": "until 15 fresh lines scroll the remnants away."
         },
         "_onOutput": {
-          "line": 185,
+          "line": 214,
           "params": [
             "terminalId"
           ]
         },
         "_classifyQuiet": {
-          "line": 208,
+          "line": 237,
           "params": [
             "terminalId"
           ]
         },
         "_readBufferTail": {
-          "line": 234,
+          "line": 263,
           "params": [
             "terminalId"
           ]
         },
         "_emit": {
-          "line": 254,
+          "line": 283,
           "params": [
             "terminalId",
             "entry"

--- a/src/renderer/laneStatus.js
+++ b/src/renderer/laneStatus.js
@@ -112,8 +112,23 @@ function getStatus(terminalId) {
     lastActivityAt: entry.lastActivityAt,
     foreground: isShell ? null : entry.foreground,
     commandLine: isShell ? null : entry.commandLine,
-    agentName: detectAgentName(entry.foreground, entry.commandLine)
+    agentName: _agentNameFor(terminalId, entry)
   };
+}
+
+// Agent identity for a lane. Process name first (reliable on Unix). On Windows
+// that's never available, so fall back to the buffer-tail TUI fingerprint and
+// report a generic 'agent' — enough for readiness checks and dispatch (which
+// only need a truthy name to know an agent owns the lane). Unix is unchanged:
+// the fingerprint branch is gated off, so getStatus does no extra buffer reads.
+function _agentNameFor(terminalId, entry) {
+  const byProcess = detectAgentName(entry.foreground, entry.commandLine);
+  if (byProcess) return byProcess;
+  if (!FOREGROUND_RELIABLE) {
+    const tail = _readBufferTail(terminalId);
+    if (tail && AGENT_PATTERNS.some((re) => re.test(tail))) return 'agent';
+  }
+  return null;
 }
 
 /**
@@ -150,6 +165,15 @@ const SHELL_NAMES = new Set([
   'pwsh', 'powershell', 'cmd', 'login'
 ]);
 
+// Whether the foreground process name reliably reflects what's running.
+// On Unix, ptyManager reads the tty foreground process group, so the name
+// flips to the agent (claude/codex/…) and back to the shell correctly. On
+// Windows node-pty can't do this — `.process` stays the spawned shell and the
+// foreground command line is unavailable (ptyManager returns null) — so agent
+// detection there can't trust the process name and must lean on the on-screen
+// TUI fingerprint instead.
+const FOREGROUND_RELIABLE = process.platform !== 'win32';
+
 function _isShellProcess(processName, shellName) {
   if (!processName) return true; // no info — assume idle prompt
   const norm = processName.toLowerCase().replace(/^-/, '').replace(/\.exe$/, '');
@@ -178,7 +202,12 @@ function _ensureEntry(terminalId) {
 // until 15 fresh lines scroll the remnants away.
 function _isAgentMode(entry, tail) {
   if (detectAgentName(entry.foreground, entry.commandLine)) return true;
-  if (entry.foreground && _isShellProcess(entry.foreground, entry.shellName)) return false;
+  // Unix: a shell foreground means no live agent — anything agent-shaped on
+  // screen is a killed agent's leftover TUI, so stop here. Windows: the
+  // foreground is ALWAYS the shell (node-pty can't see the child), so this
+  // short-circuit would suppress every agent — skip it and let the fingerprint
+  // decide (accepting that a killed agent's remnants linger until they scroll).
+  if (FOREGROUND_RELIABLE && entry.foreground && _isShellProcess(entry.foreground, entry.shellName)) return false;
   return AGENT_PATTERNS.some((re) => re.test(tail));
 }
 


### PR DESCRIPTION
## Problem

On Windows, agent dispatch never injected its prompt. The conductor (and any dispatched agent) **launched**, but the follow-up prompt (*"Read CONDUCTOR.md and follow it…"*) was **never sent** — so the orchestrator opened, Claude started in PowerShell, and then nothing happened.

## Root cause

Agent detection (`laneStatus`) leans on the PTY **foreground process name**. node-pty can't report that on Windows — `ptyProcess.process` stays the spawned shell (`pwsh`/`powershell`) and the foreground command line is unavailable (`getForegroundCommand` returns `null`). So:

1. `detectAgentName(...)` → always `null` → `agentName` never set.
2. `_isAgentMode` short-circuits on *"foreground is a shell"* → the buffer-tail TUI fingerprint fallback (Claude's `╭─` box, `esc to interrupt`, …) is **never reached**.
3. Status never becomes `agent-input`, so `_waitForAgentReady` times out (15s) and `agentDispatch` **drops the prompt**.

This affects every dispatch path on Windows (conductor, workers, spec/task dispatch); it surfaced first in the orchestrator.

## Fix

When the foreground process name is unreliable (Windows), fall back to the on-screen TUI fingerprint, which renders identically on all platforms:

- Add a `FOREGROUND_RELIABLE` flag (`true` only on Unix). Gate the *"foreground is a shell ⇒ no agent"* short-circuit behind it, so Windows falls through to the `AGENT_PATTERNS` buffer-tail check.
- Report a generic `'agent'` name when the fingerprint matches but the process name is unavailable — enough for readiness checks and dispatch, which only need a truthy agent identity.

## Unix safety

Unix behavior is **unchanged**: the fingerprint branches are gated off, so `getStatus` does no extra buffer reads and the killed-agent-remnant handling stays exactly as before. Verified with a decision-table harness across both platforms (9/9): Windows now detects a running agent and ignores a bare shell; Unix detection, killed-agent remnants, and idle-shell handling are identical to before.

## Caveat / next

This unblocks prompt injection. A **separate** Windows issue remains: the bus commands in `CONDUCTOR.md` / worker prompts use POSIX shell syntax (`node "$FRAME_ORCH_BIN/dispatch.js"`), which PowerShell won't interpolate. That's a follow-up (relative paths for the conductor + absolute paths baked into worker prompts).

> Note: on first launch Claude's *trust this folder?* prompt reads as `agent-approval` and dispatch intentionally won't inject into it — accept trust once, as on macOS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)