### PR TITLE
feat(spec-driven): default the workflow on, make it toggleable in Settings

### DIFF
--- a/PROJECT_NOTES.md
+++ b/PROJECT_NOTES.md
@@ -1385,3 +1385,23 @@ refreshed sample-project fixtures to the current managed block, regression
 test added. No SPEC_SECTION_VERSION bump — bodies unchanged. Note:
 `.claude/skills/spec-plan` seen in the affected project is not Frame-generated;
 delete it there by hand.
+
+### [2026-07-28] Spec-Driven Development is on by default, toggleable in Settings
+Reported symptom: a user initializes a project, gives a sizable task, the agent
+writes a spec — and the user never sees it. Cause: `features.specDriven` was
+`false` in the config template, but the spec command templates are staged at
+init regardless, so a CLI session could run the whole flow while the Specs
+panel kept showing the opt-in suggestion modal. The flag was hiding work that
+had already happened. Decisions: (1) new projects start with
+`features.specDriven: true` and AGENTS.md ships with the managed spec section;
+`.frame/specs/.gitkeep` is created at init. (2) Opting out moved from "edit the
+files by hand" to Settings → Workflow — a per-project toggle (the flag lives in
+`.frame/config.json`, not user-settings.json), wired through `SET_SPEC_DRIVEN`
+to `setSpecDrivenEnabled` → `enableSpecDriven` / new `disableSpecDriven`.
+Disabling flips the flag and strips the *marker-wrapped* spec section from
+AGENTS.md only (`stripManagedSpecSection`, same "prove it's ours" contract as
+docsManagedBlock's upgrade path) — a hand-written section and `.frame/specs/`
+are never touched. Projects initialized before this keep their existing flag;
+nothing force-enables on open, since that would rewrite an AGENTS.md the user
+never asked us to change. Rejected: auto-enabling when specs already exist on
+disk — it would silently undo an explicit "off" on every panel open.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ That last file is the move that makes the rest worth doing. Plans tell you inten
 Two principles shaped this:
 
 - **Files over databases.** Markdown is canonical. Any AI tool can read it without Frame, any teammate can grep it, git versions it, PRs review it.
-- **Optional, never forced.** Spec-driven dev isn't every project's shape. Frame asks once when you open the Specs panel; you opt in or skip. Existing `tasks.json` workflows are untouched.
+- **On, but never forced.** New projects start with spec-driven dev enabled, so the specs your AI writes show up in the Specs panel from the first session. It isn't every project's shape — one switch in Settings → Workflow turns it off (your specs stay on disk). Existing `tasks.json` workflows are untouched either way.
 
 ### Agent Orchestration
 

--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -737,7 +737,6 @@
       "depends": [
         "fs",
         "path",
-        "electron",
         "shared/ipcChannels",
         "shared/frameConstants",
         "shared/frameTemplates",
@@ -745,36 +744,37 @@
         "structureBootstrap",
         "commandStaging",
         "shared/docsManagedBlock",
-        "telemetry",
         "perfMonitor",
         "activityLog",
         "../scripts/detect-project",
-        "aiToolManager"
+        "electron",
+        "aiToolManager",
+        "telemetry"
       ],
       "functions": {
         "init": {
-          "line": 27,
+          "line": 25,
           "params": [
             "window"
           ],
           "purpose": "Initialize frame project module"
         },
         "isFrameProject": {
-          "line": 34,
+          "line": 32,
           "params": [
             "projectPath"
           ],
           "purpose": "Check if a project is a Frame project"
         },
         "getFrameConfig": {
-          "line": 42,
+          "line": 40,
           "params": [
             "projectPath"
           ],
           "purpose": "Get Frame config from project"
         },
         "createFileIfNotExists": {
-          "line": 55,
+          "line": 53,
           "params": [
             "filePath",
             "content"
@@ -782,7 +782,7 @@
           "purpose": "Create file if it doesn't exist"
         },
         "createSymlinkSafe": {
-          "line": 72,
+          "line": 70,
           "params": [
             "target",
             "linkPath"
@@ -790,102 +790,102 @@
           "purpose": "Create a symlink safely with Windows fallback"
         },
         "checkExistingFrameFiles": {
-          "line": 113,
+          "line": 111,
           "params": [
             "projectPath"
           ],
           "purpose": "Check which Frame files already exist in the project"
         },
         "showInitializeConfirmation": {
-          "line": 137,
+          "line": 135,
           "params": [
             "projectPath"
           ],
           "purpose": "Show confirmation dialog before initializing Frame project"
         },
         "initializeFrameProject": {
-          "line": 186,
+          "line": 187,
           "params": [
             "projectPath",
             "projectName"
           ]
         },
         "doInitializeFrameProject": {
-          "line": 194,
+          "line": 195,
           "params": [
             "projectPath",
             "projectName"
           ]
         },
         "runProjectInit": {
-          "line": 206,
+          "line": 207,
           "params": [
             "projectPath",
             "projectName"
           ]
         },
         "installSpecHintHook": {
-          "line": 432,
+          "line": 433,
           "params": [
             "projectPath"
           ],
           "purpose": "Register the spec-hint hooks in the project's .claude/settings.json."
         },
         "isSpecDrivenEnabled": {
-          "line": 489,
+          "line": 490,
           "params": [
             "projectPath"
           ]
         },
         "enableSpecDriven": {
-          "line": 494,
+          "line": 495,
           "params": [
             "projectPath"
           ]
         },
         "disableSpecDriven": {
-          "line": 521,
+          "line": 522,
           "params": [
             "projectPath"
           ],
           "purpose": "Turn the workflow off: flip the flag and take the Frame-managed spec"
         },
         "setSpecDrivenEnabled": {
-          "line": 549,
+          "line": 550,
           "params": [
             "projectPath",
             "enabled"
           ]
         },
         "writeFrameConfig": {
-          "line": 553,
+          "line": 554,
           "params": [
             "projectPath",
             "config"
           ]
         },
         "stripManagedSpecSection": {
-          "line": 567,
+          "line": 568,
           "params": [
             "text"
           ],
           "purpose": "Remove the marker-wrapped spec section from a doc, together with the `---`"
         },
         "ensureSpecDrivenArtifacts": {
-          "line": 577,
+          "line": 578,
           "params": [
             "projectPath",
             "config"
           ]
         },
         "upgradeSpecDocs": {
-          "line": 652,
+          "line": 653,
           "params": [
             "projectPath"
           ]
         },
         "setupIPC": {
-          "line": 693,
+          "line": 694,
           "params": [
             "ipcMain"
           ],

--- a/STRUCTURE.json
+++ b/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Auto-generated module structure",
-  "lastUpdated": "2026-07-27",
+  "lastUpdated": "2026-07-28",
   "architecture": {},
   "modules": {
     "main/activityLog": {
@@ -729,6 +729,8 @@
         "initializeFrameProject",
         "isSpecDrivenEnabled",
         "enableSpecDriven",
+        "disableSpecDriven",
+        "setSpecDrivenEnabled",
         "upgradeSpecDocs",
         "setupIPC"
       ],
@@ -823,39 +825,67 @@
           ]
         },
         "installSpecHintHook": {
-          "line": 423,
+          "line": 432,
           "params": [
             "projectPath"
           ],
           "purpose": "Register the spec-hint hooks in the project's .claude/settings.json."
         },
         "isSpecDrivenEnabled": {
-          "line": 476,
+          "line": 489,
           "params": [
             "projectPath"
           ]
         },
         "enableSpecDriven": {
-          "line": 481,
+          "line": 494,
           "params": [
             "projectPath"
           ]
         },
+        "disableSpecDriven": {
+          "line": 521,
+          "params": [
+            "projectPath"
+          ],
+          "purpose": "Turn the workflow off: flip the flag and take the Frame-managed spec"
+        },
+        "setSpecDrivenEnabled": {
+          "line": 549,
+          "params": [
+            "projectPath",
+            "enabled"
+          ]
+        },
+        "writeFrameConfig": {
+          "line": 553,
+          "params": [
+            "projectPath",
+            "config"
+          ]
+        },
+        "stripManagedSpecSection": {
+          "line": 567,
+          "params": [
+            "text"
+          ],
+          "purpose": "Remove the marker-wrapped spec section from a doc, together with the `---`"
+        },
         "ensureSpecDrivenArtifacts": {
-          "line": 506,
+          "line": 577,
           "params": [
             "projectPath",
             "config"
           ]
         },
         "upgradeSpecDocs": {
-          "line": 581,
+          "line": 652,
           "params": [
             "projectPath"
           ]
         },
         "setupIPC": {
-          "line": 622,
+          "line": 693,
           "params": [
             "ipcMain"
           ],
@@ -868,7 +898,8 @@
           "INITIALIZE_FRAME_PROJECT",
           "GET_FRAME_CONFIG",
           "IS_SPEC_DRIVEN_ENABLED",
-          "ENABLE_SPEC_DRIVEN"
+          "ENABLE_SPEC_DRIVEN",
+          "SET_SPEC_DRIVEN"
         ],
         "emits": [
           "IS_FRAME_PROJECT_RESULT",
@@ -4853,40 +4884,41 @@
         "settingsModal",
         "telemetryNotice",
         "healthNotice",
+        "specDrivenHint",
         "sampleBanner",
         "../package.json",
         "agentDispatch"
       ],
       "functions": {
         "init": {
-          "line": 49,
+          "line": 50,
           "purpose": "Initialize all modules"
         },
         "setupButtonHandlers": {
-          "line": 245,
+          "line": 247,
           "purpose": "Setup button click handlers"
         },
         "setupProjectSwitcher": {
-          "line": 303,
+          "line": 312,
           "purpose": "Wire the current-project dropdown: build the project list on open, switch on"
         },
         "setupUpdateDot": {
-          "line": 392,
+          "line": 401,
           "purpose": "Show update indicators when a new version is available:"
         },
         "revealSidebarTab": {
-          "line": 423,
+          "line": 432,
           "params": [
             "tabName"
           ],
           "purpose": "Show the sidebar (if hidden) and switch to the given tab. Used by focus"
         },
         "registerCommands": {
-          "line": 449,
+          "line": 458,
           "purpose": "Register every app command with the central registry. Commands are the"
         },
         "startAiSession": {
-          "line": 721,
+          "line": 730,
           "purpose": "Start the selected AI tool (Claude Code / Codex CLI / etc.) in a fresh"
         }
       },
@@ -6328,23 +6360,25 @@
       "depends": [
         "electron",
         "shared/ipcChannels",
+        "state",
+        "specDrivenHint",
         "../package.json"
       ],
       "functions": {
         "init": {
-          "line": 32
+          "line": 36
         },
         "initAboutSection": {
-          "line": 96
+          "line": 140
         },
         "runCheck": {
-          "line": 181,
+          "line": 225,
           "params": [
             "userInitiated"
           ]
         },
         "renderUpdateState": {
-          "line": 220,
+          "line": 264,
           "params": [
             "{ checked",
             "found",
@@ -6356,34 +6390,44 @@
           ]
         },
         "showUpdateBanner": {
-          "line": 244,
+          "line": 288,
           "params": [
             "info"
           ]
         },
         "hideUpdateBanner": {
-          "line": 255
+          "line": 299
         },
         "hideSidebarDot": {
-          "line": 259
+          "line": 303
         },
         "formatRelative": {
-          "line": 266,
+          "line": 310,
           "params": [
             "date"
           ]
         },
         "syncToggleFromSettings": {
-          "line": 277
+          "line": 321
+        },
+        "syncSpecDrivenToggle": {
+          "line": 341,
+          "purpose": "Reflect the current project's features.specDriven flag. With no project"
+        },
+        "setSpecDrivenNote": {
+          "line": 361,
+          "params": [
+            "message"
+          ]
         },
         "open": {
-          "line": 290
+          "line": 367
         },
         "close": {
-          "line": 297
+          "line": 374
         },
         "toggle": {
-          "line": 304
+          "line": 381
         }
       },
       "ipc": {
@@ -6467,6 +6511,87 @@
         "isVisible": {
           "line": 196,
           "purpose": "Check if sidebar is hidden"
+        }
+      }
+    },
+    "renderer/specDrivenHint": {
+      "file": "src/renderer/specDrivenHint.js",
+      "description": "Spec-Driven Development hint",
+      "exports": [
+        "init",
+        "refresh",
+        "markDismissed"
+      ],
+      "depends": [
+        "electron",
+        "shared/ipcChannels",
+        "state"
+      ],
+      "functions": {
+        "init": {
+          "line": 31
+        },
+        "evaluate": {
+          "line": 53,
+          "purpose": "Show the hint if this project qualifies. Safe to call repeatedly — a"
+        },
+        "schedule": {
+          "line": 74,
+          "params": [
+            "projectPath"
+          ]
+        },
+        "refresh": {
+          "line": 85,
+          "purpose": "Re-check after the Settings toggle changed the flag."
+        },
+        "render": {
+          "line": 90,
+          "params": [
+            "projectPath"
+          ]
+        },
+        "onOutsideClick": {
+          "line": 126,
+          "params": [
+            "e"
+          ]
+        },
+        "position": {
+          "line": 135,
+          "purpose": "Anchor to the Settings button: same baseline, just outboard of the rail."
+        },
+        "enable": {
+          "line": 157,
+          "params": [
+            "projectPath",
+            "btn"
+          ]
+        },
+        "dismissForever": {
+          "line": 179,
+          "params": [
+            "projectPath"
+          ]
+        },
+        "markDismissed": {
+          "line": 189,
+          "params": [
+            "projectPath"
+          ],
+          "purpose": "Remember that this project should not be hinted at again. Lives in user"
+        },
+        "isDismissed": {
+          "line": 201,
+          "params": [
+            "projectPath"
+          ]
+        },
+        "readDismissed": {
+          "line": 206
+        },
+        "hide": {
+          "line": 211
         }
       }
     },
@@ -6562,47 +6687,47 @@
           "line": 120
         },
         "toggle": {
-          "line": 129,
-          "purpose": "Public toggle. The first time the user invokes this on a project where"
+          "line": 130,
+          "purpose": "Public toggle. New projects have Spec-Driven Development on, so this just"
         },
         "startWatchingForProject": {
-          "line": 147,
+          "line": 148,
           "params": [
             "projectPath"
           ]
         },
         "stopWatching": {
-          "line": 156
+          "line": 157
         },
         "renderList": {
-          "line": 163
+          "line": 164
         },
         "renderSpecRow": {
-          "line": 194,
+          "line": 195,
           "params": [
             "spec"
           ]
         },
         "openDetail": {
-          "line": 214,
+          "line": 215,
           "params": [
             "slug"
           ]
         },
         "reloadDetail": {
-          "line": 220
+          "line": 221
         },
         "renderDetail": {
-          "line": 228
+          "line": 229
         },
         "runSpecCommand": {
-          "line": 301,
+          "line": 302,
           "params": [
             "command"
           ]
         },
         "renderTabButton": {
-          "line": 313,
+          "line": 314,
           "params": [
             "tab",
             "label",
@@ -6610,98 +6735,98 @@
           ]
         },
         "hasSpecTasks": {
-          "line": 319
+          "line": 320
         },
         "tasksTabLabel": {
-          "line": 325,
+          "line": 326,
           "params": [
             "hasMarkdown"
           ]
         },
         "renderTabBody": {
-          "line": 334,
+          "line": 335,
           "params": [
             "tab"
           ]
         },
         "renderPlanReportRow": {
-          "line": 359,
+          "line": 360,
           "purpose": "\"View Plan Report\" — shown above the rendered plan only when the spec"
         },
         "attachPlanReportHandler": {
-          "line": 367
+          "line": 368
         },
         "renderImplementReportRow": {
-          "line": 378,
+          "line": 379,
           "purpose": "\"View Implementation Report\" — shown above the task list only when the spec"
         },
         "attachImplementReportHandler": {
-          "line": 386
+          "line": 387
         },
         "renderTasksTabBody": {
-          "line": 393
+          "line": 394
         },
         "renderSpecTaskRow": {
-          "line": 433,
+          "line": 434,
           "params": [
             "task"
           ]
         },
         "attachTaskActionHandlers": {
-          "line": 482
+          "line": 483
         },
         "handleSpecTaskAction": {
-          "line": 495,
+          "line": 496,
           "params": [
             "taskId",
             "action"
           ]
         },
         "switchTab": {
-          "line": 514,
+          "line": 515,
           "params": [
             "tab"
           ]
         },
         "backToList": {
-          "line": 528
+          "line": 529
         },
         "showNewSpecPrompt": {
-          "line": 543
+          "line": 544
         },
         "deriveSlugPreview": {
-          "line": 645,
+          "line": 646,
           "params": [
             "title"
           ],
           "purpose": "Same shape as specManager.generateSlug — duplicated here so the renderer"
         },
         "showSuggestionModal": {
-          "line": 663,
+          "line": 664,
           "params": [
             "projectPath"
           ]
         },
         "showRenameModal": {
-          "line": 730,
+          "line": 731,
           "params": [
             "status"
           ]
         },
         "showInlineError": {
-          "line": 823,
+          "line": 824,
           "params": [
             "message"
           ]
         },
         "renderMarkdown": {
-          "line": 843,
+          "line": 844,
           "params": [
             "md"
           ]
         },
         "relativeTime": {
-          "line": 853,
+          "line": 854,
           "params": [
             "iso"
           ]
@@ -8449,11 +8574,11 @@
           "purpose": ".frame/config.json template"
         },
         "getCodexWrapperTemplate": {
-          "line": 834,
+          "line": 835,
           "purpose": "Codex CLI wrapper script"
         },
         "getGenericWrapperTemplate": {
-          "line": 871,
+          "line": 872,
           "params": [
             "toolCommand",
             "promptFlag = ''"
@@ -8461,27 +8586,27 @@
           "purpose": "Generic AI tool wrapper template"
         },
         "getStructureHookSnippet": {
-          "line": 917
+          "line": 918
         },
         "getStructurePreCommitHookTemplate": {
-          "line": 938,
+          "line": 939,
           "purpose": "Full pre-commit hook file content for the \"no existing hook\" case."
         },
         "getOrchBusHeader": {
-          "line": 961,
+          "line": 962,
           "purpose": "Orchestration command-channel scripts (.frame/bin/)"
         },
         "getOrchRequestScript": {
-          "line": 973,
+          "line": 974,
           "params": [
             "type"
           ]
         },
         "getOrchStatusScript": {
-          "line": 993
+          "line": 994
         },
         "getOrchBinScripts": {
-          "line": 1011,
+          "line": 1012,
           "purpose": "Map of filename → script body for the orchestration bin scripts. The"
         }
       }
@@ -9603,6 +9728,11 @@
     "spec": {
       "SPEC_AGENT_ACTIVITY": {
         "name": "spec-agent-activity",
+        "direction": "",
+        "description": ""
+      },
+      "SET_SPEC_DRIVEN": {
+        "name": "set-spec-driven",
         "direction": "",
         "description": ""
       }

--- a/index.html
+++ b/index.html
@@ -108,6 +108,14 @@
             <path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/><path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/>
           </svg>
         </button>
+        <!-- Settings sits at the foot of the rail, below the view tabs: it
+             opens the same modal as the app menu, it doesn't switch views —
+             hence no .sidebar-tab-btn (that class drives view switching). -->
+        <button id="sidebar-settings-btn" class="sidebar-rail-btn sidebar-rail-btn-foot" title="Settings (Cmd+,)" aria-label="Settings" tabindex="-1">
+          <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M12.22 2h-.44a2 2 0 0 0-2 2v.18a2 2 0 0 1-1 1.73l-.43.25a2 2 0 0 1-2 0l-.15-.08a2 2 0 0 0-2.73.73l-.22.38a2 2 0 0 0 .73 2.73l.15.1a2 2 0 0 1 1 1.72v.51a2 2 0 0 1-1 1.74l-.15.09a2 2 0 0 0-.73 2.73l.22.38a2 2 0 0 0 2.73.73l.15-.08a2 2 0 0 1 2 0l.43.25a2 2 0 0 1 1 1.73V20a2 2 0 0 0 2 2h.44a2 2 0 0 0 2-2v-.18a2 2 0 0 1 1-1.73l.43-.25a2 2 0 0 1 2 0l.15.08a2 2 0 0 0 2.73-.73l.22-.39a2 2 0 0 0-.73-2.73l-.15-.08a2 2 0 0 1-1-1.74v-.5a2 2 0 0 1 1-1.74l.15-.09a2 2 0 0 0 .73-2.73l-.22-.38a2 2 0 0 0-2.73-.73l-.15.08a2 2 0 0 1-2 0l-.43-.25a2 2 0 0 1-1-1.73V4a2 2 0 0 0-2-2z"/><circle cx="12" cy="12" r="3"/>
+          </svg>
+        </button>
       </nav>
 
       <div class="sidebar-panel">
@@ -1268,6 +1276,26 @@
         <button type="button" class="settings-close" data-settings-close aria-label="Close">&#x2715;</button>
       </div>
       <div class="settings-body">
+        <div class="settings-section">
+          <h4 class="settings-section-title">Workflow</h4>
+          <div class="settings-row">
+            <div class="settings-row-text">
+              <label class="settings-row-label" for="settings-spec-driven-toggle">Spec-Driven Development</label>
+              <p class="settings-row-desc" id="settings-spec-driven-desc">
+                Structure AI work into specs → plans → tasks under
+                <code>.frame/specs/</code>, visible in the Specs panel. Applies to the
+                current project: turning it off removes the spec section from AGENTS.md;
+                existing specs are kept on disk.
+              </p>
+              <p class="settings-row-desc" id="settings-spec-driven-note" style="display:none;"></p>
+            </div>
+            <label class="settings-switch">
+              <input type="checkbox" id="settings-spec-driven-toggle" />
+              <span class="settings-switch-slider"></span>
+            </label>
+          </div>
+        </div>
+
         <div class="settings-section">
           <h4 class="settings-section-title">Privacy &amp; Analytics</h4>
           <div class="settings-row">

--- a/src/main/frameProject.js
+++ b/src/main/frameProject.js
@@ -6,7 +6,6 @@
 const fs = require('fs');
 const fsp = require('fs').promises;
 const path = require('path');
-const { dialog } = require('electron');
 const { IPC } = require('../shared/ipcChannels');
 const { FRAME_DIR, FRAME_CONFIG_FILE, FRAME_FILES, FRAME_BIN_DIR } = require('../shared/frameConstants');
 const templates = require('../shared/frameTemplates');
@@ -14,7 +13,6 @@ const workspace = require('./workspace');
 const structureBootstrap = require('./structureBootstrap');
 const commandStaging = require('./commandStaging');
 const docsManagedBlock = require('../shared/docsManagedBlock');
-const telemetry = require('./telemetry');
 const perfMonitor = require('./perfMonitor');
 const activityLog = require('./activityLog');
 const detector = require('../../scripts/detect-project');
@@ -162,6 +160,9 @@ async function showInitializeConfirmation(projectPath) {
 
   message += '\n\nDo you want to continue?';
 
+  // Lazy require: CI runs the test suite with no node_modules, so the pure
+  // helpers in this module must load without Electron present.
+  const { dialog } = require('electron');
   const result = await dialog.showMessageBox(mainWindow, {
     type: existingFiles.length > 0 ? 'warning' : 'question',
     buttons: ['Cancel', 'Initialize'],
@@ -714,7 +715,10 @@ function setupIPC(ipcMain) {
       }
 
       const config = await initializeFrameProject(projectPath, projectName);
-      telemetry.track('project_initialized');
+      // Lazy require, same reason as aiToolManager below: telemetry pulls
+      // @aptabase/electron → electron, and CI runs the suite with no
+      // node_modules. Keep this module's load graph Electron-free.
+      require('./telemetry').track('project_initialized');
       event.sender.send(IPC.FRAME_PROJECT_INITIALIZED, {
         projectPath,
         config,

--- a/src/main/frameProject.js
+++ b/src/main/frameProject.js
@@ -274,10 +274,12 @@ async function runProjectInit(projectPath, projectName) {
   }
 
   // Build AGENTS.md content: Frame template + any existing instructions appended.
-  // Spec-Driven Development section is OFF by default — user opts in via the
-  // suggestion modal, which calls enableSpecDriven() to re-emit AGENTS.md
-  // with the section.
-  let agentsContent = templates.getAgentsTemplate(name, { specDriven: false, project: detectedProject });
+  // Spec-Driven Development is ON for new projects (config template sets
+  // features.specDriven), so the section ships with the file — the spec
+  // commands are staged at init anyway, and hiding the panel only meant the
+  // user couldn't see specs their AI session had already written. Opting out
+  // happens in Settings → Workflow (disableSpecDriven).
+  let agentsContent = templates.getAgentsTemplate(name, { specDriven: true, project: detectedProject });
   if (existingInstructions.length > 0) {
     const merged = existingInstructions
       .map(({ label, content }) => `## Existing Instructions (from ${label})\n\n${content}`)
@@ -298,6 +300,13 @@ async function runProjectInit(projectPath, projectName) {
     path.join(docsDirPath, 'REFERENCE.md'),
     templates.getReferenceTemplate(name)
   );
+
+  // .frame/specs/ — Spec-Driven Development is on for new projects, so the
+  // folder exists from the start (tracked by .gitkeep) instead of appearing
+  // the first time someone opts in.
+  const specsDirPath = path.join(frameDirPath, 'specs');
+  await fsp.mkdir(specsDirPath, { recursive: true });
+  await createFileIfNotExists(path.join(specsDirPath, '.gitkeep'), '');
 
   // CLAUDE.md - Symlink to AGENTS.md for Claude Code compatibility
   await createSymlinkSafe(
@@ -465,13 +474,17 @@ function installSpecHintHook(projectPath) {
   return { installed: true, added };
 }
 
-// ─── Spec-Driven Development opt-in (Slice 1.5) ──────────────
+// ─── Spec-Driven Development toggle ──────────────────────────
 //
-// Reads/writes the `features.specDriven` flag in .frame/config.json.
-// Enabling also re-emits AGENTS.md with the spec section appended (so AI
-// tools learn the workflow) and creates an empty .frame/specs/ folder
-// tracked by .gitkeep. Designed to be reversible by the user via direct
-// edits — slice 1 doesn't ship a "disable" path.
+// Reads/writes the `features.specDriven` flag in .frame/config.json. New
+// projects start enabled (config template); pre-existing projects that were
+// initialized before that keep whatever they have and can flip it in
+// Settings → Workflow.
+//
+// Enabling re-emits AGENTS.md with the spec section appended (so AI tools
+// learn the workflow) and creates an empty .frame/specs/ folder tracked by
+// .gitkeep. Disabling flips the flag back and removes the Frame-managed
+// spec section from AGENTS.md; specs already on disk are never deleted.
 
 function isSpecDrivenEnabled(projectPath) {
   const config = getFrameConfig(projectPath);
@@ -493,14 +506,72 @@ function enableSpecDriven(projectPath) {
   }
 
   config.features.specDriven = true;
+  writeFrameConfig(projectPath, config);
+
+  ensureSpecDrivenArtifacts(projectPath, config);
+  return { success: true };
+}
+
+/**
+ * Turn the workflow off: flip the flag and take the Frame-managed spec
+ * section back out of AGENTS.md so AI sessions stop being told to write
+ * specs. Never touches .frame/specs/ — the user's specs stay on disk (and
+ * come back into view if they re-enable).
+ */
+function disableSpecDriven(projectPath) {
+  if (!isFrameProject(projectPath)) {
+    return { success: false, error: 'not a Frame project' };
+  }
+
+  const config = getFrameConfig(projectPath) || {};
+  config.features = config.features || {};
+  const wasEnabled = config.features.specDriven === true;
+  config.features.specDriven = false;
+  writeFrameConfig(projectPath, config);
+
+  // AGENTS.md is user-owned: only remove the section when it is provably
+  // Frame's (well-formed managed block). A hand-written or customized
+  // section is left alone — same contract as the upgrade path.
+  const agentsPath = path.join(projectPath, FRAME_FILES.AGENTS);
+  try {
+    const existing = fs.readFileSync(agentsPath, 'utf8');
+    const stripped = stripManagedSpecSection(existing);
+    if (stripped !== null && stripped !== existing) {
+      fs.writeFileSync(agentsPath, stripped, 'utf8');
+    }
+  } catch (err) {
+    // Missing or unreadable AGENTS.md — the flag flip is what matters.
+  }
+
+  return { success: true, alreadyDisabled: !wasEnabled };
+}
+
+function setSpecDrivenEnabled(projectPath, enabled) {
+  return enabled ? enableSpecDriven(projectPath) : disableSpecDriven(projectPath);
+}
+
+function writeFrameConfig(projectPath, config) {
   fs.writeFileSync(
     path.join(projectPath, FRAME_DIR, FRAME_CONFIG_FILE),
     JSON.stringify(config, null, 2),
     'utf8'
   );
+}
 
-  ensureSpecDrivenArtifacts(projectPath, config);
-  return { success: true };
+/**
+ * Remove the marker-wrapped spec section from a doc, together with the `---`
+ * separator that precedes it in every shape Frame emits (so removal doesn't
+ * leave a double rule behind). Returns null when there is no well-formed
+ * managed block — nothing may be removed then.
+ */
+function stripManagedSpecSection(text) {
+  const block = docsManagedBlock.findBlock(text);
+  if (!block) return null;
+  const head = text.slice(0, block.start).replace(/\n*(-{3,}[ \t]*\n)?\s*$/, '');
+  const tail = text.slice(block.end).replace(/^\s*/, '');
+  if (!head) return tail;
+  if (!tail) return head + '\n';
+  return head + '\n\n' + tail;
 }
 
 function ensureSpecDrivenArtifacts(projectPath, config) {
@@ -668,12 +739,15 @@ function setupIPC(ipcMain) {
     event.sender.send(IPC.FRAME_CONFIG_DATA, { projectPath, config });
   });
 
-  // Spec-Driven Development opt-in
+  // Spec-Driven Development feature flag
   ipcMain.handle(IPC.IS_SPEC_DRIVEN_ENABLED, (event, projectPath) =>
     isSpecDrivenEnabled(projectPath)
   );
   ipcMain.handle(IPC.ENABLE_SPEC_DRIVEN, (event, projectPath) =>
     enableSpecDriven(projectPath)
+  );
+  ipcMain.handle(IPC.SET_SPEC_DRIVEN, (event, { projectPath, enabled }) =>
+    setSpecDrivenEnabled(projectPath, enabled === true)
   );
 }
 
@@ -684,6 +758,8 @@ module.exports = {
   initializeFrameProject,
   isSpecDrivenEnabled,
   enableSpecDriven,
+  disableSpecDriven,
+  setSpecDrivenEnabled,
   upgradeSpecDocs,
   setupIPC
 };

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -41,6 +41,7 @@ const appLoader = require('./appLoader');
 const settingsModal = require('./settingsModal');
 const telemetryNotice = require('./telemetryNotice');
 const healthNotice = require('./healthNotice');
+const specDrivenHint = require('./specDrivenHint');
 const sampleBanner = require('./sampleBanner');
 
 /**
@@ -229,6 +230,7 @@ function init() {
   telemetryNotice.init(() => settingsModal.open());
   healthNotice.init();
   sampleBanner.init();
+  specDrivenHint.init();
   setupUpdateDot();
   registerCommands();
   commandRegistry.bindKeyboard();
@@ -280,6 +282,13 @@ function setupButtonHandlers() {
   document.querySelectorAll('.sidebar-tab-btn').forEach(btn => {
     btn.addEventListener('click', () => revealSidebarTab(btn.dataset.sidebarTab));
   });
+
+  // Settings at the foot of the rail — same modal as the app menu entry and
+  // the Cmd+, command, so it toggles rather than re-opening on a second click.
+  const sidebarSettingsBtn = document.getElementById('sidebar-settings-btn');
+  if (sidebarSettingsBtn) {
+    sidebarSettingsBtn.addEventListener('click', () => settingsModal.toggle());
+  }
 
   // Current-project switcher (Files / Changes views): reflects the active
   // project and opens a dropdown to switch project without leaving the view.

--- a/src/renderer/settingsModal.js
+++ b/src/renderer/settingsModal.js
@@ -8,6 +8,8 @@
 
 const { ipcRenderer, shell } = require('electron');
 const { IPC } = require('../shared/ipcChannels');
+const state = require('./state');
+const specDrivenHint = require('./specDrivenHint');
 
 const TELEMETRY_KEY = 'telemetryEnabled';
 const CRASH_DUMPS_KEY = 'crashDumpsEnabled';
@@ -16,6 +18,8 @@ const DISMISSED_VERSION_KEY = 'dismissedUpdateVersion';
 let overlayEl = null;
 let toggleEl = null;
 let crashDumpsToggleEl = null;
+let specDrivenToggleEl = null;
+let specDrivenNoteEl = null;
 let isOpen = false;
 
 // About section elements + state
@@ -33,6 +37,8 @@ function init() {
   overlayEl = document.getElementById('settings-overlay');
   toggleEl = document.getElementById('settings-telemetry-toggle');
   crashDumpsToggleEl = document.getElementById('settings-crash-dumps-toggle');
+  specDrivenToggleEl = document.getElementById('settings-spec-driven-toggle');
+  specDrivenNoteEl = document.getElementById('settings-spec-driven-note');
 
   // About section
   aboutVersionEl = document.getElementById('settings-version');
@@ -65,6 +71,44 @@ function init() {
   if (crashDumpsToggleEl) {
     crashDumpsToggleEl.addEventListener('change', async () => {
       await ipcRenderer.invoke(IPC.SET_USER_SETTING, CRASH_DUMPS_KEY, crashDumpsToggleEl.checked);
+    });
+  }
+
+  // Spec-Driven Development: per-project flag in .frame/config.json, not a
+  // user preference — main writes the config and AGENTS.md section. On
+  // failure we snap the switch back so it never lies about the on-disk state.
+  if (specDrivenToggleEl) {
+    specDrivenToggleEl.addEventListener('change', async () => {
+      const projectPath = state.getProjectPath();
+      const wanted = specDrivenToggleEl.checked;
+      if (!projectPath) {
+        specDrivenToggleEl.checked = !wanted;
+        return;
+      }
+      specDrivenToggleEl.disabled = true;
+      try {
+        const result = await ipcRenderer.invoke(IPC.SET_SPEC_DRIVEN, {
+          projectPath,
+          enabled: wanted
+        });
+        if (!result || !result.success) {
+          specDrivenToggleEl.checked = !wanted;
+          setSpecDrivenNote(
+            'Could not change this setting: ' + ((result && result.error) || 'unknown error')
+          );
+        } else {
+          setSpecDrivenNote(null);
+          // Turning it off here is a deliberate choice — stop offering to
+          // turn it back on for this project.
+          if (!wanted) await specDrivenHint.markDismissed(projectPath);
+          specDrivenHint.refresh();
+        }
+      } catch (err) {
+        specDrivenToggleEl.checked = !wanted;
+        setSpecDrivenNote('Could not change this setting: ' + err.message);
+      } finally {
+        specDrivenToggleEl.disabled = false;
+      }
     });
   }
 
@@ -285,6 +329,39 @@ async function syncToggleFromSettings() {
     // Default ON when unset (local-only; nothing is uploaded)
     crashDumpsToggleEl.checked = dumps !== false;
   }
+
+  await syncSpecDrivenToggle();
+}
+
+/**
+ * Reflect the current project's features.specDriven flag. With no project
+ * open (or a folder that isn't a Frame project yet) there is nothing to
+ * write, so the switch is disabled and says why.
+ */
+async function syncSpecDrivenToggle() {
+  if (!specDrivenToggleEl) return;
+  const projectPath = state.getProjectPath();
+  if (!projectPath) {
+    specDrivenToggleEl.checked = false;
+    specDrivenToggleEl.disabled = true;
+    setSpecDrivenNote('Open a project to change this — the setting lives in its .frame/config.json.');
+    return;
+  }
+  try {
+    const enabled = await ipcRenderer.invoke(IPC.IS_SPEC_DRIVEN_ENABLED, projectPath);
+    specDrivenToggleEl.checked = enabled === true;
+    specDrivenToggleEl.disabled = false;
+    setSpecDrivenNote(null);
+  } catch (err) {
+    specDrivenToggleEl.disabled = true;
+    setSpecDrivenNote('Could not read this project’s Frame config.');
+  }
+}
+
+function setSpecDrivenNote(message) {
+  if (!specDrivenNoteEl) return;
+  specDrivenNoteEl.textContent = message || '';
+  specDrivenNoteEl.style.display = message ? '' : 'none';
 }
 
 function open() {

--- a/src/renderer/specDrivenHint.js
+++ b/src/renderer/specDrivenHint.js
@@ -1,0 +1,222 @@
+/**
+ * Spec-Driven Development hint
+ *
+ * Projects initialized before the feature defaulted to on still carry
+ * `features.specDriven: false`, which means specs their AI session writes
+ * never surface in the Specs panel. This is the pointer to the fix: a small
+ * popover anchored on the sidebar's Settings button — where the switch
+ * lives — offering to turn it on right there.
+ *
+ * Deliberately quiet: only for Frame projects with the flag off, never for
+ * new projects (they start enabled), and "Don't show again" is remembered
+ * per project. Turning the feature off from Settings also silences it — a
+ * choice the user just made is not something to nag about.
+ */
+
+const { ipcRenderer } = require('electron');
+const { IPC } = require('../shared/ipcChannels');
+const state = require('./state');
+
+const DISMISSED_KEY = 'specDrivenHintDismissed';
+const ANCHOR_ID = 'sidebar-settings-btn';
+// Let the app finish opening the project (loader fade, panels settling)
+// before something pops up in the corner.
+const SHOW_DELAY_MS = 900;
+
+let popoverEl = null;
+let shownForPath = null;
+let showTimer = null;
+let initialized = false;
+
+function init() {
+  if (initialized) return;
+  initialized = true;
+
+  // Frame status arrives after the project path (main answers
+  // CHECK_IS_FRAME_PROJECT asynchronously), so both edges re-evaluate.
+  state.onProjectChange(() => {
+    hide();
+    evaluate();
+  });
+  state.onFrameStatusChange(() => evaluate());
+
+  window.addEventListener('resize', position);
+  document.addEventListener('keydown', (e) => {
+    if (popoverEl && e.key === 'Escape') hide();
+  });
+}
+
+/**
+ * Show the hint if this project qualifies. Safe to call repeatedly — a
+ * popover already shown for the same project is left as it is.
+ */
+async function evaluate() {
+  const projectPath = state.getProjectPath();
+  if (!projectPath || !state.getIsFrameProject()) {
+    hide();
+    return;
+  }
+  if ((popoverEl || showTimer) && shownForPath === projectPath) return;
+  if (!document.getElementById(ANCHOR_ID)) return;
+
+  try {
+    if (await isDismissed(projectPath)) return;
+    const enabled = await ipcRenderer.invoke(IPC.IS_SPEC_DRIVEN_ENABLED, projectPath);
+    if (enabled === true) return;
+    // The project may have changed while we were awaiting.
+    if (state.getProjectPath() !== projectPath) return;
+    schedule(projectPath);
+  } catch (err) {
+    console.error('specDrivenHint: could not evaluate', err);
+  }
+}
+
+function schedule(projectPath) {
+  clearTimeout(showTimer);
+  shownForPath = projectPath;
+  showTimer = setTimeout(() => {
+    showTimer = null;
+    if (state.getProjectPath() !== projectPath) return;
+    render(projectPath);
+  }, SHOW_DELAY_MS);
+}
+
+/** Re-check after the Settings toggle changed the flag. */
+function refresh() {
+  hide();
+  evaluate();
+}
+
+function render(projectPath) {
+  hide();
+  shownForPath = projectPath;
+
+  popoverEl = document.createElement('div');
+  popoverEl.className = 'spec-driven-hint';
+  popoverEl.setAttribute('role', 'dialog');
+  popoverEl.setAttribute('aria-label', 'Spec-Driven Development is off');
+  popoverEl.innerHTML = `
+    <button type="button" class="spec-driven-hint-close" aria-label="Dismiss">&#x2715;</button>
+    <div class="spec-driven-hint-title">Spec-Driven Development is off</div>
+    <p class="spec-driven-hint-text">
+      Specs your AI writes stay hidden from the Specs panel while this is off.
+      New projects have it on — you can switch it here, in Settings &rarr; Workflow.
+    </p>
+    <div class="spec-driven-hint-error" role="alert"></div>
+    <div class="spec-driven-hint-actions">
+      <button type="button" class="spec-driven-hint-never">Don't show again</button>
+      <button type="button" class="spec-driven-hint-enable">Turn it on</button>
+    </div>
+  `;
+  document.body.appendChild(popoverEl);
+  position();
+
+  popoverEl.querySelector('.spec-driven-hint-close').addEventListener('click', hide);
+  popoverEl.querySelector('.spec-driven-hint-never').addEventListener('click', () => {
+    dismissForever(projectPath);
+  });
+  popoverEl.querySelector('.spec-driven-hint-enable').addEventListener('click', (e) => {
+    enable(projectPath, e.currentTarget);
+  });
+
+  // A click anywhere else means "later" — the hint returns on the next open.
+  setTimeout(() => document.addEventListener('mousedown', onOutsideClick), 0);
+}
+
+function onOutsideClick(e) {
+  if (!popoverEl) return;
+  if (popoverEl.contains(e.target)) return;
+  // Clicking the Settings button itself opens the modal, which supersedes
+  // the hint — close it either way.
+  hide();
+}
+
+/** Anchor to the Settings button: same baseline, just outboard of the rail. */
+function position() {
+  if (!popoverEl) return;
+  const anchor = document.getElementById(ANCHOR_ID);
+  if (!anchor) return;
+  const rect = anchor.getBoundingClientRect();
+  if (rect.width === 0 && rect.height === 0) {
+    // Sidebar hidden — nothing to point at.
+    hide();
+    return;
+  }
+  const gap = 8;
+  const width = popoverEl.offsetWidth;
+  const height = popoverEl.offsetHeight;
+  const left = Math.min(rect.right + gap, window.innerWidth - width - gap);
+  const top = Math.min(
+    Math.max(rect.bottom - height, gap),
+    window.innerHeight - height - gap
+  );
+  popoverEl.style.left = `${Math.max(gap, left)}px`;
+  popoverEl.style.top = `${top}px`;
+}
+
+async function enable(projectPath, btn) {
+  const errorEl = popoverEl ? popoverEl.querySelector('.spec-driven-hint-error') : null;
+  if (btn) btn.disabled = true;
+  try {
+    const result = await ipcRenderer.invoke(IPC.SET_SPEC_DRIVEN, {
+      projectPath,
+      enabled: true
+    });
+    if (!result || !result.success) {
+      if (errorEl) {
+        errorEl.textContent = 'Could not turn it on: ' + ((result && result.error) || 'unknown error');
+      }
+      if (btn) btn.disabled = false;
+      return;
+    }
+    hide();
+  } catch (err) {
+    if (errorEl) errorEl.textContent = 'Could not turn it on: ' + err.message;
+    if (btn) btn.disabled = false;
+  }
+}
+
+async function dismissForever(projectPath) {
+  hide();
+  await markDismissed(projectPath);
+}
+
+/**
+ * Remember that this project should not be hinted at again. Lives in user
+ * settings, not the project's .frame/config.json — it is a preference about
+ * Frame's UI, not a fact about the project.
+ */
+async function markDismissed(projectPath) {
+  if (!projectPath) return;
+  try {
+    const list = await readDismissed();
+    if (list.includes(projectPath)) return;
+    list.push(projectPath);
+    await ipcRenderer.invoke(IPC.SET_USER_SETTING, DISMISSED_KEY, list);
+  } catch (err) {
+    console.error('specDrivenHint: could not persist dismissal', err);
+  }
+}
+
+async function isDismissed(projectPath) {
+  const list = await readDismissed();
+  return list.includes(projectPath);
+}
+
+async function readDismissed() {
+  const stored = await ipcRenderer.invoke(IPC.GET_USER_SETTING, DISMISSED_KEY);
+  return Array.isArray(stored) ? stored.slice() : [];
+}
+
+function hide() {
+  clearTimeout(showTimer);
+  showTimer = null;
+  document.removeEventListener('mousedown', onOutsideClick);
+  if (popoverEl) {
+    popoverEl.remove();
+    popoverEl = null;
+  }
+  shownForPath = null;
+}
+
+module.exports = { init, refresh, markDismissed };

--- a/src/renderer/specPanel.js
+++ b/src/renderer/specPanel.js
@@ -123,9 +123,10 @@ function hide() {
   isVisible = false;
 }
 
-// Public toggle. The first time the user invokes this on a project where
-// Spec-Driven Development isn't enabled yet, we show a suggestion modal
-// instead of opening the panel — keeping the workflow opt-in.
+// Public toggle. New projects have Spec-Driven Development on, so this just
+// opens the panel. On a project where the feature is off — initialized
+// before the default flipped, or turned off in Settings → Workflow — we show
+// the suggestion modal instead.
 async function toggle() {
   if (isVisible) {
     hide();
@@ -675,11 +676,11 @@ function showSuggestionModal(projectPath) {
         <li>One folder per spec under <code>.frame/specs/&lt;slug&gt;/</code></li>
         <li>Slash commands (<code>/spec.new</code>, <code>/spec.plan</code>, <code>/spec.tasks</code>) drive Claude through the lifecycle</li>
         <li>Generated tasks land in your existing tasks.json with a <code>spec · slug</code> chip</li>
-        <li>Off by default — you stay in control</li>
+        <li>Can be turned off anytime in Settings → Workflow</li>
       </ul>
       <p class="spec-suggest-fineprint">
         Enabling adds a "Spec-Driven Development" section to AGENTS.md and creates an empty
-        <code>.frame/specs/</code> folder. You can disable later by editing those files directly.
+        <code>.frame/specs/</code> folder. Settings → Workflow turns it back off.
       </p>
       <div class="spec-modal-error" role="alert"></div>
       <div class="spec-modal-actions">

--- a/src/renderer/styles/components/spec-driven-hint.css
+++ b/src/renderer/styles/components/spec-driven-hint.css
@@ -1,0 +1,109 @@
+/* Spec-Driven Development hint — popover anchored on the sidebar's Settings
+   button for projects that predate the feature being on by default. Same
+   elevated-surface language as .sidebar-project-menu, sized like a tooltip
+   rather than a dialog. Position is set inline by specDrivenHint.js. */
+
+.spec-driven-hint {
+  position: fixed;
+  z-index: 8500;
+  width: 260px;
+  padding: 12px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border-default);
+  border-radius: var(--radius-md);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  font-family: var(--font-sans);
+}
+
+.spec-driven-hint-close {
+  position: absolute;
+  top: 6px;
+  right: 6px;
+  width: 20px;
+  height: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius-sm);
+  color: var(--text-muted);
+  font-size: 11px;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.spec-driven-hint-close:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.spec-driven-hint-title {
+  padding-right: 20px;
+  color: var(--text-primary);
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.spec-driven-hint-text {
+  margin: 6px 0 0;
+  color: var(--text-secondary);
+  font-size: 11px;
+  line-height: 1.5;
+}
+
+.spec-driven-hint-error {
+  margin-top: 6px;
+  color: var(--error);
+  font-size: 11px;
+  line-height: 1.4;
+}
+
+.spec-driven-hint-error:empty {
+  display: none;
+}
+
+.spec-driven-hint-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  margin-top: 10px;
+}
+
+.spec-driven-hint-actions button {
+  padding: 4px 10px;
+  border-radius: 5px;
+  font-family: inherit;
+  font-size: 11px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all var(--transition-fast);
+}
+
+.spec-driven-hint-never {
+  background: transparent;
+  border: 1px solid transparent;
+  color: var(--text-muted);
+}
+
+.spec-driven-hint-never:hover {
+  color: var(--text-primary);
+  background: var(--bg-hover);
+}
+
+.spec-driven-hint-enable {
+  background: var(--accent-primary);
+  border: 1px solid var(--accent-primary);
+  color: var(--bg-secondary);
+}
+
+.spec-driven-hint-enable:hover {
+  filter: brightness(1.08);
+}
+
+.spec-driven-hint-enable:disabled {
+  opacity: 0.6;
+  cursor: default;
+}

--- a/src/renderer/styles/layout.css
+++ b/src/renderer/styles/layout.css
@@ -351,8 +351,10 @@ body.sidebar-resizing * {
   border-right: 1px solid var(--border-subtle);
 }
 
-/* Rail buttons reuse .sidebar-tab-btn theming hooks but are square icons in a
-   column — override the horizontal-tab geometry. */
+/* Rail buttons are square icons in a column. Self-contained on purpose: the
+   view tabs also carry .sidebar-tab-btn, but the rail's foot buttons don't
+   (they open modals instead of switching views), so the shared chrome —
+   transparent background, cursor, transition — lives here, not there. */
 .sidebar-rail-btn {
   flex: 0 0 auto;
   width: 34px;
@@ -361,8 +363,11 @@ body.sidebar-resizing * {
   align-items: center;
   justify-content: center;
   padding: 0;
+  background: transparent;
   border: none;
   border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: all var(--transition-fast);
   /* Same treatment as the right-panel strip icons (.lane-rail-strip-btn):
      secondary at rest, primary on hover — readable in both themes. */
   color: var(--text-secondary);
@@ -381,6 +386,12 @@ body.sidebar-resizing * {
   color: var(--accent-primary);
   background: var(--accent-subtle);
   border-bottom: none;
+}
+
+/* Foot of the rail (Settings): pushed to the bottom and set apart from the
+   view tabs above it — it opens a modal rather than switching views. */
+.sidebar-rail-btn-foot {
+  margin-top: auto;
 }
 
 .sidebar-panel {

--- a/src/renderer/styles/main.css
+++ b/src/renderer/styles/main.css
@@ -47,6 +47,9 @@
 /* 12b. Sample-project banner */
 @import 'components/sample-banner.css';
 
+/* 12c. Spec-Driven Development hint (popover on the Settings rail button) */
+@import 'components/spec-driven-hint.css';
+
 /* 13. Tasks Dashboard (Kanban-style overlay) */
 @import 'components/tasks-dashboard.css';
 

--- a/src/shared/frameTemplates.js
+++ b/src/shared/frameTemplates.js
@@ -310,10 +310,10 @@ function renderSpecCoreSection() {
  * (getReferenceTemplate) and is loaded on demand.
  *
  * options:
- *   specDriven: include the short Spec-Driven Development section. Off by
- *               default — the user opts in via the suggestion modal or
- *               Settings, after which we re-emit AGENTS.md (or append the
- *               section to it).
+ *   specDriven: include the short Spec-Driven Development section. Init
+ *               passes true (the feature is on for new projects); the
+ *               parameter stays explicit because pre-existing projects that
+ *               opted out must not get the section back on re-emit.
  */
 /**
  * Render the Project Facts section for AGENTS.md from the detected project
@@ -805,11 +805,12 @@ function getFrameConfigTemplate(projectName) {
       taskRecognition: true
     },
     features: {
-      // Spec-Driven Development is opt-in. The user enables it via the
-      // suggestion modal that appears the first time they click the Specs
-      // panel; toggling this flag also re-emits AGENTS.md with the spec
-      // section so AI tools learn the workflow.
-      specDriven: false
+      // Spec-Driven Development is ON for new projects: the spec commands
+      // ship at init, so an AI session can write specs from day one — the
+      // flag being off only hid them from the Specs panel. The user can turn
+      // it off in Settings → Workflow, which flips this flag and strips the
+      // spec section from AGENTS.md.
+      specDriven: true
     },
     files: {
       agents: "AGENTS.md",

--- a/src/shared/ipcChannels.js
+++ b/src/shared/ipcChannels.js
@@ -169,9 +169,10 @@ const IPC = {
   BUILD_SPEC_COMMAND_FILE: 'build-spec-command-file',
   SPEC_AGENT_ACTIVITY: 'spec-agent-activity',        // renderer → main: { slug, busy } — live agent on this spec's lane
 
-  // Spec-Driven Development opt-in (Slice 1.5)
+  // Spec-Driven Development feature flag (per project, .frame/config.json)
   IS_SPEC_DRIVEN_ENABLED: 'is-spec-driven-enabled',
   ENABLE_SPEC_DRIVEN: 'enable-spec-driven',
+  SET_SPEC_DRIVEN: 'set-spec-driven',                // renderer → main: { projectPath, enabled } — Settings toggle
 
   // Orchestration (conductor / parallel spec execution)
   OPEN_ORCHESTRATOR: 'open-orchestrator',            // → renderer: open the orchestrator view

--- a/test/specDrivenToggle.test.js
+++ b/test/specDrivenToggle.test.js
@@ -1,0 +1,109 @@
+/**
+ * Spec-Driven Development flag tests.
+ *
+ * Covers the default-on contract for new projects and the enable/disable
+ * round-trip that Settings → Workflow drives: the flag in .frame/config.json
+ * and the Frame-managed spec section in AGENTS.md move together, while
+ * anything the user wrote around them survives untouched.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const frameProject = require('../src/main/frameProject');
+const templates = require('../src/shared/frameTemplates');
+const managedBlock = require('../src/shared/docsManagedBlock');
+
+function makeProject({ specDriven, agents }) {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'frame-specdriven-'));
+  fs.mkdirSync(path.join(dir, '.frame'), { recursive: true });
+  const config = templates.getFrameConfigTemplate('demo');
+  config.features.specDriven = specDriven;
+  fs.writeFileSync(
+    path.join(dir, '.frame', 'config.json'),
+    JSON.stringify(config, null, 2),
+    'utf8'
+  );
+  fs.writeFileSync(path.join(dir, 'AGENTS.md'), agents, 'utf8');
+  return dir;
+}
+
+function readAgents(dir) {
+  return fs.readFileSync(path.join(dir, 'AGENTS.md'), 'utf8');
+}
+
+test('new projects get Spec-Driven Development on by default', () => {
+  const config = templates.getFrameConfigTemplate('demo');
+  assert.equal(config.features.specDriven, true);
+
+  const agents = templates.getAgentsTemplate('demo', { specDriven: true });
+  assert.ok(agents.includes('## Spec-Driven Development'));
+  assert.ok(managedBlock.findBlock(agents), 'section must be marker-wrapped');
+});
+
+test('disable flips the flag and removes the managed section', () => {
+  const dir = makeProject({
+    specDriven: true,
+    agents: templates.getAgentsTemplate('demo', { specDriven: true })
+  });
+
+  const result = frameProject.setSpecDrivenEnabled(dir, false);
+  assert.equal(result.success, true);
+  assert.equal(frameProject.isSpecDrivenEnabled(dir), false);
+
+  const agents = readAgents(dir);
+  assert.equal(managedBlock.findBlock(agents), null);
+  assert.ok(!agents.includes('## Spec-Driven Development'));
+  // Neighbouring sections and the footer survive, with no orphaned rule left
+  // where the section used to be.
+  assert.ok(agents.includes('## Writing Frame meta files — read the reference first'));
+  assert.ok(agents.includes('*This file was automatically created by Frame.*'));
+  assert.ok(!/-{3,}\s*\n\s*-{3,}/.test(agents), 'no doubled separator');
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('enable after disable restores the section without touching user content', () => {
+  const dir = makeProject({
+    specDriven: true,
+    agents: templates.getAgentsTemplate('demo', { specDriven: true }) +
+      '\n\n## House Rules\n\nNever force-push.\n'
+  });
+
+  frameProject.setSpecDrivenEnabled(dir, false);
+  const enabled = frameProject.setSpecDrivenEnabled(dir, true);
+  assert.equal(enabled.success, true);
+  assert.equal(frameProject.isSpecDrivenEnabled(dir), true);
+
+  const agents = readAgents(dir);
+  assert.ok(agents.includes('## Spec-Driven Development'));
+  assert.ok(agents.includes('Never force-push.'), 'user section preserved');
+  assert.ok(fs.existsSync(path.join(dir, '.frame', 'specs', '.gitkeep')));
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('disable leaves a hand-written spec section alone', () => {
+  const custom = '# demo\n\n## Spec-Driven Development\n\nOur own house flavour.\n';
+  const dir = makeProject({ specDriven: true, agents: custom });
+
+  frameProject.setSpecDrivenEnabled(dir, false);
+  assert.equal(frameProject.isSpecDrivenEnabled(dir), false);
+  assert.equal(readAgents(dir), custom);
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});
+
+test('toggling a non-Frame folder fails instead of writing files', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'frame-specdriven-none-'));
+  const off = frameProject.setSpecDrivenEnabled(dir, false);
+  const on = frameProject.setSpecDrivenEnabled(dir, true);
+  assert.equal(off.success, false);
+  assert.equal(on.success, false);
+  assert.equal(fs.existsSync(path.join(dir, '.frame')), false);
+
+  fs.rmSync(dir, { recursive: true, force: true });
+});


### PR DESCRIPTION
## Problem

A user initializes a project, hands the agent a sizable task, the agent writes a spec — and the user never sees it. The spec command templates are staged at init regardless of the feature flag, so a CLI session could run the whole spec flow while `features.specDriven: false` kept the Specs panel showing the opt-in modal instead of the work already sitting in `.frame/specs/`. The flag was hiding work, not gating it.

## Changes

**Default on for new projects**
- `features.specDriven: true` in the config template; AGENTS.md ships with the managed spec section and `.frame/specs/.gitkeep` is created at init.

**A real switch in Settings → Workflow**
- Per-project toggle (the flag lives in the project's `.frame/config.json`, not user settings), wired through the new `SET_SPEC_DRIVEN` channel to `setSpecDrivenEnabled`.
- New `disableSpecDriven()` flips the flag back and removes the *marker-wrapped* spec section from AGENTS.md only. A hand-written or customized section, and the specs on disk, are never touched — the same "prove it's ours" contract `docsManagedBlock` already uses on the upgrade path.
- Disabled with no project open, and it snaps back with a reason if the write fails, so the switch never lies about on-disk state.

**Settings reachable from the sidebar rail**
- Gear button at the foot of the left icon rail, opening the same modal as the menu entry and `Cmd+,`.
- `.sidebar-rail-btn` no longer borrows its chrome (transparent background, cursor, transition) from `.sidebar-tab-btn`, so a rail button that doesn't switch views still looks like one.

**A pointer for projects that predate the new default**
- Small popover anchored on that Settings button when the current Frame project has the flag off: "Turn it on" enables it in place, "Don't show again" is remembered per project in user settings, ×/Esc/outside-click means later.
- Turning the feature off from Settings silences the hint for that project — a choice the user just made is not worth nagging about.

## Migration

Projects initialized before this keep whatever flag they have; nothing force-enables on open, since that would rewrite an AGENTS.md the user never asked us to change. They get the hint instead.

## Testing

`test/specDrivenToggle.test.js` — default-on contract, disable removes the section without leaving a doubled `---`, enable-after-disable preserves user-authored content, a hand-written spec section survives disable untouched, and toggling a non-Frame folder fails without writing anything. Full suite: 222/222. Build clean.

The UI (rail button, Settings row, hint popover) was verified by the author in the running app; there is no renderer test harness in this repo.

