### PR TITLE
fix(plugins): don't overwrite a ~/.claude/settings.json we can't parse

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Auto-generated module structure",
-  "lastUpdated": "2026-06-24",
+  "lastUpdated": "2026-06-26",
   "architecture": {},
   "modules": {
     "main/aiToolManager": {
@@ -1287,15 +1287,15 @@
           "purpose": "Toggle plugin enabled/disabled status"
         },
         "ensureOfficialMarketplace": {
-          "line": 163,
+          "line": 188,
           "purpose": "Ensure official marketplace exists"
         },
         "refreshMarketplace": {
-          "line": 192,
+          "line": 217,
           "purpose": "Refresh marketplace plugins (git pull or clone)"
         },
         "setupIPC": {
-          "line": 220,
+          "line": 245,
           "params": [
             "ipcMain"
           ],

--- a/src/main/pluginsManager.js
+++ b/src/main/pluginsManager.js
@@ -138,7 +138,23 @@ function getAllPlugins() {
  * Toggle plugin enabled/disabled status
  */
 function togglePlugin(pluginId) {
-  const settings = readJsonFile(SETTINGS_FILE) || {};
+  // This file is the user's GLOBAL Claude config — it can hold custom API /
+  // router / env / permission settings we don't own. Never overwrite a file we
+  // couldn't read: if it exists but doesn't parse, abort instead of clobbering
+  // it with just { enabledPlugins }, which would reset their config to default.
+  let settings;
+  if (fs.existsSync(SETTINGS_FILE)) {
+    settings = readJsonFile(SETTINGS_FILE);
+    if (settings === null || typeof settings !== 'object' || Array.isArray(settings)) {
+      return {
+        success: false,
+        pluginId,
+        error: 'Could not parse ~/.claude/settings.json — refusing to overwrite it so your custom settings stay intact. Fix or remove that file, then try again.'
+      };
+    }
+  } else {
+    settings = {};
+  }
 
   if (!settings.enabledPlugins) {
     settings.enabledPlugins = {};
@@ -147,6 +163,15 @@ function togglePlugin(pluginId) {
   // Toggle the status
   const currentStatus = settings.enabledPlugins[pluginId] === true;
   settings.enabledPlugins[pluginId] = !currentStatus;
+
+  // Belt and suspenders: back up the existing file before we touch it.
+  try {
+    if (fs.existsSync(SETTINGS_FILE)) {
+      fs.copyFileSync(SETTINGS_FILE, SETTINGS_FILE + '.bak');
+    }
+  } catch (err) {
+    console.error('Could not back up settings.json:', err);
+  }
 
   const success = writeJsonFile(SETTINGS_FILE, settings);
 


### PR DESCRIPTION
## Problem (reported by a new tester)

> It reset claude cli to default instead of using my custom api settings.

Toggling a plugin in the Plugins panel is the **only** place Frame writes the user's global `~/.claude/settings.json`. It did:

```js
const settings = readJsonFile(SETTINGS_FILE) || {};
// ...modify enabledPlugins...
writeJsonFile(SETTINGS_FILE, settings);
```

On a valid file this preserves everything (read-modify-write of the whole object). But `readJsonFile` returns `null` when the file **exists but can't be parsed** — e.g. a custom router/proxy wrote a non-standard format. The `|| {}` then kicks in, and the file is overwritten with just `{ enabledPlugins }` — **wiping the user's custom API / router / env / permission settings** and resetting Claude to default.

## Fix

- If `settings.json` **exists but doesn't parse**, abort the toggle and return an error — never clobber a file we couldn't safely read.
- Only start from `{}` when the file genuinely **doesn't exist** (nothing to lose).
- Back the file up to `settings.json.bak` before writing (belt and suspenders).

This is the user's global Claude config and may hold settings we don't own, so the safe default is: leave it alone unless we can read it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)