### PR TITLE
fix(ai-tools): packaged app reports 'CLI not found' — probe via interactive login shell

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Auto-generated module structure",
-  "lastUpdated": "2026-06-22",
+  "lastUpdated": "2026-06-24",
   "architecture": {},
   "modules": {
     "main/aiToolManager": {
@@ -24,11 +24,16 @@
         "fs",
         "path",
         "child_process",
+        "os",
         "shared/ipcChannels"
       ],
       "functions": {
+        "loginShell": {
+          "line": 15,
+          "purpose": "doesn't source the zsh configs where PATH (claude/codex/gemini) usually lives."
+        },
         "init": {
-          "line": 73,
+          "line": 85,
           "params": [
             "window",
             "app"
@@ -36,54 +41,54 @@
           "purpose": "Initialize the AI Tool Manager"
         },
         "loadConfig": {
-          "line": 83,
+          "line": 95,
           "purpose": "Load configuration from file"
         },
         "saveConfig": {
-          "line": 98,
+          "line": 110,
           "purpose": "Save configuration to file"
         },
         "getAvailableTools": {
-          "line": 109,
+          "line": 121,
           "purpose": "Get all available AI tools"
         },
         "getActiveTool": {
-          "line": 116,
+          "line": 128,
           "purpose": "Get the currently active tool"
         },
         "setActiveTool": {
-          "line": 124,
+          "line": 136,
           "params": [
             "toolId"
           ],
           "purpose": "Set the active AI tool"
         },
         "getConfig": {
-          "line": 143,
+          "line": 155,
           "purpose": "Get full configuration for renderer"
         },
         "addCustomTool": {
-          "line": 153,
+          "line": 165,
           "params": [
             "tool"
           ],
           "purpose": "Add a custom AI tool"
         },
         "removeCustomTool": {
-          "line": 170,
+          "line": 182,
           "params": [
             "toolId"
           ],
           "purpose": "Remove a custom AI tool"
         },
         "isPathLike": {
-          "line": 182,
+          "line": 194,
           "params": [
             "command"
           ]
         },
         "isCommandAvailable": {
-          "line": 196,
+          "line": 208,
           "params": [
             "command",
             "projectPath"
@@ -91,18 +96,18 @@
           "purpose": "shell. Tries the tool's primary command first, then its fallback."
         },
         "setupIPC": {
-          "line": 250,
+          "line": 265,
           "purpose": "Setup IPC handlers"
         },
         "getCommand": {
-          "line": 299,
+          "line": 314,
           "params": [
             "action"
           ],
           "purpose": "Get command for specific action"
         },
         "getStartCommand": {
-          "line": 307,
+          "line": 322,
           "purpose": "Get the start command for active tool"
         }
       },

--- a/src/main/aiToolManager.js
+++ b/src/main/aiToolManager.js
@@ -7,6 +7,18 @@ const { ipcMain } = require('electron');
 const fs = require('fs');
 const path = require('path');
 const { spawn } = require('child_process');
+const os = require('os');
+
+// The user's real login shell. In a GUI-launched (packaged) app, process.env.SHELL
+// is often unset, so fall back to the passwd entry — never to /bin/sh, which
+// doesn't source the zsh configs where PATH (claude/codex/gemini) usually lives.
+function loginShell() {
+  try {
+    const s = os.userInfo().shell;
+    if (s) return s;
+  } catch {}
+  return process.env.SHELL || '/bin/zsh';
+}
 const { IPC } = require('../shared/ipcChannels');
 
 let mainWindow = null;
@@ -209,16 +221,19 @@ async function isCommandAvailable(command, projectPath) {
     }
   }
 
-  // PATH-based command: probe via the user's login shell so PATH
-  // additions from .zshrc/.bashrc and shim managers (asdf, nvm, brew)
-  // are visible — same reason we run the PTY shell with -l.
+  // PATH-based command: probe via the user's **interactive login** shell so
+  // PATH additions from .zshrc/.bashrc and shim managers (asdf, nvm, brew) are
+  // visible — exactly like the PTY, which runs the shell with `-i -l`. A
+  // packaged app launched from Finder has a minimal PATH and often no $SHELL,
+  // and a non-interactive login (`-lc`) skips .zshrc — that's why the bundled
+  // app reported "CLI not found" while the terminal could run it fine.
   const isWin = process.platform === 'win32';
   const shell = isWin
     ? (process.env.COMSPEC || 'cmd.exe')
-    : (process.env.SHELL || '/bin/sh');
+    : (process.env.SHELL || loginShell());
   const args = isWin
     ? ['/c', `where ${command}`]
-    : ['-lc', `command -v ${command}`];
+    : ['-ilc', `command -v ${command}`];
 
   return new Promise((resolve) => {
     let settled = false;
@@ -238,7 +253,7 @@ async function isCommandAvailable(command, projectPath) {
     const timer = setTimeout(() => {
       try { child.kill('SIGTERM'); } catch {}
       finish(false);
-    }, 3000);
+    }, 6000);
     child.on('exit', (code) => finish(code === 0));
     child.on('error', () => finish(false));
   });


### PR DESCRIPTION
## Problem

In the **packaged (Finder-launched) macOS app**, opening the Orchestrator (or any agent dispatch — task/spec runs, conductor, workers) failed with a red **\"CLI not found\"** toast, and the agent was never started.

A GUI-launched app gets a **minimal PATH** (\`/usr/bin:/bin:/usr/sbin:/sbin\`) and often **no \`\$SHELL\`**. The availability pre-flight (\`isCommandAvailable\`) fell back to \`/bin/sh -lc 'command -v claude'\`:
- \`/bin/sh\` doesn't source the user's zsh configs.
- a **non-interactive** login (\`-lc\`) skips \`.zshrc\`, where the agent's PATH usually lives (e.g. \`. ~/.local/bin/env\`).

So the check reported the CLI missing and \`agentDispatch\` refused to send the start command — even though the **PTY** (which runs the shell with \`-i -l\`) could launch \`claude\` perfectly. Dev (\`npm start\`) inherited the terminal's full PATH, so it only reproduced in the bundled app.

## Fix

Probe with the user's **real login shell** (\`os.userInfo().shell\`, reliable in GUI apps where \`\$SHELL\` is unset) using an **interactive login** (\`-ilc\`) — exactly matching the PTY, so the check sees the same PATH the terminal will. Timeout bumped 3s → 6s for heavier interactive rc files.

## Verification

Faithful packaged-app simulation (cleared env, minimal PATH, no \`\$SHELL\`):
- before — \`/bin/zsh -lc 'command -v claude'\` → **not found** (misses \`.zshrc\`)
- after — \`/bin/zsh -ilc 'command -v claude'\` → **\`~/.local/bin/claude\`** ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)