### PR TITLE
fix(freshness): content-aware STRUCTURE drift check — no false positive on merges

### DIFF
--- a/scripts/check-freshness.js
+++ b/scripts/check-freshness.js
@@ -12,7 +12,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execSync, spawnSync } = require('child_process');
 
 // FRAME_PROJECT_ROOT lets the same script run from .frame/bin/ inside a user
 // project. Frame's own callers don't set it — behavior is unchanged.
@@ -62,11 +62,45 @@ function checkPhantomModules(structure) {
 }
 
 /**
- * 2. STRUCTURE drift — lastUpdated older than the last commit touching src
+ * Ask update-structure.js --check whether a regen would actually change
+ * STRUCTURE.json. Returns true (out of date), false (in sync), or null
+ * (cannot verify — checker missing or errored).
+ */
+function confirmContentDrift() {
+  const checker = path.join(__dirname, 'update-structure.js');
+  if (!fs.existsSync(checker)) return null;
+  try {
+    const r = spawnSync('node', [checker, '--check'], {
+      cwd: ROOT_DIR,
+      env: { ...process.env, FRAME_PROJECT_ROOT: ROOT_DIR },
+      stdio: 'ignore',
+      timeout: 30000
+    });
+    if (r.status === 0) return false;
+    if (r.status === 1) return true;
+  } catch (e) {
+    // fall through to null
+  }
+  return null;
+}
+
+/**
+ * 2. STRUCTURE drift — the date heuristic (lastUpdated older than the last
+ * commit touching src) is only a cheap pre-filter: a merge or revert dated
+ * after lastUpdated can touch src without changing any module content, and
+ * an idempotent regen wouldn't clear such a warning. When the dates look
+ * stale, the actual content decides.
  */
 function checkStructureDrift(structure) {
   const lastSrcCommit = git('git log -1 --format=%cs -- src');
-  if (lastSrcCommit && structure.lastUpdated && structure.lastUpdated < lastSrcCommit) {
+  if (!(lastSrcCommit && structure.lastUpdated && structure.lastUpdated < lastSrcCommit)) return;
+
+  const drift = confirmContentDrift();
+  if (drift === false) return; // dates disagree but content is in sync — not stale
+
+  if (drift === true) {
+    warn('structure-drift', `STRUCTURE.json content is out of date vs src (lastUpdated ${structure.lastUpdated}) — run: npm run structure`);
+  } else {
     warn('structure-drift', `STRUCTURE.json (${structure.lastUpdated}) predates the last src commit (${lastSrcCommit}) — run: npm run structure`);
   }
 }

--- a/scripts/find-module.js
+++ b/scripts/find-module.js
@@ -14,7 +14,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const { execSync } = require('child_process');
+const { execSync, spawnSync } = require('child_process');
 
 // FRAME_PROJECT_ROOT lets the same script run from .frame/bin/ inside a user
 // project. Frame's own callers don't set it — behavior is unchanged.
@@ -47,7 +47,11 @@ function loadIntentMap() {
 }
 
 /**
- * One-line warning when STRUCTURE.json predates the last commit touching src
+ * One-line warning when STRUCTURE.json is stale. The date comparison is a
+ * cheap pre-filter; when it fires, update-structure.js --check confirms
+ * against actual content — merges/reverts dated after lastUpdated that
+ * changed no module content must not produce a banner (an idempotent regen
+ * couldn't clear it).
  */
 function stalenessBanner(structure) {
   try {
@@ -56,9 +60,24 @@ function stalenessBanner(structure) {
       encoding: 'utf-8',
       stdio: ['pipe', 'pipe', 'ignore']
     }).trim();
-    if (lastSrcCommit && structure.lastUpdated && structure.lastUpdated < lastSrcCommit) {
-      return `⚠ STRUCTURE.json (${structure.lastUpdated}) is older than the last src commit (${lastSrcCommit}) — run: npm run structure`;
+    if (!(lastSrcCommit && structure.lastUpdated && structure.lastUpdated < lastSrcCommit)) {
+      return null;
     }
+
+    const checker = path.join(__dirname, 'update-structure.js');
+    if (fs.existsSync(checker)) {
+      const r = spawnSync('node', [checker, '--check'], {
+        cwd: ROOT_DIR,
+        env: { ...process.env, FRAME_PROJECT_ROOT: ROOT_DIR },
+        stdio: 'ignore',
+        timeout: 30000
+      });
+      if (r.status === 0) return null; // dates disagree, content in sync
+      if (r.status === 1) {
+        return '⚠ STRUCTURE.json content is out of date vs src — run: npm run structure';
+      }
+    }
+    return `⚠ STRUCTURE.json (${structure.lastUpdated}) is older than the last src commit (${lastSrcCommit}) — run: npm run structure`;
   } catch (e) {
     // Not a git repo or git unavailable — no banner
   }

--- a/scripts/update-structure.js
+++ b/scripts/update-structure.js
@@ -8,6 +8,7 @@
  * Usage:
  *   node scripts/update-structure.js              # Full update
  *   node scripts/update-structure.js --changed    # Only git staged changes
+ *   node scripts/update-structure.js --check      # Would a regen change anything? (writes nothing; exit 0/1/2)
  *   node scripts/update-structure.js file1.js file2.js  # Specific files
  */
 
@@ -351,13 +352,13 @@ function loadStructure() {
  * Runs in every mode so deletions are reconciled even when they never hit
  * the staged diff (the phantom-module class of bug).
  */
-function reconcileDeletedModules(structure) {
+function reconcileDeletedModules(structure, quiet) {
   let removed = 0;
   for (const [key, mod] of Object.entries(structure.modules)) {
     const file = mod.file || path.join('src', `${key}.js`);
     if (!fs.existsSync(path.join(ROOT_DIR, file))) {
       delete structure.modules[key];
-      console.log(`  - Removed (missing on disk): ${key}`);
+      if (!quiet) console.log(`  - Removed (missing on disk): ${key}`);
       removed++;
     }
   }
@@ -376,19 +377,24 @@ function sortKeys(obj) {
 }
 
 /**
+ * Normalize a structure for output: sorted modules, and architectureNotes —
+ * hand-written insight — preserved verbatim when present, omitted entirely
+ * when empty (never emit an empty object that looks populated).
+ */
+function normalizeStructure(structure) {
+  structure.modules = sortKeys(structure.modules);
+  if (structure.architectureNotes && Object.keys(structure.architectureNotes).length === 0) {
+    delete structure.architectureNotes;
+  }
+}
+
+/**
  * Save STRUCTURE.json.
  * Modules are sorted for stable output, and lastUpdated is only bumped when
  * content actually changed — a regen on an unchanged tree is byte-identical.
  */
 function saveStructure(structure) {
-  structure.modules = sortKeys(structure.modules);
-
-  // architectureNotes is hand-written insight: preserved verbatim across
-  // regens when present, omitted entirely when empty — never emit an empty
-  // object that looks populated.
-  if (structure.architectureNotes && Object.keys(structure.architectureNotes).length === 0) {
-    delete structure.architectureNotes;
-  }
+  normalizeStructure(structure);
 
   let previous = null;
   try {
@@ -413,7 +419,7 @@ function saveStructure(structure) {
  * Preserves existing rich data (direction, payload, description) for known channels.
  * Adds skeleton entries for new channels discovered in ipcChannels.js.
  */
-function syncIPCChannels(structure) {
+function syncIPCChannels(structure, quiet) {
   const ipcFile = path.join(SRC_DIR, 'shared', 'ipcChannels.js');
   if (!fs.existsSync(ipcFile)) return;
 
@@ -485,7 +491,64 @@ function syncIPCChannels(structure) {
   structure.ipcChannels = updated;
 
   const total = Object.values(updated).reduce((sum, cat) => sum + Object.keys(cat).length, 0);
-  console.log(`  ✓ IPC channels: ${total} total (${added} new) — parsed from ipcChannels.js`);
+  if (!quiet) console.log(`  ✓ IPC channels: ${total} total (${added} new) — parsed from ipcChannels.js`);
+}
+
+/**
+ * Parse the given files into structure.modules (preserving manual
+ * descriptions when the auto-extracted one is empty)
+ */
+function processFiles(structure, files, quiet) {
+  for (const file of files) {
+    try {
+      const moduleKey = getModuleKey(file);
+      const moduleInfo = parseJSFile(file);
+
+      const existing = structure.modules[moduleKey] || {};
+      structure.modules[moduleKey] = {
+        ...moduleInfo,
+        description: moduleInfo.description || existing.description || ''
+      };
+
+      if (!quiet) console.log(`  ✓ ${moduleKey}`);
+    } catch (e) {
+      if (!quiet) console.error(`  ✗ ${file}: ${e.message}`);
+    }
+  }
+}
+
+/**
+ * --check: report whether a full regen would change STRUCTURE.json
+ * (ignoring lastUpdated) without writing anything. Exit 0 = in sync,
+ * 1 = out of date, 2 = cannot check. Lets check-freshness.js and
+ * find-module.js confirm date-based drift suspicion against actual
+ * content, so merges/reverts that changed no module content don't
+ * produce false staleness warnings.
+ */
+function runCheck() {
+  if (!fs.existsSync(STRUCTURE_FILE)) {
+    console.log('STRUCTURE.json missing — run: npm run structure');
+    process.exit(2);
+  }
+
+  const current = loadStructure();
+  const rebuilt = JSON.parse(JSON.stringify(current));
+
+  reconcileDeletedModules(rebuilt, true);
+  if (fs.existsSync(SRC_DIR)) {
+    processFiles(rebuilt, getAllJSFiles(), true);
+  }
+  syncIPCChannels(rebuilt, true);
+  generateIntentIndex(rebuilt);
+  normalizeStructure(rebuilt);
+
+  const withoutTimestamp = (s) => JSON.stringify({ ...s, lastUpdated: undefined });
+  if (withoutTimestamp(current) === withoutTimestamp(rebuilt)) {
+    console.log('STRUCTURE.json is in sync with src/.');
+    process.exit(0);
+  }
+  console.log('STRUCTURE.json is out of date — run: npm run structure');
+  process.exit(1);
 }
 
 /**
@@ -493,6 +556,12 @@ function syncIPCChannels(structure) {
  */
 function main() {
   const args = process.argv.slice(2);
+
+  if (args.includes('--check')) {
+    runCheck();
+    return;
+  }
+
   const structure = loadStructure();
 
   let filesToProcess = [];
@@ -523,24 +592,7 @@ function main() {
 
   console.log(`Mode: ${mode}, Processing ${filesToProcess.length} file(s)...`);
 
-  for (const file of filesToProcess) {
-    try {
-      const moduleKey = getModuleKey(file);
-      const moduleInfo = parseJSFile(file);
-
-      // Preserve manually added fields (like detailed descriptions)
-      const existing = structure.modules[moduleKey] || {};
-      structure.modules[moduleKey] = {
-        ...moduleInfo,
-        // Keep manual description if auto-extracted is empty
-        description: moduleInfo.description || existing.description || ''
-      };
-
-      console.log(`  ✓ ${moduleKey}`);
-    } catch (e) {
-      console.error(`  ✗ ${file}: ${e.message}`);
-    }
-  }
+  processFiles(structure, filesToProcess, false);
 
   // Sync IPC channels from ipcChannels.js
   syncIPCChannels(structure);


### PR DESCRIPTION
Found live right after merging #103: the drift warning fired because the merge commit was dated after STRUCTURE.json's `lastUpdated`, even though module content was byte-identical — and since the regen is idempotent (keeps `lastUpdated` when nothing changed), `npm run structure` could never clear the warning.

## Fix

- `update-structure.js --check` (new): rebuilds the structure in memory and reports whether a regen would change STRUCTURE.json, ignoring `lastUpdated`, **without writing anything**. Exit 0 = in sync, 1 = out of date, 2 = cannot check.
- `check-freshness.js` and `find-module.js` keep the date comparison as a cheap pre-filter; when it fires, `--check` confirms against actual content. Content in sync → no warning. Real drift → a content-based message, cleared by `npm run structure`.

## Properties

- Zero cost on the common fresh path (the expensive check runs only when dates disagree).
- Byte-idempotent regen guarantee from #103 untouched.
- Works in user projects too (both scripts ship side-by-side in `.frame/bin/`).

## Verified

- Live repro (post-#103 merge state): warning and banner gone, `--check` exit 0.
- Real src change: `--check` exit 1, banner + freshness warning appear, regen clears them.
- Double regen still byte-identical; 31/31 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)