### PR TITLE
feat(supervisor): native Supervisor view in Frame (multi-phase integration)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,15 @@ release/
 # Frame runtime artifacts (staged spec / agent-dispatch prompts — regenerated)
 .frame/runtime/
 
+# Per-instance Frame state — created as users open projects in Frame.
+# Upstream's own dev specs remain tracked (gitignore doesn't affect
+# already-tracked files); this just stops future usage-generated specs and
+# per-instance tasks from being staged on accident. Long-term: move spec/task
+# state behind a storage adapter (DB or remote file store) so multiple Frame
+# installs / forks don't fight over the same files in git.
+.frame/specs/
+tasks.json
+
 #Walkthroughs
 WALKTHROUGH/*.p8
 RELEASE.local.md

--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -7597,7 +7597,9 @@
       "description": "Supervisor bridge (main) — Phase A skeleton + Phase B handlers.",
       "exports": [
         "register",
-        "listProjectDocs"
+        "listProjectDocs",
+        "listProjectSpecs",
+        "listWorkspaceProjects"
       ],
       "depends": [
         "fs",
@@ -7607,14 +7609,25 @@
       ],
       "functions": {
         "listProjectDocs": {
-          "line": 15,
+          "line": 17,
           "params": [
             "{ project_id",
             "project_path }"
           ]
         },
+        "listWorkspaceProjects": {
+          "line": 80,
+          "purpose": "Returns [{ name, path, isFrameProject }] for the active workspace, or []."
+        },
+        "listProjectSpecs": {
+          "line": 112,
+          "params": [
+            "{ project_path }"
+          ],
+          "purpose": "[{ slug, phase, files: [{ path, label }] }]"
+        },
         "register": {
-          "line": 71,
+          "line": 146,
           "params": [
             "ipcMain"
           ]
@@ -7622,6 +7635,8 @@
       },
       "ipc": {
         "listens": [
+          "SUP",
+          "SUP",
           "SUP",
           "SUP"
         ],
@@ -7635,10 +7650,10 @@
       "depends": [
         "path",
         "../shared/supervisor-ipc",
-        "header",
-        "projectTree",
-        "kanban",
         "terminal",
+        "header",
+        "kanban",
+        "projectTree",
         "commandRegistry"
       ],
       "functions": {
@@ -7649,10 +7664,10 @@
           "line": 35
         },
         "open": {
-          "line": 91
+          "line": 100
         },
         "init": {
-          "line": 98
+          "line": 107
         }
       }
     },
@@ -7660,6 +7675,7 @@
       "file": "src/shared/supervisor-ipc.js",
       "description": "SUPERVISOR-OWNED IPC channel names. All channels prefixed with SUPERVISOR_",
       "exports": [
+        "SUPERVISOR_LIST_PROJECT_SPECS",
         "SUPERVISOR_DAEMON_START",
         "SUPERVISOR_DAEMON_STOP",
         "SUPERVISOR_RESPOND_ESCALATION"
@@ -7730,6 +7746,7 @@
         "create"
       ],
       "depends": [
+        "path",
         "electron",
         "../shared/supervisor-ipc",
         "header",
@@ -7737,27 +7754,42 @@
       ],
       "functions": {
         "esc": {
-          "line": 18,
+          "line": 23,
           "params": [
             "s"
           ]
         },
         "fetchJson": {
-          "line": 24,
+          "line": 29,
           "params": [
             "p"
           ]
         },
-        "openDoc": {
-          "line": 30,
+        "openFile": {
+          "line": 35,
           "params": [
             "absPath"
           ]
         },
-        "create": {
-          "line": 39,
+        "taskMatchesProject": {
+          "line": 49,
           "params": [
-            "root"
+            "task",
+            "projectName"
+          ],
+          "purpose": "option since the workspace payload has no project_id field."
+        },
+        "flatTasks": {
+          "line": 61,
+          "params": [
+            "workspace"
+          ]
+        },
+        "create": {
+          "line": 71,
+          "params": [
+            "root",
+            "opts = {}"
           ]
         }
       }

--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -7594,16 +7594,27 @@
     },
     "main/supervisor-bridge/index": {
       "file": "src/main/supervisor-bridge/index.js",
-      "description": "Supervisor bridge (main) — Phase A skeleton.",
+      "description": "Supervisor bridge (main) — Phase A skeleton + Phase B handlers.",
       "exports": [
-        "register"
+        "register",
+        "listProjectDocs"
       ],
       "depends": [
+        "fs",
+        "os",
+        "path",
         "../shared/supervisor-ipc"
       ],
       "functions": {
+        "listProjectDocs": {
+          "line": 15,
+          "params": [
+            "{ project_id",
+            "project_path }"
+          ]
+        },
         "register": {
-          "line": 10,
+          "line": 71,
           "params": [
             "ipcMain"
           ]
@@ -7611,6 +7622,7 @@
       },
       "ipc": {
         "listens": [
+          "SUP",
           "SUP"
         ],
         "emits": []
@@ -7618,23 +7630,29 @@
     },
     "renderer/supervisor-ui/index": {
       "file": "src/renderer/supervisor-ui/index.js",
-      "description": "Supervisor UI (renderer) — Phase A skeleton.",
+      "description": "Supervisor UI (renderer) — Phase B composition.",
       "exports": [],
       "depends": [
-        "electron",
+        "path",
         "../shared/supervisor-ipc",
+        "header",
+        "projectTree",
+        "kanban",
         "terminal",
         "commandRegistry"
       ],
       "functions": {
+        "injectStylesOnce": {
+          "line": 23
+        },
         "createViewport": {
-          "line": 18
+          "line": 35
         },
         "open": {
-          "line": 68
+          "line": 91
         },
         "init": {
-          "line": 75
+          "line": 98
         }
       }
     },
@@ -7648,6 +7666,154 @@
       ],
       "depends": [],
       "functions": {}
+    },
+    "renderer/supervisor-ui/header": {
+      "file": "src/renderer/supervisor-ui/header.js",
+      "description": "Supervisor header — Phase B.",
+      "exports": [
+        "create",
+        "SUPERVISOR_API"
+      ],
+      "depends": [],
+      "functions": {
+        "esc": {
+          "line": 16,
+          "params": [
+            "s"
+          ]
+        },
+        "fetchJson": {
+          "line": 22,
+          "params": [
+            "path"
+          ]
+        },
+        "create": {
+          "line": 28,
+          "params": [
+            "root"
+          ]
+        }
+      }
+    },
+    "renderer/supervisor-ui/kanban": {
+      "file": "src/renderer/supervisor-ui/kanban.js",
+      "description": "Supervisor kanban — Phase B.",
+      "exports": [
+        "create"
+      ],
+      "depends": [
+        "path",
+        "header",
+        "taskCard",
+        "editor"
+      ],
+      "functions": {
+        "fetchJson": {
+          "line": 19,
+          "params": [
+            "p"
+          ]
+        },
+        "create": {
+          "line": 25,
+          "params": [
+            "root"
+          ]
+        }
+      }
+    },
+    "renderer/supervisor-ui/projectTree": {
+      "file": "src/renderer/supervisor-ui/projectTree.js",
+      "description": "Supervisor project tree — Phase B.",
+      "exports": [
+        "create"
+      ],
+      "depends": [
+        "electron",
+        "../shared/supervisor-ipc",
+        "header",
+        "editor"
+      ],
+      "functions": {
+        "esc": {
+          "line": 18,
+          "params": [
+            "s"
+          ]
+        },
+        "fetchJson": {
+          "line": 24,
+          "params": [
+            "p"
+          ]
+        },
+        "openDoc": {
+          "line": 30,
+          "params": [
+            "absPath"
+          ]
+        },
+        "create": {
+          "line": 39,
+          "params": [
+            "root"
+          ]
+        }
+      }
+    },
+    "renderer/supervisor-ui/taskCard": {
+      "file": "src/renderer/supervisor-ui/taskCard.js",
+      "description": "Supervisor task card — Phase B (collapsed only).",
+      "exports": [
+        "render",
+        "statusTag"
+      ],
+      "depends": [
+        "path"
+      ],
+      "functions": {
+        "esc": {
+          "line": 9,
+          "params": [
+            "s"
+          ]
+        },
+        "statusTag": {
+          "line": 15,
+          "params": [
+            "t"
+          ]
+        },
+        "elapsedLabel": {
+          "line": 24,
+          "params": [
+            "t"
+          ]
+        },
+        "costLabel": {
+          "line": 32,
+          "params": [
+            "t"
+          ]
+        },
+        "resolveDeliverable": {
+          "line": 43,
+          "params": [
+            "p",
+            "supervisorRoot"
+          ],
+          "purpose": "`run-state/`)."
+        },
+        "render": {
+          "line": 57,
+          "params": [
+            "t",
+            "columnKey",
+            "ctx"
+          ]
+        }
+      }
     }
   },
   "ipcChannels": {
@@ -8476,6 +8642,13 @@
         "description": "GitHub Panel Module"
       }
     ],
+    "header": [
+      {
+        "module": "renderer/supervisor-ui/header",
+        "file": "src/renderer/supervisor-ui/header.js",
+        "description": "Supervisor header — Phase B."
+      }
+    ],
     "history": [
       {
         "module": "main/promptLogger",
@@ -8497,7 +8670,7 @@
       {
         "module": "main/supervisor-bridge/index",
         "file": "src/main/supervisor-bridge/index.js",
-        "description": "Supervisor bridge (main) — Phase A skeleton."
+        "description": "Supervisor bridge (main) — Phase A skeleton + Phase B handlers."
       },
       {
         "module": "renderer/index",
@@ -8507,7 +8680,7 @@
       {
         "module": "renderer/supervisor-ui/index",
         "file": "src/renderer/supervisor-ui/index.js",
-        "description": "Supervisor UI (renderer) — Phase A skeleton."
+        "description": "Supervisor UI (renderer) — Phase B composition."
       },
       {
         "module": "templates/sample-project/src/index",
@@ -8520,6 +8693,13 @@
         "module": "shared/ipcChannels",
         "file": "src/shared/ipcChannels.js",
         "description": "IPC Channel Constants"
+      }
+    ],
+    "kanban": [
+      {
+        "module": "renderer/supervisor-ui/kanban",
+        "file": "src/renderer/supervisor-ui/kanban.js",
+        "description": "Supervisor kanban — Phase B."
       }
     ],
     "lane-board": [
@@ -8628,6 +8808,13 @@
         "module": "renderer/projectStatusBadges",
         "file": "src/renderer/projectStatusBadges.js",
         "description": "Project Status Badges"
+      }
+    ],
+    "project-tree": [
+      {
+        "module": "renderer/supervisor-ui/projectTree",
+        "file": "src/renderer/supervisor-ui/projectTree.js",
+        "description": "Supervisor project tree — Phase B."
       }
     ],
     "prompts": [
@@ -8750,6 +8937,13 @@
         "module": "shared/supervisor-ipc",
         "file": "src/shared/supervisor-ipc.js",
         "description": "SUPERVISOR-OWNED IPC channel names. All channels prefixed with SUPERVISOR_"
+      }
+    ],
+    "task-card": [
+      {
+        "module": "renderer/supervisor-ui/taskCard",
+        "file": "src/renderer/supervisor-ui/taskCard.js",
+        "description": "Supervisor task card — Phase B (collapsed only)."
       }
     ],
     "task-confirm-modal": [

--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Auto-generated module structure",
-  "lastUpdated": "2026-06-22",
+  "lastUpdated": "2026-06-23",
   "architecture": {},
   "modules": {
     "main/aiToolManager": {
@@ -988,7 +988,8 @@
         "gitDiffManager",
         "telemetry",
         "specManager",
-        "orchestrationManager"
+        "orchestrationManager",
+        "supervisor-bridge"
       ],
       "functions": {
         "createWindow": {
@@ -1000,11 +1001,11 @@
           "purpose": "Setup all IPC handlers"
         },
         "init": {
-          "line": 144,
+          "line": 146,
           "purpose": "Initialize application"
         },
         "initModulesWithWindow": {
-          "line": 163,
+          "line": 165,
           "params": [
             "window"
           ],
@@ -3302,6 +3303,7 @@
         "telemetryNotice",
         "sampleBanner",
         "../package.json",
+        "supervisor-ui",
         "agentDispatch"
       ],
       "functions": {
@@ -3310,26 +3312,26 @@
           "purpose": "Initialize all modules"
         },
         "setupButtonHandlers": {
-          "line": 225,
+          "line": 226,
           "purpose": "Setup button click handlers"
         },
         "setupProjectSwitcher": {
-          "line": 308,
+          "line": 309,
           "purpose": "and close on outside click / Escape."
         },
         "setupUpdateDot": {
-          "line": 397,
+          "line": 398,
           "purpose": "→ About → \"Dismiss this version\"). Both click open Settings → About."
         },
         "revealSidebarTab": {
-          "line": 428,
+          "line": 429,
           "params": [
             "tabName"
           ],
           "purpose": "commands so they don't try to focus an element inside a hidden container."
         },
         "registerCommands": {
-          "line": 454,
+          "line": 455,
           "purpose": "Command Palette and the global keyboard handler."
         }
       },
@@ -7589,6 +7591,63 @@
           "ORCH_WORKER_LANE"
         ]
       }
+    },
+    "main/supervisor-bridge/index": {
+      "file": "src/main/supervisor-bridge/index.js",
+      "description": "Supervisor bridge (main) — Phase A skeleton.",
+      "exports": [
+        "register"
+      ],
+      "depends": [
+        "../shared/supervisor-ipc"
+      ],
+      "functions": {
+        "register": {
+          "line": 10,
+          "params": [
+            "ipcMain"
+          ]
+        }
+      },
+      "ipc": {
+        "listens": [
+          "SUP"
+        ],
+        "emits": []
+      }
+    },
+    "renderer/supervisor-ui/index": {
+      "file": "src/renderer/supervisor-ui/index.js",
+      "description": "Supervisor UI (renderer) — Phase A skeleton.",
+      "exports": [],
+      "depends": [
+        "electron",
+        "../shared/supervisor-ipc",
+        "terminal",
+        "commandRegistry"
+      ],
+      "functions": {
+        "createViewport": {
+          "line": 18
+        },
+        "open": {
+          "line": 68
+        },
+        "init": {
+          "line": 75
+        }
+      }
+    },
+    "shared/supervisor-ipc": {
+      "file": "src/shared/supervisor-ipc.js",
+      "description": "SUPERVISOR-OWNED IPC channel names. All channels prefixed with SUPERVISOR_",
+      "exports": [
+        "SUPERVISOR_DAEMON_START",
+        "SUPERVISOR_DAEMON_STOP",
+        "SUPERVISOR_RESPOND_ESCALATION"
+      ],
+      "depends": [],
+      "functions": {}
     }
   },
   "ipcChannels": {
@@ -8436,9 +8495,19 @@
         "description": "Main Process Entry Point"
       },
       {
+        "module": "main/supervisor-bridge/index",
+        "file": "src/main/supervisor-bridge/index.js",
+        "description": "Supervisor bridge (main) — Phase A skeleton."
+      },
+      {
         "module": "renderer/index",
         "file": "src/renderer/index.js",
         "description": "Renderer Entry Point"
+      },
+      {
+        "module": "renderer/supervisor-ui/index",
+        "file": "src/renderer/supervisor-ui/index.js",
+        "description": "Supervisor UI (renderer) — Phase A skeleton."
       },
       {
         "module": "templates/sample-project/src/index",
@@ -8674,6 +8743,13 @@
         "module": "main/structureBootstrap",
         "file": "src/main/structureBootstrap.js",
         "description": "Structure Bootstrap"
+      }
+    ],
+    "supervisor-ipc": [
+      {
+        "module": "shared/supervisor-ipc",
+        "file": "src/shared/supervisor-ipc.js",
+        "description": "SUPERVISOR-OWNED IPC channel names. All channels prefixed with SUPERVISOR_"
       }
     ],
     "task-confirm-modal": [

--- a/docs/frame-modifications.md
+++ b/docs/frame-modifications.md
@@ -1,0 +1,35 @@
+# Frame modifications ledger (supervisor-integration fork)
+
+Every modification to a tracked Frame source file (not new files in
+`src/main/supervisor-bridge/`, `src/renderer/supervisor-ui/`, or
+`src/shared/supervisor-ipc.js` — those are additive and don't need tracking)
+gets a row here. The `marker count` column is verified by
+`scripts/check-supervisor-mods.sh` on every commit. Mismatch = upstream rebase
+silently dropped one of our edits.
+
+## Phase A — Skeleton (2026-06-23, Frame @ d324153)
+
+### Q1 resolution
+
+Spec §9 Q1 asked: "Do we add the `supervisor` section type via a registration
+call in `multiTerminalUI.js` (1 supervisor-mod line), or is `openSection`
+generic enough that no registration is needed?"
+
+**Resolution: no-mod.** `src/renderer/multiTerminalUI.js:217` defines
+`openSection(type, itemRef, factory, { newTab })`. `type` is opaque — at
+lines 222-224 it is used only for "find existing viewport of same type"
+matching against `this.sections`. There is no dispatch table, switch, or
+enum. The caller supplies a `factory` module exposing `createViewport()` that
+returns a viewport object with `{type, key, viewClass, navigate, getChip,
+render, dispose}`. Our `src/renderer/supervisor-ui/` module is that factory,
+and the host is acquired via the existing `terminal.getMultiTerminalUI()`
+accessor (same pattern used by built-in commands such as `lane.home` /
+`terminal.new` in `src/renderer/index.js:639,651,665,675,685,696`). Result:
+zero modifications to `multiTerminalUI.js` for Phase A.
+
+### Modifications
+
+| Date | Frame upstream SHA | File | Lines added | Rationale | Marker grep count |
+|---|---|---|---|---|---|
+| 2026-06-23 | d324153 | `src/main/index.js` | 1 | Register supervisor-bridge IPC channels (Phase A) | 1 |
+| 2026-06-23 | d324153 | `src/renderer/index.js` | 1 | Init supervisor-ui (Phase A) | 1 |

--- a/scripts/check-supervisor-mods.sh
+++ b/scripts/check-supervisor-mods.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# Verify every row in docs/frame-modifications.md has its claimed marker count
+# in the corresponding file. Fails loudly if any mismatch — that means an
+# upstream rebase silently dropped one of our edits.
+set -euo pipefail
+LEDGER="docs/frame-modifications.md"
+if [ ! -f "$LEDGER" ]; then
+  echo "ledger not found at $LEDGER"
+  exit 1
+fi
+# Skip header rows (start with `|---` or `| Date `). Grep just the data rows.
+FAIL=0
+while IFS='|' read -r _ _ _ file _ _ count _; do
+  file=$(echo "$file" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//' | tr -d '`')
+  count=$(echo "$count" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+  if [ -z "$file" ] || [ -z "$count" ] || [ "$file" = "File" ] || ! [[ "$count" =~ ^[0-9]+$ ]]; then
+    continue
+  fi
+  if [ ! -f "$file" ]; then
+    echo "FAIL: ledger names $file but file does not exist"
+    FAIL=1
+    continue
+  fi
+  actual=$(grep -c 'supervisor-mod' "$file" || echo 0)
+  if [ "$actual" -ne "$count" ]; then
+    echo "FAIL: $file expected $count supervisor-mod markers, found $actual"
+    FAIL=1
+  fi
+done < "$LEDGER"
+if [ "$FAIL" -ne 0 ]; then
+  exit 1
+fi
+echo "OK: all ledger rows verified"

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -126,6 +126,8 @@ function setupAllIPC() {
   // Orchestration — conductor-led parallel spec execution
   orchestrationManager.setupIPC(ipcMain);
 
+  require('./supervisor-bridge').register(ipcMain); // supervisor-mod
+
   // Telemetry — toggle from Settings
   ipcMain.handle(IPC.TELEMETRY_SET_ENABLED, (event, enabled) =>
     telemetry.setEnabled(enabled)

--- a/src/main/supervisor-bridge/index.js
+++ b/src/main/supervisor-bridge/index.js
@@ -11,6 +11,8 @@ const path = require('path');
 const SUP = require('../../shared/supervisor-ipc');
 
 const DOC_CAP = 100;
+const SPEC_CAP = 50;
+const FRAME_WORKSPACES_PATH = path.join(os.homedir(), '.frame', 'workspaces.json');
 
 function listProjectDocs({ project_id, project_path }) {
   const out = [];
@@ -68,6 +70,79 @@ function listProjectDocs({ project_id, project_path }) {
   return out;
 }
 
+/**
+ * Read Frame's own workspace projects from ~/.frame/workspaces.json. The
+ * supervisor view uses this as its project source: the supervisor's
+ * /api/memory/projects endpoint only knows about memory namespaces (no path),
+ * and the brief's /api/meta.projects field doesn't exist server-side.
+ * Returns [{ name, path, isFrameProject }] for the active workspace, or [].
+ */
+function listWorkspaceProjects() {
+  try {
+    if (!fs.existsSync(FRAME_WORKSPACES_PATH)) return [];
+    const data = JSON.parse(fs.readFileSync(FRAME_WORKSPACES_PATH, 'utf8'));
+    const aw = data.activeWorkspace || 'default';
+    const ws = (data.workspaces || {})[aw];
+    if (!ws || !Array.isArray(ws.projects)) return [];
+    return ws.projects
+      .map((p) => ({
+        name: p.name || (p.path ? path.basename(p.path) : ''),
+        path: p.path || '',
+        isFrameProject: !!p.isFrameProject,
+      }))
+      .filter((p) => p.path);
+  } catch (e) {
+    console.warn('[supervisor-bridge] failed to read workspaces.json:', e.message);
+    return [];
+  }
+}
+
+/**
+ * Scan <project_path>/.frame/specs/ for one level of spec slugs and surface a
+ * flat list of clickable markdown files. The brief originally pointed at a
+ * (nonexistent) /api/frame-specs/<id> endpoint; reading the filesystem from
+ * main is the local equivalent and keeps the channel architecture parallel
+ * to SUPERVISOR_LIST_PROJECT_DOCS.
+ *
+ * For each slug dir we list spec.md → plan.md → tasks.md if present, and try
+ * to read a one-line "phase" hint from the spec.md frontmatter or first
+ * heading for display in the tree. Returns:
+ *   [{ slug, phase, files: [{ path, label }] }]
+ */
+function listProjectSpecs({ project_path }) {
+  if (!project_path) return [];
+  const specsRoot = path.join(project_path, '.frame', 'specs');
+  if (!fs.existsSync(specsRoot)) return [];
+  let slugs;
+  try { slugs = fs.readdirSync(specsRoot); } catch { return []; }
+  const out = [];
+  for (const slug of slugs) {
+    if (out.length >= SPEC_CAP) break;
+    const slugDir = path.join(specsRoot, slug);
+    let stat;
+    try { stat = fs.statSync(slugDir); } catch { continue; }
+    if (!stat.isDirectory()) continue;
+    const files = [];
+    for (const fname of ['spec.md', 'plan.md', 'tasks.md']) {
+      const fpath = path.join(slugDir, fname);
+      if (fs.existsSync(fpath)) files.push({ path: fpath, label: fname });
+    }
+    if (!files.length) continue;
+    // Best-effort phase hint: first heading of spec.md if present.
+    let phase = '';
+    const specPath = path.join(slugDir, 'spec.md');
+    if (fs.existsSync(specPath)) {
+      try {
+        const head = fs.readFileSync(specPath, 'utf8').slice(0, 1024);
+        const m = head.match(/^#+\s+(.+)$/m);
+        if (m) phase = m[1].trim().slice(0, 80);
+      } catch { /* ignore */ }
+    }
+    out.push({ slug, phase, files });
+  }
+  return out;
+}
+
 function register(ipcMain) {
   // Round-trip sanity check used by the renderer's Supervisor section on first
   // open. Future phases register stateWatcher / tailReader / taskSubmitter
@@ -81,6 +156,21 @@ function register(ipcMain) {
   ipcMain.handle(SUP.SUPERVISOR_LIST_PROJECT_DOCS, async (_evt, payload) => {
     return listProjectDocs(payload || {});
   });
+
+  // Phase B: list .frame/specs/<slug>/{spec,plan,tasks}.md for a project.
+  // No supervisor API endpoint exists for this — we scan the project's
+  // own .frame/specs/ directory directly from main.
+  ipcMain.handle(SUP.SUPERVISOR_LIST_PROJECT_SPECS, async (_evt, payload) => {
+    return listProjectSpecs(payload || {});
+  });
+
+  // Phase B: surface Frame's own workspace projects to the supervisor view.
+  // The supervisor API only knows about memory namespaces; pairing those
+  // with Frame's known projects gives us project_path (which the docs and
+  // specs handlers need to do anything useful beyond the memory tree).
+  ipcMain.handle(SUP.SUPERVISOR_LIST_WORKSPACE_PROJECTS, async () => {
+    return listWorkspaceProjects();
+  });
 }
 
-module.exports = { register, listProjectDocs };
+module.exports = { register, listProjectDocs, listProjectSpecs, listWorkspaceProjects };

--- a/src/main/supervisor-bridge/index.js
+++ b/src/main/supervisor-bridge/index.js
@@ -1,0 +1,19 @@
+// Supervisor bridge (main) — Phase A skeleton.
+//
+// All supervisor-owned main-process modules live under src/main/supervisor-bridge/
+// per docs/frame-edit-discipline.md §1.1 (additive new dirs never conflict on
+// upstream rebase). The Frame edit is a single supervisor-mod line in
+// src/main/index.js that invokes register(ipcMain) from setupAllIPC().
+
+const SUP = require('../../shared/supervisor-ipc');
+
+function register(ipcMain) {
+  // Round-trip sanity check used by the renderer's Supervisor section on first
+  // open. Future phases register stateWatcher / tailReader / taskSubmitter
+  // handlers here.
+  ipcMain.handle(SUP.SUPERVISOR_PING, async () => {
+    return { ok: true, ts: Date.now(), phase: 'A-skeleton' };
+  });
+}
+
+module.exports = { register };

--- a/src/main/supervisor-bridge/index.js
+++ b/src/main/supervisor-bridge/index.js
@@ -1,19 +1,86 @@
-// Supervisor bridge (main) — Phase A skeleton.
+// Supervisor bridge (main) — Phase A skeleton + Phase B handlers.
 //
 // All supervisor-owned main-process modules live under src/main/supervisor-bridge/
 // per docs/frame-edit-discipline.md §1.1 (additive new dirs never conflict on
 // upstream rebase). The Frame edit is a single supervisor-mod line in
 // src/main/index.js that invokes register(ipcMain) from setupAllIPC().
 
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
 const SUP = require('../../shared/supervisor-ipc');
+
+const DOC_CAP = 100;
+
+function listProjectDocs({ project_id, project_path }) {
+  const out = [];
+
+  // <project_path>/develop/*.md (one level deep)
+  if (project_path) {
+    try {
+      const devDir = path.join(project_path, 'develop');
+      if (fs.existsSync(devDir)) {
+        for (const name of fs.readdirSync(devDir)) {
+          if (out.length >= DOC_CAP) break;
+          if (name.endsWith('.md')) {
+            out.push({ path: path.join(devDir, name), label: `develop/${name}` });
+          }
+        }
+      }
+    } catch (e) {
+      // Best-effort: ignore unreadable dirs (broken symlinks etc).
+    }
+  }
+
+  // ~/memory/<project_id>/**/*.md (recursive, capped)
+  if (project_id) {
+    try {
+      const memRoot = path.join(os.homedir(), 'memory', project_id);
+      if (fs.existsSync(memRoot)) {
+        const walk = (dir, prefix) => {
+          if (out.length >= DOC_CAP) return;
+          let names;
+          try { names = fs.readdirSync(dir); } catch { return; }
+          for (const name of names) {
+            if (out.length >= DOC_CAP) return;
+            const full = path.join(dir, name);
+            let stat;
+            try { stat = fs.statSync(full); } catch { continue; }
+            if (stat.isDirectory()) walk(full, `${prefix}${name}/`);
+            else if (name.endsWith('.md')) {
+              out.push({ path: full, label: `memory/${prefix}${name}` });
+            }
+          }
+        };
+        walk(memRoot, '');
+      }
+    } catch (e) {
+      // Best-effort
+    }
+  }
+
+  if (out.length >= DOC_CAP) {
+    console.warn(
+      `[supervisor-bridge] doc cap of ${DOC_CAP} hit for project="${project_id}"; ` +
+      `additional docs not listed`
+    );
+  }
+  return out;
+}
 
 function register(ipcMain) {
   // Round-trip sanity check used by the renderer's Supervisor section on first
   // open. Future phases register stateWatcher / tailReader / taskSubmitter
   // handlers here.
   ipcMain.handle(SUP.SUPERVISOR_PING, async () => {
-    return { ok: true, ts: Date.now(), phase: 'A-skeleton' };
+    return { ok: true, ts: Date.now(), phase: 'B-readonly' };
+  });
+
+  // Phase B: enumerate markdown docs for a project across the supervisor's
+  // own develop/ folder and the user's ~/memory/<project_id>/ namespace.
+  ipcMain.handle(SUP.SUPERVISOR_LIST_PROJECT_DOCS, async (_evt, payload) => {
+    return listProjectDocs(payload || {});
   });
 }
 
-module.exports = { register };
+module.exports = { register, listProjectDocs };

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -211,6 +211,7 @@ function init() {
   sampleBanner.init();
   setupUpdateDot();
   registerCommands();
+  require('./supervisor-ui').init(); // supervisor-mod
   commandRegistry.bindKeyboard();
 
   // Setup window resize handler

--- a/src/renderer/supervisor-ui/header.js
+++ b/src/renderer/supervisor-ui/header.js
@@ -1,0 +1,118 @@
+// Supervisor header — Phase B.
+//
+// Polls /api/heartbeat (5s) and /api/workspace (4s) from the supervisor monitor
+// running at SUPERVISOR_API. Renders the heartbeat dot, in-flight count, today's
+// cost, and three action buttons. Submit/Stop are non-functional placeholders
+// in Phase B — they alert "Phase D" so we know wiring is correct without
+// hijacking behavior. Refresh forces a re-poll.
+//
+// /api/meta does NOT expose `profile` or `projects` in the actual server (the
+// Phase B brief inferred this from the spec, but the code is authoritative —
+// see supervisor/scripts/monitor/server.py:1151). We render the daemon state
+// (running/idle/etc) from heartbeat.state instead of a missing profile field.
+
+const SUPERVISOR_API = 'http://127.0.0.1:8766';
+
+function esc(s) {
+  return String(s == null ? '' : s).replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ));
+}
+
+async function fetchJson(path) {
+  const res = await fetch(`${SUPERVISOR_API}${path}`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}
+
+function create(root) {
+  let hbTimer = null;
+  let wsTimer = null;
+  let alive = true;
+
+  root.innerHTML = `
+    <div class="sup-live">
+      <div class="sup-dot" id="sup-dot"></div>
+      <div class="sup-brand">SUPERVISOR</div>
+    </div>
+    <div class="sup-meta">
+      <span>daemon: <span class="v" id="sup-daemon">…</span></span>
+      <span>in-flight: <span class="v" id="sup-inflight">0</span></span>
+      <span>cost today: <span class="v" id="sup-cost">$0.00</span></span>
+    </div>
+    <div class="sup-actions">
+      <button class="sup-btn primary" id="sup-btn-submit" title="Submit a new task (Phase D)">▶ Submit task</button>
+      <button class="sup-btn" id="sup-btn-stop" title="Stop daemon (Phase D)">⏸ Stop daemon</button>
+      <button class="sup-btn" id="sup-btn-refresh" title="Force re-poll now">↻ Refresh</button>
+    </div>
+  `;
+
+  const dotEl = root.querySelector('#sup-dot');
+  const daemonEl = root.querySelector('#sup-daemon');
+  const inflightEl = root.querySelector('#sup-inflight');
+  const costEl = root.querySelector('#sup-cost');
+
+  async function pollHeartbeat() {
+    if (!alive) return;
+    try {
+      const hb = await fetchJson('/api/heartbeat');
+      if (!alive) return;
+      const isAlive = !!hb.alive;
+      dotEl.classList.toggle('alive', isAlive);
+      dotEl.classList.toggle('dead', !isAlive);
+      daemonEl.textContent = hb.state || (isAlive ? 'running' : 'offline');
+      inflightEl.textContent = String((hb.in_flight || []).length);
+    } catch (err) {
+      if (!alive) return;
+      dotEl.classList.remove('alive');
+      dotEl.classList.add('dead');
+      daemonEl.textContent = 'unreachable';
+    }
+  }
+
+  async function pollWorkspace() {
+    if (!alive) return;
+    try {
+      const ws = await fetchJson('/api/workspace');
+      if (!alive) return;
+      const cost = (ws.totals && ws.totals.cost_today_usd) || 0;
+      costEl.textContent = `$${Number(cost).toFixed(2)}`;
+    } catch (err) {
+      // Quiet — header keeps the last good value
+    }
+  }
+
+  function refresh() {
+    pollHeartbeat();
+    pollWorkspace();
+  }
+
+  // Buttons
+  root.querySelector('#sup-btn-submit').addEventListener('click', () => {
+    alert('Submit task lands in Phase D.');
+  });
+  root.querySelector('#sup-btn-stop').addEventListener('click', () => {
+    alert('Stop daemon lands in Phase D.');
+  });
+  root.querySelector('#sup-btn-refresh').addEventListener('click', refresh);
+
+  function start() {
+    if (hbTimer || wsTimer) return;
+    refresh();
+    hbTimer = setInterval(pollHeartbeat, 5000);
+    wsTimer = setInterval(pollWorkspace, 4000);
+  }
+
+  function stop() {
+    alive = false;
+    if (hbTimer) clearInterval(hbTimer);
+    if (wsTimer) clearInterval(wsTimer);
+    hbTimer = null;
+    wsTimer = null;
+  }
+
+  start();
+  return { start, stop, refresh };
+}
+
+module.exports = { create, SUPERVISOR_API };

--- a/src/renderer/supervisor-ui/index.js
+++ b/src/renderer/supervisor-ui/index.js
@@ -38,8 +38,14 @@ function createViewport() {
   let rendered = false;
 
   function navigate(/* itemRef */) {
-    // Phase B section has no sub-navigation. Phase D will route to a specific
-    // project / task here.
+    // multiTerminalUI.openSection() calls navigate() once after creating the
+    // viewport — every other section module (diffSection, specSection,
+    // taskSection, orchestrator) signals notifySectionChanged() here to
+    // trigger the host's section render. Without this, the viewport stays
+    // off-screen and render() is never invoked.
+    const terminal = require('../terminal');
+    const host = terminal.getMultiTerminalUI();
+    if (host) host.notifySectionChanged();
   }
 
   function getChip() {
@@ -58,8 +64,11 @@ function createViewport() {
       </div>
     `;
     const header = require('./header').create(el.querySelector('#supervisor-header'));
-    const tree = require('./projectTree').create(el.querySelector('#supervisor-tree'));
     const kanban = require('./kanban').create(el.querySelector('#supervisor-kanban'));
+    const tree = require('./projectTree').create(
+      el.querySelector('#supervisor-tree'),
+      { onScrollToTask: (id) => kanban.scrollToTask(id) }
+    );
     controllers = { header, tree, kanban };
     rendered = true;
   }

--- a/src/renderer/supervisor-ui/index.js
+++ b/src/renderer/supervisor-ui/index.js
@@ -1,4 +1,4 @@
-// Supervisor UI (renderer) — Phase A skeleton.
+// Supervisor UI (renderer) — Phase B composition.
 //
 // Per docs/frame-edit-discipline.md §1.6, the renderer addition is a standalone
 // module under src/renderer/supervisor-ui/ exposing ONE init() function. The
@@ -9,18 +9,37 @@
 // openSection(type, itemRef, factory, opts) treats `type` as an opaque string
 // (only used for "find existing viewport of same type" matching at L222-224).
 // No dispatch table; no registration required. This module is the factory.
+//
+// Phase B: createViewport().render(el) composes header + projectTree + kanban
+// and wires teardown into the viewport's dispose() hook (already invoked by
+// multiTerminalUI on section close — see multiTerminalUI.js:248).
 
-const { ipcRenderer } = require('electron');
+const path = require('path');
 const SUP = require('../../shared/supervisor-ipc');
 
 let seq = 0;
+let stylesInjected = false;
+
+function injectStylesOnce() {
+  if (stylesInjected) return;
+  stylesInjected = true;
+  // index.html is loaded with loadFile('index.html') (see src/main/index.js:55);
+  // relative href resolves against the project root.
+  const link = document.createElement('link');
+  link.rel = 'stylesheet';
+  link.href = 'src/renderer/supervisor-ui/styles.css';
+  link.dataset.supervisorStyles = '1';
+  document.head.appendChild(link);
+}
 
 function createViewport() {
   const key = `supervisor-vp:${++seq}`;
+  let controllers = null;
+  let rendered = false;
 
   function navigate(/* itemRef */) {
-    // Phase A: section has no sub-navigation. Phase B introduces project /
-    // kanban routing via this hook.
+    // Phase B section has no sub-navigation. Phase D will route to a specific
+    // project / task here.
   }
 
   function getChip() {
@@ -28,30 +47,34 @@ function createViewport() {
   }
 
   function render(el) {
+    injectStylesOnce();
     el.innerHTML = `
-      <div style="padding: 24px; font-family: var(--font-sans); color: var(--text-primary);">
-        <h2 style="margin: 0 0 8px;">Supervisor — Loading…</h2>
-        <p style="color: var(--text-secondary); margin: 0;">
-          Phase A skeleton. Real content arrives in Phase B.
-        </p>
-        <p style="color: var(--text-secondary); margin: 16px 0 0; font-size: 12px;">
-          Phase A handshake: <span id="supervisor-ping-result">testing…</span>
-        </p>
+      <div class="supervisor-root">
+        <div class="supervisor-header" id="supervisor-header"></div>
+        <div class="supervisor-body">
+          <aside class="supervisor-tree" id="supervisor-tree"></aside>
+          <main class="supervisor-kanban" id="supervisor-kanban"></main>
+        </div>
       </div>
     `;
-    // Round-trip SUPERVISOR_PING to confirm the bridge wiring is alive.
-    ipcRenderer.invoke(SUP.SUPERVISOR_PING).then((r) => {
-      const out = el.querySelector('#supervisor-ping-result');
-      if (out) out.textContent = JSON.stringify(r);
-    }).catch((err) => {
-      const out = el.querySelector('#supervisor-ping-result');
-      if (out) out.textContent = `error: ${err && err.message ? err.message : String(err)}`;
-    });
+    const header = require('./header').create(el.querySelector('#supervisor-header'));
+    const tree = require('./projectTree').create(el.querySelector('#supervisor-tree'));
+    const kanban = require('./kanban').create(el.querySelector('#supervisor-kanban'));
+    controllers = { header, tree, kanban };
+    rendered = true;
   }
 
   function dispose() {
-    // Phase A has no listeners to tear down. Phase C will unsubscribe from
-    // SUPERVISOR_STATE here.
+    // multiTerminalUI.closeSection() calls viewport.dispose() — wire down all
+    // pollers + listeners here so the supervisor view stops polling /api/* once
+    // the user closes the tab.
+    if (controllers) {
+      try { controllers.header.stop(); } catch {}
+      try { controllers.tree.stop(); } catch {}
+      try { controllers.kanban.stop(); } catch {}
+      controllers = null;
+    }
+    rendered = false;
   }
 
   return {

--- a/src/renderer/supervisor-ui/index.js
+++ b/src/renderer/supervisor-ui/index.js
@@ -1,0 +1,87 @@
+// Supervisor UI (renderer) — Phase A skeleton.
+//
+// Per docs/frame-edit-discipline.md §1.6, the renderer addition is a standalone
+// module under src/renderer/supervisor-ui/ exposing ONE init() function. The
+// Frame edit is a single supervisor-mod line in src/renderer/index.js that
+// invokes init().
+//
+// Q1 resolution (see docs/frame-modifications.md): src/renderer/multiTerminalUI.js
+// openSection(type, itemRef, factory, opts) treats `type` as an opaque string
+// (only used for "find existing viewport of same type" matching at L222-224).
+// No dispatch table; no registration required. This module is the factory.
+
+const { ipcRenderer } = require('electron');
+const SUP = require('../../shared/supervisor-ipc');
+
+let seq = 0;
+
+function createViewport() {
+  const key = `supervisor-vp:${++seq}`;
+
+  function navigate(/* itemRef */) {
+    // Phase A: section has no sub-navigation. Phase B introduces project /
+    // kanban routing via this hook.
+  }
+
+  function getChip() {
+    return { type: 'supervisor', title: 'Supervisor' };
+  }
+
+  function render(el) {
+    el.innerHTML = `
+      <div style="padding: 24px; font-family: var(--font-sans); color: var(--text-primary);">
+        <h2 style="margin: 0 0 8px;">Supervisor — Loading…</h2>
+        <p style="color: var(--text-secondary); margin: 0;">
+          Phase A skeleton. Real content arrives in Phase B.
+        </p>
+        <p style="color: var(--text-secondary); margin: 16px 0 0; font-size: 12px;">
+          Phase A handshake: <span id="supervisor-ping-result">testing…</span>
+        </p>
+      </div>
+    `;
+    // Round-trip SUPERVISOR_PING to confirm the bridge wiring is alive.
+    ipcRenderer.invoke(SUP.SUPERVISOR_PING).then((r) => {
+      const out = el.querySelector('#supervisor-ping-result');
+      if (out) out.textContent = JSON.stringify(r);
+    }).catch((err) => {
+      const out = el.querySelector('#supervisor-ping-result');
+      if (out) out.textContent = `error: ${err && err.message ? err.message : String(err)}`;
+    });
+  }
+
+  function dispose() {
+    // Phase A has no listeners to tear down. Phase C will unsubscribe from
+    // SUPERVISOR_STATE here.
+  }
+
+  return {
+    type: 'supervisor',
+    key,
+    viewClass: 'section-view',
+    navigate,
+    getChip,
+    render,
+    dispose,
+  };
+}
+
+function open() {
+  const terminal = require('../terminal');
+  const host = terminal.getMultiTerminalUI();
+  if (!host) return;
+  host.openSection('supervisor', null, api, { newTab: false });
+}
+
+function init() {
+  const { register } = require('../commandRegistry');
+  register({
+    id: 'supervisor.open',
+    title: 'Open Supervisor',
+    category: 'Supervisor',
+    shortcut: 'CmdOrCtrl+Shift+U',
+    run: () => open(),
+  });
+}
+
+const api = { init, open, createViewport };
+module.exports = api;

--- a/src/renderer/supervisor-ui/kanban.js
+++ b/src/renderer/supervisor-ui/kanban.js
@@ -1,0 +1,173 @@
+// Supervisor kanban — Phase B.
+//
+// Polls /api/workspace (4s) and renders 4 columns plus a full-width
+// "Needs You" row above. Column mapping per server.py:derive_workspace
+// (supervisor/scripts/monitor/server.py:336):
+//   columns.pending   → Pending column
+//   columns.active    → In-flight column
+//   columns.awaiting  → Needs You row (above the grid)
+//   columns.done      → Done + Failed columns (split client-side by t.status)
+//
+// /api/meta returns audit_path; we derive supervisorRoot = parent of run-state/
+// so deliverable paths (which are project-relative) resolve to absolute paths
+// that editor.openFile can consume.
+
+const path = require('path');
+const { SUPERVISOR_API } = require('./header');
+const taskCard = require('./taskCard');
+
+async function fetchJson(p) {
+  const res = await fetch(`${SUPERVISOR_API}${p}`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}
+
+function create(root) {
+  let timer = null;
+  let alive = true;
+  let supervisorRoot = null;
+  let pendingScrollTaskId = null;
+
+  root.innerHTML = `
+    <div class="sup-needs-you" id="sup-needs-you">
+      <div class="sup-section-hdr">
+        Needs You <span class="sup-count" id="sup-needs-count">0</span>
+      </div>
+      <div class="sup-needs-you-list" id="sup-needs-you-list"></div>
+    </div>
+    <div class="sup-columns">
+      <div class="sup-col">
+        <h3>Pending <span class="sup-count" id="sup-ct-pending">0</span></h3>
+        <div class="sup-col-list" id="sup-list-pending"></div>
+      </div>
+      <div class="sup-col">
+        <h3>In-flight <span class="sup-count" id="sup-ct-active">0</span></h3>
+        <div class="sup-col-list" id="sup-list-active"></div>
+      </div>
+      <div class="sup-col">
+        <h3>Done <span class="sup-count" id="sup-ct-done">0</span></h3>
+        <div class="sup-col-list" id="sup-list-done"></div>
+      </div>
+      <div class="sup-col">
+        <h3>Failed <span class="sup-count" id="sup-ct-failed">0</span></h3>
+        <div class="sup-col-list" id="sup-list-failed"></div>
+      </div>
+    </div>
+  `;
+
+  async function resolveSupervisorRoot() {
+    if (supervisorRoot) return supervisorRoot;
+    try {
+      const meta = await fetchJson('/api/meta');
+      if (meta && meta.audit_path) {
+        // audit_path = <ROOT>/run-state/audit.jsonl → ROOT = grandparent
+        supervisorRoot = path.dirname(path.dirname(meta.audit_path));
+      }
+    } catch (err) {
+      // Without the root, deliverable paths stay relative — editor.openFile
+      // will fail and the user sees an error in the editor overlay. We log
+      // once so the cause is debuggable.
+      console.warn('[supervisor] could not resolve audit_path:', err.message);
+    }
+    return supervisorRoot;
+  }
+
+  function onArtifactClick(absPath) {
+    try {
+      const editor = require('../editor');
+      // editor.openFile(filePath, source) — Phase A spec §9 Q2 verified the
+      // signature accepts absolute paths outside the current Frame project
+      // root: src/main/fileEditor.js reads via fs.readFileSync(filePath) with
+      // no project-root check.
+      editor.openFile(absPath, 'supervisor');
+    } catch (err) {
+      console.warn('[supervisor] editor.openFile failed:', err);
+    }
+  }
+
+  function fillList(elId, items, emptyMsg, columnKey) {
+    const el = root.querySelector(`#${elId}`);
+    if (!el) return;
+    el.innerHTML = '';
+    if (!items.length) {
+      el.innerHTML = `<div class="sup-col-empty">${emptyMsg}</div>`;
+      return;
+    }
+    const ctx = { supervisorRoot, onArtifactClick };
+    items.forEach((t) => {
+      const card = taskCard.render(t, columnKey, ctx);
+      el.appendChild(card);
+      if (pendingScrollTaskId && card.dataset.taskId === pendingScrollTaskId) {
+        setTimeout(() => {
+          card.scrollIntoView({ behavior: 'smooth', block: 'center' });
+          card.classList.add('flash');
+          setTimeout(() => card.classList.remove('flash'), 2000);
+        }, 50);
+        pendingScrollTaskId = null;
+      }
+    });
+  }
+
+  async function poll() {
+    if (!alive) return;
+    await resolveSupervisorRoot();
+    try {
+      const ws = await fetchJson('/api/workspace');
+      if (!alive) return;
+      const cols = ws.columns || {};
+      const pending = cols.pending || [];
+      const active = cols.active || [];
+      const awaiting = cols.awaiting || [];
+      const allDone = cols.done || [];
+      // Split Done into "done" and "failed" — server lumps them in `done`.
+      const done = allDone.filter((t) => t.status !== 'failed');
+      const failed = allDone.filter((t) => t.status === 'failed');
+
+      // Counts
+      root.querySelector('#sup-ct-pending').textContent = String(pending.length);
+      root.querySelector('#sup-ct-active').textContent = String(active.length);
+      root.querySelector('#sup-ct-done').textContent = String(done.length);
+      root.querySelector('#sup-ct-failed').textContent = String(failed.length);
+      root.querySelector('#sup-needs-count').textContent = String(awaiting.length);
+
+      fillList('sup-list-pending', pending, 'Queue empty', 'pending');
+      fillList('sup-list-active', active, 'No active work', 'active');
+      fillList('sup-list-done', done, 'No completed tasks', 'done');
+      fillList('sup-list-failed', failed, 'No failures ✓', 'failed');
+
+      // Needs-You row
+      const needsListEl = root.querySelector('#sup-needs-you-list');
+      needsListEl.innerHTML = '';
+      if (!awaiting.length) {
+        needsListEl.innerHTML = '<div class="sup-needs-you-empty">Nothing needs you ✓</div>';
+      } else {
+        const ctx = { supervisorRoot, onArtifactClick };
+        awaiting.forEach((t) => needsListEl.appendChild(taskCard.render(t, 'awaiting', ctx)));
+      }
+    } catch (err) {
+      // Quiet — keep the last rendered state
+    }
+  }
+
+  function scrollToTask(taskId) {
+    pendingScrollTaskId = taskId;
+    poll();
+  }
+
+  function start() {
+    if (timer) return;
+    poll();
+    timer = setInterval(poll, 4000);
+  }
+
+  function stop() {
+    alive = false;
+    if (timer) clearInterval(timer);
+    timer = null;
+  }
+
+  start();
+  return { start, stop, refresh: poll, scrollToTask };
+}
+
+module.exports = { create };

--- a/src/renderer/supervisor-ui/projectTree.js
+++ b/src/renderer/supervisor-ui/projectTree.js
@@ -1,16 +1,21 @@
 // Supervisor project tree — Phase B.
 //
-// Left rail listing supervisor-known projects. Source: /api/memory/projects
-// (the actual server has no /api/meta.projects array — that was inferred in
-// the brief; reality lives in supervisor/scripts/monitor/server.py:691).
-//
-// Per project, lazy-fetch docs (via SUPERVISOR_LIST_PROJECT_DOCS IPC). Clicking
-// a doc routes through editor.openFile(absPath).
-//
-// `queue/` child (per-project task filter) is deferred: workspace tasks don't
-// carry a project_id field. `.frame/specs/` child is deferred: no backend
-// endpoint exists for it yet. Both reappear when their data sources land.
+// Left rail listing Frame's workspace projects (from ~/.frame/workspaces.json
+// via SUPERVISOR_LIST_WORKSPACE_PROJECTS). For each project, three lazy
+// children:
+//   queue/ — /api/workspace filtered by substring match on title/id/profile/
+//            brief vs the project name (workspace tasks don't carry a
+//            project_id field, so we mirror the loose-match the PWA's
+//            project filter already does at supervisor/mobile/index.html:990).
+//            Clicking a queue row scrolls + flashes the matching card in
+//            the kanban via the onScrollToTask callback.
+//   docs/  — SUPERVISOR_LIST_PROJECT_DOCS({project_id: name, project_path}).
+//            Lists develop/*.md + ~/memory/<name>/**/*.md.
+//   specs/ — SUPERVISOR_LIST_PROJECT_SPECS({project_path}). Lists
+//            .frame/specs/<slug>/{spec,plan,tasks}.md — scanned from the
+//            filesystem since no supervisor API exposes this.
 
+const path = require('path');
 const { ipcRenderer } = require('electron');
 const SUP = require('../../shared/supervisor-ipc');
 const { SUPERVISOR_API } = require('./header');
@@ -27,7 +32,7 @@ async function fetchJson(p) {
   return res.json();
 }
 
-function openDoc(absPath) {
+function openFile(absPath) {
   try {
     const editor = require('../editor');
     editor.openFile(absPath, 'supervisor');
@@ -36,23 +41,51 @@ function openDoc(absPath) {
   }
 }
 
-function create(root) {
+/**
+ * Heuristic project-match: case-insensitive substring against title/id/
+ * profile/brief. Mirrors the PWA's project filter — loose, but the only
+ * option since the workspace payload has no project_id field.
+ */
+function taskMatchesProject(task, projectName) {
+  if (!projectName) return false;
+  const n = String(projectName).toLowerCase();
+  if (!n) return false;
+  return (
+    (task.id || '').toLowerCase().includes(n) ||
+    (task.title || '').toLowerCase().includes(n) ||
+    (task.profile || '').toLowerCase().includes(n) ||
+    (task.brief || '').toLowerCase().includes(n)
+  );
+}
+
+function flatTasks(workspace) {
+  const cols = (workspace && workspace.columns) || {};
+  return [
+    ...(cols.pending || []),
+    ...(cols.active || []),
+    ...(cols.awaiting || []),
+    ...(cols.done || []),
+  ];
+}
+
+function create(root, opts = {}) {
   let alive = true;
+  const onScrollToTask = opts.onScrollToTask || (() => {});
 
   root.innerHTML = '<div class="sup-tree-empty">Loading projects…</div>';
 
-  function buildDocsChildEl(projectId) {
+  function makeGroupNode(label, loader, renderChildren) {
     const wrap = document.createElement('div');
     wrap.className = 'sup-tree-node';
     wrap.innerHTML = `
-      <div class="sup-tree-row group" data-act="toggle-docs">
+      <div class="sup-tree-row group">
         <span class="sup-chev">▸</span>
-        <span class="sup-label">docs</span>
+        <span class="sup-label">${esc(label)}</span>
       </div>
       <div class="sup-tree-children"></div>
     `;
-    const childrenEl = wrap.querySelector('.sup-tree-children');
     const rowEl = wrap.querySelector('.sup-tree-row');
+    const childrenEl = wrap.querySelector('.sup-tree-children');
     let loaded = false;
     rowEl.addEventListener('click', async (e) => {
       e.stopPropagation();
@@ -62,27 +95,10 @@ function create(root) {
         loaded = true;
         childrenEl.innerHTML = '<div class="sup-tree-loading">loading…</div>';
         try {
-          const docs = await ipcRenderer.invoke(
-            SUP.SUPERVISOR_LIST_PROJECT_DOCS,
-            { project_id: projectId, project_path: null }
-          );
+          const data = await loader();
           if (!alive) return;
           childrenEl.innerHTML = '';
-          if (!docs || !docs.length) {
-            childrenEl.innerHTML = '<div class="sup-tree-loading">no docs</div>';
-            return;
-          }
-          docs.forEach((d) => {
-            const row = document.createElement('div');
-            row.className = 'sup-tree-row leaf';
-            row.title = d.path;
-            row.innerHTML = `<span class="sup-label">${esc(d.label)}</span>`;
-            row.addEventListener('click', (ev) => {
-              ev.stopPropagation();
-              openDoc(d.path);
-            });
-            childrenEl.appendChild(row);
-          });
+          renderChildren(childrenEl, data);
         } catch (err) {
           childrenEl.innerHTML = `<div class="sup-tree-loading">error: ${esc(err.message || err)}</div>`;
         }
@@ -91,15 +107,93 @@ function create(root) {
     return wrap;
   }
 
+  function renderQueueChildren(childrenEl, tasks) {
+    if (!tasks.length) {
+      childrenEl.innerHTML = '<div class="sup-tree-loading">no matching tasks</div>';
+      return;
+    }
+    tasks.slice(0, 50).forEach((t) => {
+      const row = document.createElement('div');
+      row.className = 'sup-tree-row leaf';
+      row.title = `${t.id} — ${t.status || ''}`;
+      row.innerHTML = `
+        <span class="sup-label">${esc((t.title || t.id || '').slice(0, 48))}</span>
+        <span class="sup-meta-chip">${esc(t.status || '')}</span>
+      `;
+      row.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        onScrollToTask(t.id);
+      });
+      childrenEl.appendChild(row);
+    });
+  }
+
+  function renderDocsChildren(childrenEl, docs) {
+    if (!docs.length) {
+      childrenEl.innerHTML = '<div class="sup-tree-loading">no docs</div>';
+      return;
+    }
+    docs.forEach((d) => {
+      const row = document.createElement('div');
+      row.className = 'sup-tree-row leaf';
+      row.title = d.path;
+      row.innerHTML = `<span class="sup-label">${esc(d.label)}</span>`;
+      row.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        openFile(d.path);
+      });
+      childrenEl.appendChild(row);
+    });
+  }
+
+  function renderSpecsChildren(childrenEl, specs) {
+    if (!specs.length) {
+      childrenEl.innerHTML = '<div class="sup-tree-loading">no specs</div>';
+      return;
+    }
+    specs.forEach((s) => {
+      const slugWrap = document.createElement('div');
+      slugWrap.className = 'sup-tree-node';
+      const phaseChip = s.phase ? `<span class="sup-meta-chip" title="${esc(s.phase)}">${esc(s.phase.slice(0, 18))}</span>` : '';
+      slugWrap.innerHTML = `
+        <div class="sup-tree-row group">
+          <span class="sup-chev">▸</span>
+          <span class="sup-label">${esc(s.slug)}</span>
+          ${phaseChip}
+        </div>
+        <div class="sup-tree-children"></div>
+      `;
+      const slugRow = slugWrap.querySelector('.sup-tree-row');
+      const slugKids = slugWrap.querySelector('.sup-tree-children');
+      slugRow.addEventListener('click', (ev) => {
+        ev.stopPropagation();
+        const expanded = slugWrap.classList.toggle('expanded');
+        slugRow.querySelector('.sup-chev').textContent = expanded ? '▾' : '▸';
+        if (expanded && !slugKids.children.length) {
+          s.files.forEach((f) => {
+            const r = document.createElement('div');
+            r.className = 'sup-tree-row leaf';
+            r.title = f.path;
+            r.innerHTML = `<span class="sup-label">${esc(f.label)}</span>`;
+            r.addEventListener('click', (e2) => {
+              e2.stopPropagation();
+              openFile(f.path);
+            });
+            slugKids.appendChild(r);
+          });
+        }
+      });
+      childrenEl.appendChild(slugWrap);
+    });
+  }
+
   function buildProjectNode(p) {
     const node = document.createElement('div');
     node.className = 'sup-tree-node';
-    const notesLabel = typeof p.notes === 'number' ? `${p.notes}` : '';
     node.innerHTML = `
       <div class="sup-tree-row project">
         <span class="sup-chev">▸</span>
         <span class="sup-label">${esc(p.name)}</span>
-        <span class="sup-meta-chip">${esc(notesLabel)}</span>
       </div>
       <div class="sup-tree-children"></div>
     `;
@@ -111,7 +205,33 @@ function create(root) {
       rowEl.querySelector('.sup-chev').textContent = expanded ? '▾' : '▸';
       if (expanded && !built) {
         built = true;
-        childrenEl.appendChild(buildDocsChildEl(p.name));
+
+        const queueNode = makeGroupNode(
+          'queue',
+          async () => {
+            const ws = await fetchJson('/api/workspace');
+            return flatTasks(ws).filter((t) => taskMatchesProject(t, p.name));
+          },
+          renderQueueChildren
+        );
+        const docsNode = makeGroupNode(
+          'docs',
+          () => ipcRenderer.invoke(SUP.SUPERVISOR_LIST_PROJECT_DOCS, {
+            project_id: p.name,
+            project_path: p.path,
+          }),
+          renderDocsChildren
+        );
+        const specsNode = makeGroupNode(
+          '.frame/specs',
+          () => ipcRenderer.invoke(SUP.SUPERVISOR_LIST_PROJECT_SPECS, {
+            project_path: p.path,
+          }),
+          renderSpecsChildren
+        );
+        childrenEl.appendChild(queueNode);
+        childrenEl.appendChild(docsNode);
+        childrenEl.appendChild(specsNode);
       }
     });
     return node;
@@ -119,11 +239,11 @@ function create(root) {
 
   async function load() {
     try {
-      const projects = await fetchJson('/api/memory/projects');
+      const projects = await ipcRenderer.invoke(SUP.SUPERVISOR_LIST_WORKSPACE_PROJECTS);
       if (!alive) return;
       root.innerHTML = '';
       if (!projects || !projects.length) {
-        root.innerHTML = '<div class="sup-tree-empty">No projects registered</div>';
+        root.innerHTML = '<div class="sup-tree-empty">No Frame projects in workspace.<br/><small>Add one from the Home board.</small></div>';
         return;
       }
       projects.forEach((p) => {
@@ -131,7 +251,7 @@ function create(root) {
       });
     } catch (err) {
       if (!alive) return;
-      root.innerHTML = `<div class="sup-tree-empty">supervisor unreachable<br/><small>${esc(err.message || err)}</small></div>`;
+      root.innerHTML = `<div class="sup-tree-empty">project list unavailable<br/><small>${esc(err.message || err)}</small></div>`;
     }
   }
 

--- a/src/renderer/supervisor-ui/projectTree.js
+++ b/src/renderer/supervisor-ui/projectTree.js
@@ -1,0 +1,150 @@
+// Supervisor project tree — Phase B.
+//
+// Left rail listing supervisor-known projects. Source: /api/memory/projects
+// (the actual server has no /api/meta.projects array — that was inferred in
+// the brief; reality lives in supervisor/scripts/monitor/server.py:691).
+//
+// Per project, lazy-fetch docs (via SUPERVISOR_LIST_PROJECT_DOCS IPC). Clicking
+// a doc routes through editor.openFile(absPath).
+//
+// `queue/` child (per-project task filter) is deferred: workspace tasks don't
+// carry a project_id field. `.frame/specs/` child is deferred: no backend
+// endpoint exists for it yet. Both reappear when their data sources land.
+
+const { ipcRenderer } = require('electron');
+const SUP = require('../../shared/supervisor-ipc');
+const { SUPERVISOR_API } = require('./header');
+
+function esc(s) {
+  return String(s == null ? '' : s).replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ));
+}
+
+async function fetchJson(p) {
+  const res = await fetch(`${SUPERVISOR_API}${p}`);
+  if (!res.ok) throw new Error(`HTTP ${res.status}`);
+  return res.json();
+}
+
+function openDoc(absPath) {
+  try {
+    const editor = require('../editor');
+    editor.openFile(absPath, 'supervisor');
+  } catch (err) {
+    console.warn('[supervisor] editor.openFile failed:', err);
+  }
+}
+
+function create(root) {
+  let alive = true;
+
+  root.innerHTML = '<div class="sup-tree-empty">Loading projects…</div>';
+
+  function buildDocsChildEl(projectId) {
+    const wrap = document.createElement('div');
+    wrap.className = 'sup-tree-node';
+    wrap.innerHTML = `
+      <div class="sup-tree-row group" data-act="toggle-docs">
+        <span class="sup-chev">▸</span>
+        <span class="sup-label">docs</span>
+      </div>
+      <div class="sup-tree-children"></div>
+    `;
+    const childrenEl = wrap.querySelector('.sup-tree-children');
+    const rowEl = wrap.querySelector('.sup-tree-row');
+    let loaded = false;
+    rowEl.addEventListener('click', async (e) => {
+      e.stopPropagation();
+      const expanded = wrap.classList.toggle('expanded');
+      rowEl.querySelector('.sup-chev').textContent = expanded ? '▾' : '▸';
+      if (expanded && !loaded) {
+        loaded = true;
+        childrenEl.innerHTML = '<div class="sup-tree-loading">loading…</div>';
+        try {
+          const docs = await ipcRenderer.invoke(
+            SUP.SUPERVISOR_LIST_PROJECT_DOCS,
+            { project_id: projectId, project_path: null }
+          );
+          if (!alive) return;
+          childrenEl.innerHTML = '';
+          if (!docs || !docs.length) {
+            childrenEl.innerHTML = '<div class="sup-tree-loading">no docs</div>';
+            return;
+          }
+          docs.forEach((d) => {
+            const row = document.createElement('div');
+            row.className = 'sup-tree-row leaf';
+            row.title = d.path;
+            row.innerHTML = `<span class="sup-label">${esc(d.label)}</span>`;
+            row.addEventListener('click', (ev) => {
+              ev.stopPropagation();
+              openDoc(d.path);
+            });
+            childrenEl.appendChild(row);
+          });
+        } catch (err) {
+          childrenEl.innerHTML = `<div class="sup-tree-loading">error: ${esc(err.message || err)}</div>`;
+        }
+      }
+    });
+    return wrap;
+  }
+
+  function buildProjectNode(p) {
+    const node = document.createElement('div');
+    node.className = 'sup-tree-node';
+    const notesLabel = typeof p.notes === 'number' ? `${p.notes}` : '';
+    node.innerHTML = `
+      <div class="sup-tree-row project">
+        <span class="sup-chev">▸</span>
+        <span class="sup-label">${esc(p.name)}</span>
+        <span class="sup-meta-chip">${esc(notesLabel)}</span>
+      </div>
+      <div class="sup-tree-children"></div>
+    `;
+    const rowEl = node.querySelector('.sup-tree-row');
+    const childrenEl = node.querySelector('.sup-tree-children');
+    let built = false;
+    rowEl.addEventListener('click', () => {
+      const expanded = node.classList.toggle('expanded');
+      rowEl.querySelector('.sup-chev').textContent = expanded ? '▾' : '▸';
+      if (expanded && !built) {
+        built = true;
+        childrenEl.appendChild(buildDocsChildEl(p.name));
+      }
+    });
+    return node;
+  }
+
+  async function load() {
+    try {
+      const projects = await fetchJson('/api/memory/projects');
+      if (!alive) return;
+      root.innerHTML = '';
+      if (!projects || !projects.length) {
+        root.innerHTML = '<div class="sup-tree-empty">No projects registered</div>';
+        return;
+      }
+      projects.forEach((p) => {
+        root.appendChild(buildProjectNode(p));
+      });
+    } catch (err) {
+      if (!alive) return;
+      root.innerHTML = `<div class="sup-tree-empty">supervisor unreachable<br/><small>${esc(err.message || err)}</small></div>`;
+    }
+  }
+
+  function start() {
+    load();
+  }
+
+  function stop() {
+    alive = false;
+  }
+
+  start();
+  return { start, stop, refresh: load };
+}
+
+module.exports = { create };

--- a/src/renderer/supervisor-ui/styles.css
+++ b/src/renderer/supervisor-ui/styles.css
@@ -1,0 +1,412 @@
+/* Supervisor view — Phase B styles.
+   All colors, spacing, radii, fonts reference Frame design tokens from
+   src/renderer/styles/variables.css. Light/dark theme flip is automatic. */
+
+.supervisor-root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  width: 100%;
+  overflow: hidden;
+  background: var(--bg-primary);
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: 13px;
+}
+
+/* ---- Header ---- */
+.supervisor-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-md, 12px);
+  padding: var(--space-md, 12px) var(--space-lg, 16px);
+  border-bottom: 1px solid var(--border-default);
+  background: var(--bg-secondary);
+  flex-shrink: 0;
+}
+.supervisor-header .sup-live {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm, 8px);
+}
+.supervisor-header .sup-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+  background: var(--text-muted);
+  box-shadow: 0 0 0 4px rgba(124, 179, 130, 0);
+  transition: background var(--transition-fast), box-shadow var(--transition-fast);
+}
+.supervisor-header .sup-dot.alive {
+  background: var(--success);
+  box-shadow: 0 0 0 4px var(--success-subtle);
+}
+.supervisor-header .sup-dot.dead {
+  background: var(--error);
+  box-shadow: 0 0 0 4px var(--error-subtle);
+}
+.supervisor-header .sup-brand {
+  font-weight: 600;
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+.supervisor-header .sup-meta {
+  display: flex;
+  gap: var(--space-lg, 16px);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-secondary);
+}
+.supervisor-header .sup-meta .v {
+  color: var(--text-primary);
+  font-weight: 600;
+}
+.supervisor-header .sup-meta .v.warn {
+  color: var(--error);
+}
+.supervisor-header .sup-actions {
+  margin-left: auto;
+  display: flex;
+  gap: var(--space-sm, 8px);
+}
+.supervisor-header .sup-btn {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-default);
+  color: var(--text-primary);
+  font-family: inherit;
+  font-size: 11.5px;
+  font-weight: 600;
+  padding: 6px 12px;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  letter-spacing: 0.02em;
+  transition: background var(--transition-fast), border-color var(--transition-fast);
+}
+.supervisor-header .sup-btn:hover {
+  background: var(--bg-hover);
+  border-color: var(--border-strong);
+}
+.supervisor-header .sup-btn[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+.supervisor-header .sup-btn.primary {
+  background: var(--accent-primary);
+  border-color: var(--accent-primary);
+  color: var(--bg-primary);
+}
+.supervisor-header .sup-btn.primary:hover {
+  background: var(--accent-secondary);
+}
+
+/* ---- Body layout ---- */
+.supervisor-body {
+  display: flex;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+.supervisor-tree {
+  width: 240px;
+  flex-shrink: 0;
+  border-right: 1px solid var(--border-default);
+  background: var(--bg-secondary);
+  overflow-y: auto;
+  padding: var(--space-md, 12px) 0;
+}
+.supervisor-kanban {
+  flex: 1;
+  min-width: 0;
+  overflow-y: auto;
+  padding: var(--space-lg, 16px);
+}
+
+/* ---- Project tree ---- */
+.sup-tree-empty {
+  padding: var(--space-md, 12px) var(--space-lg, 16px);
+  color: var(--text-tertiary);
+  font-size: 11.5px;
+  font-family: var(--font-mono);
+}
+.sup-tree-node {
+  display: block;
+}
+.sup-tree-row {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px var(--space-md, 12px);
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--text-primary);
+  user-select: none;
+  border-radius: 0;
+  transition: background var(--transition-fast);
+}
+.sup-tree-row:hover {
+  background: var(--bg-hover);
+}
+.sup-tree-row .sup-chev {
+  width: 12px;
+  display: inline-block;
+  font-size: 10px;
+  color: var(--text-tertiary);
+  flex-shrink: 0;
+}
+.sup-tree-row .sup-label {
+  flex: 1;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.sup-tree-row .sup-meta-chip {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-tertiary);
+  margin-left: auto;
+  flex-shrink: 0;
+}
+.sup-tree-row.project {
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+.sup-tree-row.group {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-secondary);
+  padding-left: 28px;
+}
+.sup-tree-row.leaf {
+  font-size: 11.5px;
+  color: var(--text-secondary);
+  padding-left: 44px;
+  font-family: var(--font-mono);
+}
+.sup-tree-row.leaf:hover {
+  color: var(--text-primary);
+}
+.sup-tree-children {
+  display: none;
+}
+.sup-tree-node.expanded > .sup-tree-children {
+  display: block;
+}
+.sup-tree-loading {
+  padding: 4px 44px;
+  font-size: 11px;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+}
+
+/* ---- Kanban ---- */
+.sup-needs-you {
+  margin-bottom: var(--space-lg, 16px);
+}
+.sup-needs-you .sup-section-hdr {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-secondary);
+  margin-bottom: var(--space-sm, 8px);
+  padding-bottom: 6px;
+  border-bottom: 1px solid var(--border-default);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.sup-needs-you .sup-count {
+  background: var(--error-subtle);
+  color: var(--error);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 1px 7px;
+  border-radius: 8px;
+}
+.sup-needs-you .sup-needs-you-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: var(--space-sm, 8px);
+}
+.sup-needs-you-empty {
+  font-size: 12px;
+  color: var(--text-tertiary);
+  font-family: var(--font-mono);
+  padding: var(--space-md, 12px);
+}
+
+.sup-columns {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: var(--space-md, 12px);
+}
+@media (max-width: 880px) {
+  .sup-columns { grid-template-columns: 1fr; }
+}
+.sup-col {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  padding: var(--space-sm, 8px);
+  min-height: 160px;
+  display: flex;
+  flex-direction: column;
+}
+.sup-col h3 {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--text-secondary);
+  margin: 0 0 var(--space-sm, 8px);
+  padding: 0 4px 6px;
+  border-bottom: 1px solid var(--border-subtle);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-weight: 600;
+}
+.sup-col h3 .sup-count {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  padding: 1px 7px;
+  border-radius: 8px;
+  font-weight: normal;
+  letter-spacing: 0;
+}
+.sup-col-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-sm, 8px);
+}
+.sup-col-empty {
+  text-align: center;
+  color: var(--text-tertiary);
+  padding: var(--space-xl, 24px) var(--space-md, 12px);
+  font-size: 11.5px;
+  font-family: var(--font-mono);
+}
+
+/* ---- Task card ---- */
+.sup-card {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm, 8px) var(--space-md, 12px);
+  transition: border-color var(--transition-fast), background var(--transition-fast);
+}
+.sup-card.flash {
+  border-color: var(--accent-primary);
+  background: var(--accent-subtle);
+}
+.sup-card.esc {
+  border-color: var(--error);
+  background: var(--error-subtle);
+}
+.sup-card.done {
+  opacity: 0.85;
+}
+.sup-card-row1 {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 6px;
+  flex-wrap: wrap;
+}
+.sup-tag {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  padding: 2px 6px;
+  border-radius: 5px;
+  font-weight: 700;
+  flex-shrink: 0;
+}
+.sup-tag.running { color: var(--info); background: rgba(120, 165, 212, 0.15); }
+.sup-tag.escalate { color: var(--error); background: var(--error-subtle); }
+.sup-tag.done { color: var(--success); background: var(--success-subtle); }
+.sup-tag.failed { color: var(--error); background: var(--error-subtle); }
+.sup-tag.pending { color: var(--text-tertiary); background: var(--bg-elevated); }
+.sup-tag.revising { color: var(--warning); background: rgba(224, 164, 88, 0.15); }
+.sup-tid {
+  font-family: var(--font-mono);
+  font-size: 9.5px;
+  color: var(--text-muted);
+  margin-left: auto;
+  max-width: 120px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.sup-card-title {
+  font-size: 12.5px;
+  font-weight: 600;
+  line-height: 1.32;
+  margin: 0 0 6px;
+  color: var(--text-primary);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+}
+.sup-card-meta {
+  display: flex;
+  gap: 10px;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-muted);
+  margin-top: 4px;
+  flex-wrap: wrap;
+}
+.sup-card-meta .warn { color: var(--error); }
+.sup-card-profile {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-secondary);
+  background: var(--bg-elevated);
+  padding: 1px 6px;
+  border-radius: 4px;
+}
+
+/* ---- Artifact links on Done cards ---- */
+.sup-artifacts {
+  margin-top: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.sup-artifact {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--info);
+  background: transparent;
+  border: none;
+  padding: 2px 4px;
+  text-align: left;
+  cursor: pointer;
+  border-radius: 4px;
+  transition: background var(--transition-fast), color var(--transition-fast);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.sup-artifact:hover {
+  background: var(--bg-elevated);
+  color: var(--accent-primary);
+}
+
+/* ---- Error / empty banners ---- */
+.sup-banner {
+  background: var(--error-subtle);
+  border: 1px solid var(--error);
+  border-radius: var(--radius-sm);
+  padding: var(--space-sm, 8px) var(--space-md, 12px);
+  margin-bottom: var(--space-md, 12px);
+  font-size: 12px;
+  color: var(--error);
+  font-family: var(--font-mono);
+}

--- a/src/renderer/supervisor-ui/taskCard.js
+++ b/src/renderer/supervisor-ui/taskCard.js
@@ -1,0 +1,114 @@
+// Supervisor task card — Phase B (collapsed only).
+//
+// Expanded state lands in Phase D (or B.5). For now: title, profile chip,
+// elapsed time if in-flight, and (for Done cards) a compact list of artifact
+// links resolved against the supervisor root.
+
+const path = require('path');
+
+function esc(s) {
+  return String(s == null ? '' : s).replace(/[&<>"']/g, (c) => (
+    { '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]
+  ));
+}
+
+function statusTag(t) {
+  if (t.pending_human_response) return 'escalate';
+  if (t.last_critique_verdict === 'revise') return 'revising';
+  if (t.status === 'done') return 'done';
+  if (t.status === 'failed') return 'failed';
+  if (t.status === 'pending') return 'pending';
+  return 'running';
+}
+
+function elapsedLabel(t) {
+  const s = Number(t.elapsed_s || 0);
+  if (!s) return null;
+  const mins = Math.floor(s / 60);
+  const secs = Math.round(s % 60);
+  return `${mins}m ${secs}s`;
+}
+
+function costLabel(t) {
+  if (typeof t.cost_usd === 'number' && t.cost_usd > 0) return `$${t.cost_usd.toFixed(2)}`;
+  return null;
+}
+
+/**
+ * Resolve a (possibly relative) deliverable path against the supervisor root.
+ * Server returns paths like "src/foo.py" or "prompts/bar.md" — relative to
+ * the supervisor ROOT. We compute ROOT from /api/meta.audit_path (parent of
+ * `run-state/`).
+ */
+function resolveDeliverable(p, supervisorRoot) {
+  if (!p) return p;
+  if (path.isAbsolute(p)) return p;
+  if (!supervisorRoot) return p;
+  return path.resolve(supervisorRoot, p);
+}
+
+/**
+ * Render a single task card into `parentEl`.
+ * @param {object} t              task object from /api/workspace
+ * @param {string} columnKey      pending|active|awaiting|done|failed
+ * @param {object} ctx            { supervisorRoot, onArtifactClick }
+ * @returns {HTMLElement} the card element (for highlighting/scroll-to)
+ */
+function render(t, columnKey, ctx) {
+  const card = document.createElement('div');
+  const tag = statusTag(t);
+  card.className = 'sup-card';
+  if (tag === 'escalate') card.classList.add('esc');
+  if (tag === 'done' || tag === 'failed') card.classList.add('done');
+  card.dataset.taskId = t.id || '';
+
+  const profileChip = t.profile
+    ? `<span class="sup-card-profile">${esc(t.profile)}</span>`
+    : '';
+  const tid = (t.id || '').slice(-12);
+
+  const metaParts = [];
+  const cost = costLabel(t);
+  if (cost) metaParts.push(`<span>${cost}</span>`);
+  const elapsed = elapsedLabel(t);
+  if (elapsed && t.is_active) metaParts.push(`<span>${elapsed}</span>`);
+  if (t.tool_uses) metaParts.push(`<span>${t.tool_uses} tools</span>`);
+
+  card.innerHTML = `
+    <div class="sup-card-row1">
+      <span class="sup-tag ${tag}">${tag}</span>
+      ${profileChip}
+      <span class="sup-tid" title="${esc(t.id || '')}">${esc(tid)}</span>
+    </div>
+    <div class="sup-card-title" title="${esc(t.title || '')}">${esc(t.title || t.id || '(untitled)')}</div>
+    ${metaParts.length ? `<div class="sup-card-meta">${metaParts.join('')}</div>` : ''}
+  `;
+
+  // Artifact links on Done cards
+  const deliverables = Array.isArray(t.deliverables) ? t.deliverables : [];
+  if (deliverables.length && (tag === 'done' || tag === 'failed')) {
+    const artifactsEl = document.createElement('div');
+    artifactsEl.className = 'sup-artifacts';
+    deliverables.slice(0, 8).forEach((rel) => {
+      const abs = resolveDeliverable(rel, ctx.supervisorRoot);
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'sup-artifact';
+      const filename = path.basename(rel);
+      btn.textContent = `▸ ${filename}`;
+      btn.title = abs || rel;
+      btn.addEventListener('click', (e) => {
+        e.stopPropagation();
+        if (typeof ctx.onArtifactClick === 'function') {
+          ctx.onArtifactClick(abs || rel);
+        }
+      });
+      artifactsEl.appendChild(btn);
+    });
+    card.appendChild(artifactsEl);
+  }
+
+  return card;
+}
+
+module.exports = { render, statusTag };

--- a/src/shared/supervisor-ipc.js
+++ b/src/shared/supervisor-ipc.js
@@ -7,6 +7,8 @@ module.exports = {
   SUPERVISOR_STATE: 'supervisor:state',                  // reactive state push (main → renderer)
   SUPERVISOR_LIST_PROFILES: 'supervisor:list-profiles',  // scan profiles/*.yaml
   SUPERVISOR_LIST_PROJECT_DOCS: 'supervisor:list-project-docs',
+  SUPERVISOR_LIST_PROJECT_SPECS: 'supervisor:list-project-specs',       // scan <project_path>/.frame/specs/
+  SUPERVISOR_LIST_WORKSPACE_PROJECTS: 'supervisor:list-workspace-projects', // read ~/.frame/workspaces.json
   // Phase D
   SUPERVISOR_SUBMIT_TASK: 'supervisor:submit-task',
   SUPERVISOR_DAEMON_START: 'supervisor:daemon-start',

--- a/src/shared/supervisor-ipc.js
+++ b/src/shared/supervisor-ipc.js
@@ -1,0 +1,17 @@
+// SUPERVISOR-OWNED IPC channel names. All channels prefixed with SUPERVISOR_
+// per docs/frame-edit-discipline.md §1.5 to prevent collision with upstream Frame.
+module.exports = {
+  // Phase A
+  SUPERVISOR_PING: 'supervisor:ping',                    // round-trip sanity check
+  // Phase B (declared now; handlers land later)
+  SUPERVISOR_STATE: 'supervisor:state',                  // reactive state push (main → renderer)
+  SUPERVISOR_LIST_PROFILES: 'supervisor:list-profiles',  // scan profiles/*.yaml
+  SUPERVISOR_LIST_PROJECT_DOCS: 'supervisor:list-project-docs',
+  // Phase D
+  SUPERVISOR_SUBMIT_TASK: 'supervisor:submit-task',
+  SUPERVISOR_DAEMON_START: 'supervisor:daemon-start',
+  SUPERVISOR_DAEMON_STOP: 'supervisor:daemon-stop',
+  SUPERVISOR_RESPOND_ESCALATION: 'supervisor:respond-escalation',
+  // Phase E
+  SUPERVISOR_NOTIFY: 'supervisor:notify',
+};


### PR DESCRIPTION
## Summary

Native Frame integration of the supervisor (Remy) dashboard. Frame becomes a desktop client of the supervisor daemon at `:8766`, alongside the existing mobile PWA. Spec: `~/memory/lemonadestand/decisions/supervisor-native-frame-view-spec-2026-06-23.md`.

This branch hosts the full multi-phase rollout as stacked commits. Each phase is independently reviewable. Merge once Phase F lands and Chris approves.

## Phases

- [x] **A** — Skeleton: Supervisor tab + bridge IPC + ping handshake + ledger + check script (`77d8d7c`)
- [ ] **B** — Read-only dashboard: header + project tree + kanban + artifact links (in-flight)
- [ ] **C** — Live output + reactive state (file-watch + PTY-backed log tail)
- [ ] **D** — Actions: submit task + daemon start/stop + escalation respond
- [ ] **E** — Notifications: Electron-native OS notifications
- [ ] **F** — Polish: command palette, keyboard shortcuts, theme audit, sidebar footer chip

## Discipline budget (target ≤5 modified Frame files / ≤15 lines)

After Phase A: **2 modified Frame source files / 2 modified lines** — well under target. Tracked in `docs/frame-modifications.md`; verified by `scripts/check-supervisor-mods.sh`.

## How to preview locally

```bash
cd ~/Desktop/lemonade-stand/Frame-supervisor-tab-skeleton    # or wherever this worktree lives
git pull origin feat/supervisor-dashboard
npm install                                                     # first time only
npm run build && npm start
# In Frame: Cmd+Shift+P → "Open Supervisor"
```

Or once the alias is set: `frame-preview`.

## Mobile PWA unchanged

The PWA at `http://127.0.0.1:8766/` keeps running unchanged for mobile use. Frame and the PWA consume the same supervisor monitor HTTP API.

## Test plan

- [ ] Phase A smoke: Cmd+Shift+P → "Open Supervisor" opens a section showing "Supervisor — Loading…" + a live IPC ping result JSON
- [ ] Phase B smoke: section shows live heartbeat + project tree + kanban; clicking a `.md` artifact opens in Frame's markdown viewer
- [ ] Phase C smoke: heartbeat updates within 1s of daemon tick; tail-log streams ANSI output
- [ ] Phase D smoke: submit-task lands a new pending card; daemon stop/start toggles correctly
- [ ] Phase E smoke: failing a task surfaces an OS notification even when Frame is unfocused
- [ ] Phase F smoke: sidebar-footer heartbeat chip visible from any view; all palette commands registered
- [ ] Mobile PWA still works on iPhone Safari after each phase

🤖 Generated with [Claude Code](https://claude.com/claude-code)