### PR TITLE
feat(specs-dashboard): add keyword search over spec.md content

### DIFF
--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Auto-generated module structure",
-  "lastUpdated": "2026-06-24",
+  "lastUpdated": "2026-07-02",
   "architecture": {},
   "modules": {
     "main/aiToolManager": {
@@ -1620,6 +1620,7 @@
         "setupIPC",
         "validateSpecStatus",
         "listSpecs",
+        "searchSpecs",
         "getSpec",
         "createSpec",
         "updateSpecStatus",
@@ -1832,15 +1833,23 @@
             "slug"
           ]
         },
+        "searchSpecs": {
+          "line": 487,
+          "params": [
+            "projectPath",
+            "query"
+          ],
+          "purpose": "result with the active phase filter."
+        },
         "createSpec": {
-          "line": 480,
+          "line": 508,
           "params": [
             "projectPath",
             "opts"
           ]
         },
         "updateSpecStatus": {
-          "line": 522,
+          "line": 550,
           "params": [
             "projectPath",
             "slug",
@@ -1848,14 +1857,14 @@
           ]
         },
         "deleteSpec": {
-          "line": 540,
+          "line": 568,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "renameSpec": {
-          "line": 557,
+          "line": 585,
           "params": [
             "projectPath",
             "oldSlug",
@@ -1864,30 +1873,30 @@
           "purpose": "Returns { success: true, slug, status } on success, { error } on failure."
         },
         "startWatching": {
-          "line": 664,
+          "line": 692,
           "params": [
             "projectPath"
           ],
           "purpose": "across all three platforms — if that ever changes, swap in a poller."
         },
         "stopWatching": {
-          "line": 706
+          "line": 734
         },
         "pushSpecData": {
-          "line": 726,
+          "line": 754,
           "params": [
             "projectPath"
           ]
         },
         "init": {
-          "line": 737,
+          "line": 765,
           "params": [
             "window"
           ],
           "purpose": "─── Init + IPC ────────────────────────────────────────────"
         },
         "setupIPC": {
-          "line": 741,
+          "line": 769,
           "params": [
             "ipcMain"
           ]
@@ -1896,6 +1905,7 @@
       "ipc": {
         "listens": [
           "LIST_SPECS",
+          "SEARCH_SPECS",
           "GET_SPEC",
           "CREATE_SPEC",
           "UPDATE_SPEC_STATUS",
@@ -4592,78 +4602,91 @@
       ],
       "functions": {
         "init": {
-          "line": 49
+          "line": 54
         },
         "setupIPCListeners": {
-          "line": 81
+          "line": 90
         },
         "show": {
-          "line": 119,
+          "line": 131,
           "purpose": "─── Visibility ──────────────────────────────────────────"
         },
         "hide": {
-          "line": 150
+          "line": 163
         },
         "toggle": {
-          "line": 157
+          "line": 170
         },
         "renderFilters": {
-          "line": 163,
+          "line": 176,
           "purpose": "─── Filters ─────────────────────────────────────────────"
         },
         "applyFilter": {
-          "line": 177,
+          "line": 190,
           "params": [
             "specsList"
           ]
         },
+        "setupSearch": {
+          "line": 206,
+          "purpose": "─── Search ──────────────────────────────────────────────"
+        },
+        "runSearch": {
+          "line": 220,
+          "params": [
+            "rawQuery"
+          ]
+        },
+        "clearSearch": {
+          "line": 243
+        },
         "renderGrid": {
-          "line": 190,
+          "line": 254,
           "purpose": "─── Grid ────────────────────────────────────────────────"
         },
         "renderCard": {
-          "line": 218,
+          "line": 284,
           "params": [
             "spec"
           ]
         },
         "selectCard": {
-          "line": 250,
+          "line": 316,
           "params": [
             "slug"
           ],
           "purpose": "─── Detail aside ───────────────────────────────────────"
         },
         "clearSelection": {
-          "line": 258
+          "line": 324
         },
         "reloadDetail": {
-          "line": 266
+          "line": 332
         },
         "renderDetailHeader": {
-          "line": 282
+          "line": 348
         },
         "nextActionForPhase": {
-          "line": 354,
+          "line": 420,
           "params": [
             "phase"
           ]
         },
         "renderNextActionBar": {
-          "line": 370,
+          "line": 436,
           "params": [
             "action",
             "lane"
           ]
         },
         "runSpecCommand": {
-          "line": 401,
+          "line": 467,
           "params": [
             "command"
           ]
         },
         "tabBtn": {
-          "line": 412,
+          "line": 478,
           "params": [
             "tab",
             "label",
@@ -4671,57 +4694,57 @@
           ]
         },
         "renderDetailBody": {
-          "line": 418
+          "line": 484
         },
         "renderTasksTabBody": {
-          "line": 439
+          "line": 505
         },
         "renderSpecTaskRow": {
-          "line": 476,
+          "line": 542,
           "params": [
             "task"
           ]
         },
         "attachTaskActionHandlers": {
-          "line": 525
+          "line": 591
         },
         "handleSpecTaskAction": {
-          "line": 538,
+          "line": 604,
           "params": [
             "taskId",
             "action"
           ]
         },
         "hasSpecTasks": {
-          "line": 549,
+          "line": 615,
           "purpose": "─── Helpers ────────────────────────────────────────────"
         },
         "tasksTabLabel": {
-          "line": 555,
+          "line": 621,
           "params": [
             "hasMarkdown"
           ]
         },
         "renderMarkdown": {
-          "line": 564,
+          "line": 630,
           "params": [
             "md"
           ]
         },
         "escapeHtml": {
-          "line": 569,
+          "line": 635,
           "params": [
             "s"
           ]
         },
         "relativeTime": {
-          "line": 575,
+          "line": 641,
           "params": [
             "iso"
           ]
         },
         "displayProjectName": {
-          "line": 586,
+          "line": 652,
           "params": [
             "projectPath"
           ]
@@ -7872,6 +7895,11 @@
       },
       "ORCH_REMOVE_WORKER": {
         "name": "orch-remove-worker",
+        "direction": "",
+        "description": ""
+      },
+      "SEARCH_SPECS": {
+        "name": "search-specs",
         "direction": "",
         "description": ""
       }

--- a/index.html
+++ b/index.html
@@ -1010,7 +1010,14 @@
           <button id="specs-dashboard-close" class="specs-dashboard-close" tabindex="-1" aria-label="Close dashboard">&#x2715;</button>
         </div>
       </div>
-      <div id="specs-dashboard-filters" class="specs-dashboard-filters"></div>
+      <div class="specs-dashboard-toolbar">
+        <div id="specs-dashboard-filters" class="specs-dashboard-filters"></div>
+        <div class="specs-dashboard-search">
+          <svg class="specs-dashboard-search-icon" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+          <input id="specs-dashboard-search-input" class="specs-dashboard-search-input" type="text" placeholder="Search spec.md…" autocomplete="off" spellcheck="false" tabindex="-1" />
+          <button id="specs-dashboard-search-clear" class="specs-dashboard-search-clear" tabindex="-1" title="Clear search" type="button">&#x2715;</button>
+        </div>
+      </div>
       <div class="specs-dashboard-body">
         <div id="specs-dashboard-grid" class="specs-dashboard-grid"></div>
         <aside id="specs-dashboard-detail" class="specs-dashboard-detail">

--- a/src/main/specManager.js
+++ b/src/main/specManager.js
@@ -477,6 +477,34 @@ function getSpec(projectPath, slug) {
   };
 }
 
+/**
+ * Search specs by keyword over their spec.md content. Case-insensitive
+ * substring match. Returns the array of matching slugs, or null for an
+ * empty/whitespace query (meaning "no search active" — caller shows all).
+ * Used by the specs dashboard search box; the renderer intersects the
+ * result with the active phase filter.
+ */
+function searchSpecs(projectPath, query) {
+  const q = (query || '').trim().toLowerCase();
+  if (!q) return null;
+  const root = getSpecsRoot(projectPath);
+  if (!fs.existsSync(root)) return [];
+  let entries;
+  try {
+    entries = fs.readdirSync(root, { withFileTypes: true });
+  } catch (err) {
+    console.error('specManager: searchSpecs readdir failed', err);
+    return [];
+  }
+  const matches = [];
+  for (const ent of entries) {
+    if (!ent.isDirectory()) continue;
+    const body = readFileSafe(path.join(getSpecDir(projectPath, ent.name), SPEC_FILE));
+    if (body && body.toLowerCase().includes(q)) matches.push(ent.name);
+  }
+  return matches;
+}
+
 function createSpec(projectPath, opts) {
   const { title, ai_tool, description } = opts || {};
   if (!title || typeof title !== 'string') return { error: 'title required' };
@@ -742,6 +770,9 @@ function setupIPC(ipcMain) {
   ipcMain.handle(IPC.LIST_SPECS, (event, projectPath) =>
     listSpecs(projectPath)
   );
+  ipcMain.handle(IPC.SEARCH_SPECS, (event, { projectPath, query }) =>
+    searchSpecs(projectPath, query)
+  );
   ipcMain.handle(IPC.GET_SPEC, (event, { projectPath, slug }) =>
     getSpec(projectPath, slug)
   );
@@ -775,6 +806,7 @@ module.exports = {
   generateSlug,
   validateSpecStatus,
   listSpecs,
+  searchSpecs,
   getSpec,
   createSpec,
   updateSpecStatus,

--- a/src/renderer/specsDashboard.js
+++ b/src/renderer/specsDashboard.js
@@ -37,11 +37,16 @@ let selectedSlug = null;
 let selectedSpec = null;   // full spec body (from GET_SPEC)
 let selectedTab = 'spec';
 let activeFilter = 'all';
+let searchQuery = '';        // current search text (trimmed lower-cased when matched)
+let searchMatches = null;    // Set of slugs matching the query, or null when no search is active
+let searchDebounce = null;
 
 let dashboardEl = null;
 let projectLabelEl = null;
 let gridEl = null;
 let filtersEl = null;
+let searchInputEl = null;
+let searchWrapEl = null;
 let detailEl = null;
 let detailEmptyEl = null;
 let detailContentEl = null;
@@ -53,6 +58,8 @@ function init() {
   projectLabelEl = document.getElementById('specs-dashboard-project');
   gridEl = document.getElementById('specs-dashboard-grid');
   filtersEl = document.getElementById('specs-dashboard-filters');
+  searchInputEl = document.getElementById('specs-dashboard-search-input');
+  searchWrapEl = document.querySelector('.specs-dashboard-search');
   detailEl = document.getElementById('specs-dashboard-detail');
   detailEmptyEl = detailEl.querySelector('.specs-dashboard-detail-empty');
   detailContentEl = detailEl.querySelector('.specs-dashboard-detail-content');
@@ -66,6 +73,7 @@ function init() {
   detailEl.querySelector('.specs-dashboard-detail-close')?.addEventListener('click', clearSelection);
 
   renderFilters();
+  setupSearch();
   setupIPCListeners();
 
   // Esc closes detail first, then dashboard
@@ -73,6 +81,7 @@ function init() {
     if (!isVisible) return;
     if (e.key === 'Escape') {
       if (selectedSlug) clearSelection();
+      else if (searchQuery) clearSearch();
       else hide();
     }
   });
@@ -82,7 +91,10 @@ function setupIPCListeners() {
   ipcRenderer.on(IPC.SPEC_DATA, (event, { specs: incoming }) => {
     specs = incoming || [];
     if (isVisible) {
-      renderGrid();
+      // spec.md content may have changed on disk — refresh matches if a
+      // search is active (runSearch re-renders the grid itself).
+      if (searchQuery) runSearch(searchQuery);
+      else renderGrid();
       if (selectedSlug) reloadDetail();
     }
   });
@@ -130,6 +142,7 @@ async function show() {
   // overlaps z-indexes and confuses the layout. Force the side panel closed.
   try { require('./specPanel').hide?.(); } catch {}
 
+  clearSearch();  // start from a clean search state on every open
   dashboardEl.classList.add('visible');
   isVisible = true;
   if (projectLabelEl) projectLabelEl.textContent = displayProjectName(projectPath);
@@ -175,14 +188,65 @@ function renderFilters() {
 }
 
 function applyFilter(specsList) {
-  if (activeFilter === 'all') return specsList;
-  if (activeFilter === 'active') return specsList.filter(s => s.phase !== 'done');
-  if (activeFilter === 'done') return specsList.filter(s => s.phase === 'done');
-  if (activeFilter.startsWith('phase:')) {
+  let out = specsList;
+  if (activeFilter === 'active') out = out.filter(s => s.phase !== 'done');
+  else if (activeFilter === 'done') out = out.filter(s => s.phase === 'done');
+  else if (activeFilter.startsWith('phase:')) {
     const target = activeFilter.slice('phase:'.length);
-    return specsList.filter(s => s.phase === target);
+    out = out.filter(s => s.phase === target);
   }
-  return specsList;
+  // Keyword search over spec.md — searchMatches (a slug Set) is computed by
+  // the main process; null means no active search, so everything passes.
+  if (searchMatches) out = out.filter(s => searchMatches.has(s.slug));
+  return out;
+}
+
+// ─── Search ──────────────────────────────────────────────
+
+function setupSearch() {
+  if (!searchInputEl) return;
+  searchInputEl.addEventListener('input', () => {
+    const value = searchInputEl.value;
+    if (searchWrapEl) searchWrapEl.classList.toggle('has-query', value.trim().length > 0);
+    clearTimeout(searchDebounce);
+    searchDebounce = setTimeout(() => runSearch(value), 180);
+  });
+  document.getElementById('specs-dashboard-search-clear')?.addEventListener('click', () => {
+    clearSearch();
+    searchInputEl.focus();
+  });
+}
+
+async function runSearch(rawQuery) {
+  const query = (rawQuery || '').trim();
+  searchQuery = query;
+  if (!query) {
+    searchMatches = null;
+    if (isVisible) renderGrid();
+    return;
+  }
+  const projectPath = state.getProjectPath();
+  if (!projectPath) return;
+  let matches = [];
+  try {
+    matches = await ipcRenderer.invoke(IPC.SEARCH_SPECS, { projectPath, query }) || [];
+  } catch (err) {
+    matches = [];
+  }
+  // A newer keystroke may have superseded this query while awaiting — ignore
+  // stale results so the grid always reflects the latest input.
+  if (searchQuery !== query) return;
+  searchMatches = new Set(matches);
+  if (isVisible) renderGrid();
+}
+
+function clearSearch() {
+  searchQuery = '';
+  searchMatches = null;
+  clearTimeout(searchDebounce);
+  if (searchInputEl) searchInputEl.value = '';
+  if (searchWrapEl) searchWrapEl.classList.remove('has-query');
+  if (isVisible) renderGrid();
 }
 
 // ─── Grid ────────────────────────────────────────────────
@@ -203,6 +267,8 @@ function renderGrid() {
       gridEl.querySelector('#specs-dashboard-empty-new')?.addEventListener('click', () => {
         require('./specPanel').showNewSpecPrompt?.();
       });
+    } else if (searchMatches) {
+      gridEl.innerHTML = `<div class="specs-dashboard-empty"><p>No specs match “${escapeHtml(searchQuery)}”.</p></div>`;
     } else {
       gridEl.innerHTML = `<div class="specs-dashboard-empty"><p>No specs match the active filter.</p></div>`;
     }

--- a/src/renderer/styles/components/panels.css
+++ b/src/renderer/styles/components/panels.css
@@ -5663,13 +5663,88 @@
   background: var(--bg-hover);
 }
 
+.specs-dashboard-toolbar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-lg);
+  padding: var(--space-md) var(--space-xl);
+  border-bottom: 1px solid var(--border-subtle);
+  background: var(--bg-primary);
+}
+
 .specs-dashboard-filters {
   display: flex;
   gap: var(--space-xs);
   flex-wrap: wrap;
-  padding: var(--space-md) var(--space-xl);
-  border-bottom: 1px solid var(--border-subtle);
-  background: var(--bg-primary);
+}
+
+.specs-dashboard-search {
+  position: relative;
+  flex: 0 0 240px;
+}
+
+.specs-dashboard-search-icon {
+  position: absolute;
+  left: 10px;
+  top: 50%;
+  transform: translateY(-50%);
+  color: var(--text-tertiary);
+  pointer-events: none;
+  transition: color var(--transition-fast);
+}
+
+.specs-dashboard-search-input {
+  width: 100%;
+  height: 30px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border-subtle);
+  border-radius: var(--radius-md);
+  padding: 0 28px 0 32px;
+  color: var(--text-primary);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  transition: all var(--transition-fast);
+}
+
+.specs-dashboard-search-input:focus {
+  outline: none;
+  border-color: var(--accent-primary);
+  background: var(--bg-elevated);
+  box-shadow: 0 0 0 1px var(--accent-subtle);
+}
+
+.specs-dashboard-search:focus-within .specs-dashboard-search-icon {
+  color: var(--accent-primary);
+}
+
+.specs-dashboard-search-clear {
+  position: absolute;
+  right: 6px;
+  top: 50%;
+  transform: translateY(-50%);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 18px;
+  height: 18px;
+  padding: 0;
+  border: none;
+  border-radius: var(--radius-sm);
+  background: transparent;
+  color: var(--text-tertiary);
+  font-size: 11px;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.specs-dashboard-search-clear:hover {
+  color: var(--text-primary);
+  background: var(--bg-tertiary);
+}
+
+.specs-dashboard-search.has-query .specs-dashboard-search-clear {
+  display: flex;
 }
 
 .specs-dashboard-filter-btn {

--- a/src/shared/ipcChannels.js
+++ b/src/shared/ipcChannels.js
@@ -147,6 +147,7 @@ const IPC = {
 
   // Spec-Driven Development (Slice 1) — .frame/specs/<slug>/ lifecycle
   LIST_SPECS: 'list-specs',
+  SEARCH_SPECS: 'search-specs',
   GET_SPEC: 'get-spec',
   CREATE_SPEC: 'create-spec',
   UPDATE_SPEC_STATUS: 'update-spec-status',


### PR DESCRIPTION
Adds a search box to the specs dashboard toolbar that filters the card grid by matching a keyword against each spec's spec.md body. Search runs in the main process (SEARCH_SPECS IPC, case-insensitive substring) and composes with the existing phase filters in the renderer.