### PR TITLE
Debounce the resize storm; keep the watchdog's evidence

### DIFF
--- a/.frame/PROJECT_NOTES.md
+++ b/.frame/PROJECT_NOTES.md
@@ -1749,3 +1749,35 @@ spec — transcripts Claude Code already pruned cannot come back.
 Also worth keeping: `CLAUDE_CONFIG_DIR` is now honoured when resolving
 Claude's data directory (matching Claude Code itself), which is also the seam
 the tests use to point the module at a fixture tree.
+
+### [2026-08-24] The "high internal traffic" toast: resize storm found, watchdog now leaves evidence (spec: resize-storm-watchdog)
+
+Kaan saw a warning at the top of the window now and then — "unusual high
+traffic" — unreadable and gone before it could be read, and asked whether it
+had reached the logs. It had not: the warning was a renderer `console.warn`
+plus a 4-second toast, and electron-log bridges only the main process, so
+`main.log` held zero watchdog lines. A watchdog whose evidence evaporates is
+not a watchdog.
+
+Cause, measured before changing anything: `window.addEventListener('resize')`
+→ `fitTerminal()` → `fitAll()` with no debounce, so a window drag sent one
+`TERMINAL_RESIZE_ID` per terminal per frame — 363 messages in 2.2s with three
+terminals (~205/s), past the 300-per-5s threshold. Ruled out by measurement:
+idle, streaming PTY output (already batched), touching 300 source files, git
+churn, spec status.json churn — all ~0/s.
+
+So the toast was accusing legitimate traffic of being a render loop while
+pointing at real waste (the PTY only needs the final size). Fixed by
+debouncing 80ms — the same settle the terminals view's ResizeObserver already
+used — 363 → 6 messages, terminals still fit their panes.
+
+Two things the incident taught, both now fixed: (1) the watchdog logs through
+`electron-log/renderer` so the channel breakdown survives the toast, and its
+wording reports what it observed rather than asserting a loop; (2) toasts can
+opt into sticky mode with an ×, because a warning carrying detail cannot fade
+in four seconds.
+
+And a plain bug found while verifying: `.app-toast-error` used
+`var(--error-subtle)` — 15% alpha — as its background, so whatever sat behind
+the toast read through the text. That was part of "tam okunaklı değil" all
+along. The tint is now layered over `--bg-elevated`.

--- a/.frame/STRUCTURE.json
+++ b/.frame/STRUCTURE.json
@@ -5574,30 +5574,30 @@
           "purpose": "Initialize all modules"
         },
         "setupButtonHandlers": {
-          "line": 246,
+          "line": 253,
           "purpose": "Setup button click handlers"
         },
         "setupProjectSwitcher": {
-          "line": 323,
+          "line": 330,
           "purpose": "Wire the current-project dropdown: build the project list on open, switch on"
         },
         "setupUpdateDot": {
-          "line": 434,
+          "line": 441,
           "purpose": "Show update indicators when a new version is available:"
         },
         "revealSidebarTab": {
-          "line": 465,
+          "line": 472,
           "params": [
             "tabName"
           ],
           "purpose": "Show the sidebar (if hidden) and switch to the given tab. Used by focus"
         },
         "registerCommands": {
-          "line": 488,
+          "line": 495,
           "purpose": "Register every app command with the central registry. Commands are the"
         },
         "startAiSession": {
-          "line": 760,
+          "line": 767,
           "purpose": "Start the selected AI tool (Claude Code / Codex CLI / etc.) in a fresh"
         }
       },
@@ -5619,18 +5619,26 @@
       ],
       "depends": [
         "electron",
+        "electron-log/renderer",
         "notify"
       ],
       "functions": {
+        "toMainLog": {
+          "line": 29,
+          "params": [
+            "message"
+          ],
+          "purpose": "electron-log's renderer entry forwards to the main process's file"
+        },
         "bump": {
-          "line": 26,
+          "line": 45,
           "params": [
             "direction",
             "channel"
           ]
         },
         "init": {
-          "line": 32
+          "line": 51
         }
       }
     },
@@ -6113,19 +6121,26 @@
       "description": "Notify",
       "exports": [
         "error",
-        "'error')",
+        "options) => show(message",
+        "'error'",
+        "options)",
         "success",
-        "'success')",
+        "options) => show(message",
+        "'success'",
+        "options)",
         "info",
-        "'info')"
+        "options) => show(message",
+        "'info'",
+        "options)"
       ],
       "depends": [],
       "functions": {
         "show": {
-          "line": 26,
+          "line": 32,
           "params": [
             "message",
-            "type = 'info'"
+            "type = 'info'",
+            "{ sticky = false } = {}"
           ]
         }
       }

--- a/.frame/specs/resize-storm-watchdog/digest.md
+++ b/.frame/specs/resize-storm-watchdog/digest.md
@@ -1,0 +1,17 @@
+---
+keywords: ipc watchdog, resize storm, terminal resize, toast, notify, logging, main.log
+related: audit-q3-performance-resources, terminals-view, audit-q3-ux-error-feedback
+---
+The "unusually high internal traffic" toast users saw was real traffic with
+a wrong diagnosis: the window `resize` listener called `fitAll()` per frame,
+sending one `TERMINAL_RESIZE_ID` per open terminal — 363 messages in 2.2s
+with three terminals. It is now debounced 80ms (matching the terminals
+view's ResizeObserver): 363 → 6, terminals still fit. The warning itself
+never reached `main.log` (renderer `console.warn` is not bridged), so it now
+logs through `electron-log/renderer` — no Frame IPC channel added — and its
+wording reports rate + channels instead of asserting a render loop. The
+toast gained a sticky mode (`notify.*(msg, { sticky: true })`, × to close),
+and the error toast's 15%-alpha background was layered over an opaque base:
+content behind it had been reading through the text.
+
+Chain: spec.md → plan.md → tasks.md → outcome.md

--- a/.frame/specs/resize-storm-watchdog/outcome.md
+++ b/.frame/specs/resize-storm-watchdog/outcome.md
@@ -1,0 +1,49 @@
+# Outcome — resize-storm-watchdog
+
+Shipped 2026-08-24. Live-verified in the running app, 321 tests pass.
+
+## A — the resize storm
+
+`window.addEventListener('resize')` → `terminal.fitTerminal()` →
+`manager.fitAll()` now waits 80ms for the drag to settle (the interval the
+terminals view's ResizeObserver already used).
+
+| dragging the window, 3 terminals open | `terminal-resize-id` messages |
+| --- | --- |
+| before | **363** (~205/s) |
+| after | **6** |
+
+The terminal still ends at the right size: after shrinking the window the
+xterm screen still fills its pane (349px pane / 328px screen).
+
+## B — the warning now leaves evidence
+
+The watchdog logs through `electron-log/renderer`, so the line reaches
+`~/Library/Logs/Frame/main.log` (main's redaction hook still runs over it,
+and no Frame IPC channel was added). Verified with a forced storm:
+
+```
+[2026-08-24 22:59:47.562] [warn] [ipcWatchdog] 81 IPC msg/s sustained for 5s
+  — top: out:__watchdog_selftest__ ×400, out:terminal-resize-id ×6
+```
+
+Wording no longer states a render loop as fact — it reports the rate and the
+channels, and names a loop as the usual cause.
+
+## C — the toast can be read
+
+`notify.error(msg, { sticky: true })` skips the auto-hide and adds an ×.
+Verified: still on screen after 5s (the old error toast was gone at 4s),
+dismissed by the × click. Ordinary toasts keep their 4000/2000ms timing.
+
+**Found while verifying:** the error toast's background was
+`var(--error-subtle)` — 15% alpha — so the tab bar behind it read straight
+through the message. That, as much as the fade, is why the warning was
+"tam okunaklı değil". The tint is now layered over `--bg-elevated`, opaque
+in both themes.
+
+## What was measured but was not the cause
+
+Idle, streaming terminal output (batched per terminal), touching 300 source
+files, git churn, and rewriting every spec `status.json` — all ~0 IPC/s.
+Window resize was the only source.

--- a/.frame/specs/resize-storm-watchdog/plan.md
+++ b/.frame/specs/resize-storm-watchdog/plan.md
@@ -1,0 +1,28 @@
+# Plan — resize-storm-watchdog
+
+## Approach
+
+**A.** `index.js`'s window `resize` listener gets an 80ms trailing debounce
+around `terminal.fitTerminal()` — the same interval `terminalsView`'s
+ResizeObserver uses, so both resize paths behave alike. Nothing else about
+fitting changes.
+
+**B.** `ipcWatchdog` logs through `electron-log/renderer`, which forwards to
+the main process's file transport on electron-log's own internal channel —
+no Frame IPC channel is added, and the existing redaction hook still runs
+over it. The require is guarded so a missing/failed logger never breaks the
+watchdog's console path. Message rewritten to report what was observed
+(rate + top channels) and name a render loop as the usual cause rather than
+the verdict.
+
+**C.** `notify` gains an options argument: `notify.error(msg, { sticky:
+true })` renders a close button and skips the auto-hide timer. Default
+behavior — 4000ms for errors, 2000ms otherwise, one toast at a time — is
+untouched. The watchdog is the only caller that opts in.
+
+## Footprint
+
+- src/renderer/index.js
+- src/renderer/ipcWatchdog.js
+- src/renderer/notify.js
+- src/renderer/styles/components/ui.css (toast close button)

--- a/.frame/specs/resize-storm-watchdog/spec.md
+++ b/.frame/specs/resize-storm-watchdog/spec.md
@@ -1,0 +1,41 @@
+# The resize storm, and a watchdog that leaves evidence
+
+> **What we're building:** Window resizing stops flooding IPC, and when the
+> traffic watchdog does fire, its warning survives — written to the log file
+> and shown in a toast the user can actually read.
+
+## User's report (original, Turkish)
+
+> arada bir hata mesajı çıkıyor yukarıda, unusual high traffic vs gibi tam
+> okunaklı da değil, kayboluyor, loglara düşmüş mü kontrol eder misin?
+
+Answer to the question asked: **no, it never reached the log.** The warning
+is a renderer `console.warn` plus a 4-second toast; `electron-log` bridges
+the main process only, so `~/Library/Logs/Frame/main.log` contains not a
+single watchdog line. The toast fades and nothing remains.
+
+## What was actually firing (measured)
+
+`window.addEventListener('resize')` → `terminal.fitTerminal()` →
+`manager.fitAll()` → per terminal `fitAddon.fit()` + one `TERMINAL_RESIZE_ID`
+send, with **no debounce**. Dragging the window with three terminals open:
+**363 resize messages in 2.2 s (~205/s)** — past the watchdog's 300-per-5s
+threshold, so a few seconds of dragging produces the toast.
+
+The traffic is real waste (each message resizes a PTY; the pty only needs the
+final size), but it is not the render loop the warning accuses it of. Idle,
+streaming terminal output, touching 300 source files, git churn and spec
+file churn were all measured at ~0 messages.
+
+## Goal / Acceptance
+
+- **A.** Window resize is debounced before it reaches `fitAll()`, matching
+  the 80ms the terminals view's ResizeObserver already uses. Dragging sends
+  a handful of resize messages instead of hundreds; the terminal still ends
+  at the correct size.
+- **B.** A watchdog warning is written to the main log file — channel
+  breakdown included — so the next unexplained storm leaves evidence after
+  the toast is gone. The wording stops asserting "render loop" as fact.
+- **C.** The warning toast stays until dismissed instead of fading after
+  four seconds, with an × to close it. Only messages that opt in are sticky;
+  ordinary toasts keep their current timing.

--- a/.frame/specs/resize-storm-watchdog/status.json
+++ b/.frame/specs/resize-storm-watchdog/status.json
@@ -1,0 +1,15 @@
+{
+  "slug": "resize-storm-watchdog",
+  "title": "The resize storm, and a watchdog that leaves evidence",
+  "phase": "done",
+  "ai_tool": "claude-code",
+  "generated_task_ids": [
+    "task-spec-resize-storm-watchdog-T01",
+    "task-spec-resize-storm-watchdog-T02",
+    "task-spec-resize-storm-watchdog-T03",
+    "task-spec-resize-storm-watchdog-T04"
+  ],
+  "created_at": "2026-08-24T21:10:00Z",
+  "updated_at": "2026-08-24T20:00:47.206Z",
+  "last_phase_at": "2026-08-24T20:00:47.206Z"
+}

--- a/.frame/specs/resize-storm-watchdog/tasks.md
+++ b/.frame/specs/resize-storm-watchdog/tasks.md
@@ -1,0 +1,10 @@
+# Tasks — resize-storm-watchdog
+
+- [x] T01 · Debounce the window resize → fitAll path (80ms trailing).
+- [x] T02 · Watchdog warnings reach the main log via electron-log/renderer,
+      with the channel breakdown and honest wording.
+- [x] T03 · Sticky toasts: notify options + close button + styles; watchdog
+      opts in.
+- [x] T04 · Verify live (resize message count before/after, forced storm
+      lands in main.log, toast stays until dismissed), tests, STRUCTURE,
+      outcome + digest.

--- a/.frame/tasks.json
+++ b/.frame/tasks.json
@@ -7,7 +7,7 @@
   },
   "project": "Frame",
   "version": "2.0",
-  "lastUpdated": "2026-08-24T19:41:00.638Z",
+  "lastUpdated": "2026-08-24T20:00:47.206Z",
   "taskSchema": {
     "_comment": "This schema shows the expected structure for each task",
     "id": "unique-id (task-xxx format)",
@@ -5169,6 +5169,58 @@
       "createdAt": "2026-08-24T19:35:15.908Z",
       "updatedAt": "2026-08-24T19:41:00.638Z",
       "completedAt": "2026-08-24T19:41:00.638Z"
+    },
+    {
+      "id": "task-spec-resize-storm-watchdog-T01",
+      "title": "Debounce the window resize -> fitAll path (80ms trailing).",
+      "description": "",
+      "source": "spec:resize-storm-watchdog:T01",
+      "status": "completed",
+      "priority": "medium",
+      "category": "fix",
+      "context": "From spec: resize-storm-watchdog",
+      "createdAt": "2026-08-24T19:56:21.051Z",
+      "updatedAt": "2026-08-24T20:00:47.206Z",
+      "completedAt": "2026-08-24T20:00:47.206Z"
+    },
+    {
+      "id": "task-spec-resize-storm-watchdog-T02",
+      "title": "Watchdog warnings reach the main log via electron-log/renderer, with the channel breakdown and honest wording.",
+      "description": "",
+      "source": "spec:resize-storm-watchdog:T02",
+      "status": "completed",
+      "priority": "medium",
+      "category": "fix",
+      "context": "From spec: resize-storm-watchdog",
+      "createdAt": "2026-08-24T19:56:21.051Z",
+      "updatedAt": "2026-08-24T20:00:47.206Z",
+      "completedAt": "2026-08-24T20:00:47.206Z"
+    },
+    {
+      "id": "task-spec-resize-storm-watchdog-T03",
+      "title": "Sticky toasts: notify options + close button + styles; watchdog opts in.",
+      "description": "",
+      "source": "spec:resize-storm-watchdog:T03",
+      "status": "completed",
+      "priority": "medium",
+      "category": "fix",
+      "context": "From spec: resize-storm-watchdog",
+      "createdAt": "2026-08-24T19:56:21.051Z",
+      "updatedAt": "2026-08-24T20:00:47.206Z",
+      "completedAt": "2026-08-24T20:00:47.206Z"
+    },
+    {
+      "id": "task-spec-resize-storm-watchdog-T04",
+      "title": "Verify live (resize message count before/after, forced storm lands in main.log, toast stays until dismissed), tests, STRUCTURE, outcome + digest.",
+      "description": "",
+      "source": "spec:resize-storm-watchdog:T04",
+      "status": "completed",
+      "priority": "medium",
+      "category": "test",
+      "context": "From spec: resize-storm-watchdog",
+      "createdAt": "2026-08-24T19:56:21.051Z",
+      "updatedAt": "2026-08-24T20:00:47.206Z",
+      "completedAt": "2026-08-24T20:00:47.206Z"
     }
   ],
   "metadata": {

--- a/src/renderer/index.js
+++ b/src/renderer/index.js
@@ -234,9 +234,16 @@ function init() {
   registerCommands();
   commandRegistry.bindKeyboard();
 
-  // Setup window resize handler
+  // Window resize → refit every terminal, but only once the drag settles.
+  // Undebounced this fired per frame and each frame sent one resize IPC per
+  // open terminal — 363 messages in 2.2s with three terminals, enough to trip
+  // the IPC watchdog (resize-storm-watchdog spec). The PTY only needs the
+  // final size. 80ms matches the terminals view's own ResizeObserver, so both
+  // resize paths settle alike.
+  let resizeSettleTimer = null;
   window.addEventListener('resize', () => {
-    terminal.fitTerminal();
+    clearTimeout(resizeSettleTimer);
+    resizeSettleTimer = setTimeout(() => terminal.fitTerminal(), 80);
   });
 }
 

--- a/src/renderer/ipcWatchdog.js
+++ b/src/renderer/ipcWatchdog.js
@@ -11,9 +11,28 @@
  * never blocks or drops a message. Threshold is set well above legitimate
  * bursts (project switch, dashboard load ≈ tens of calls) and requires the
  * rate to be sustained for a full window, so it only fires on loops.
+ *
+ * Every warning is written to the main log file as well as the console. The
+ * first real report of this warning could not be investigated at all: the
+ * toast had faded, and `console.warn` never reached `main.log`, so nothing
+ * remained of a storm that had already happened (resize-storm-watchdog spec).
  */
 
 const { ipcRenderer } = require('electron');
+
+/**
+ * electron-log's renderer entry forwards to the main process's file
+ * transport over its own internal channel — no Frame IPC channel involved,
+ * and main's redaction hook still runs over the line. Guarded: a watchdog
+ * that throws while reporting a storm would be worse than the storm.
+ */
+function toMainLog(message) {
+  try {
+    require('electron-log/renderer').warn('[ipcWatchdog]', message);
+  } catch (err) {
+    console.warn('[ipcWatchdog] could not write to the main log:', err.message);
+  }
+}
 
 const WINDOW_MS = 5000;
 const THRESHOLD = 300;       // messages per window (~60/s sustained)
@@ -56,14 +75,19 @@ function init() {
         .map(([ch, n]) => `${ch} ×${n}`)
         .join(', ');
       const perSec = Math.round(total / (WINDOW_MS / 1000));
-      console.warn(`[ipcWatchdog] IPC storm: ${perSec} msg/s sustained — top: ${top}`);
+      const detail = `${perSec} IPC msg/s sustained for ${WINDOW_MS / 1000}s — top: ${top}`;
+      console.warn(`[ipcWatchdog] ${detail}`);
+      toMainLog(detail);
       if (Date.now() - lastWarnAt > REARM_MS) {
         lastWarnAt = Date.now();
         try {
+          // Sticky: this text names the channels, which is the whole point —
+          // it has to survive long enough to be read or copied.
           require('./notify').error(
-            `Unusually high internal traffic (${perSec} msg/s) — likely a render loop. Top: ${top}`
+            `Frame is sending ${detail}. A render loop is the usual cause; the full breakdown is in the log.`,
+            { sticky: true }
           );
-        } catch (_) { /* notify not ready — console.warn already fired */ }
+        } catch (_) { /* notify not ready — the console and log lines already fired */ }
       }
     }
     counts = {};

--- a/src/renderer/notify.js
+++ b/src/renderer/notify.js
@@ -11,6 +11,12 @@
  * one), errors stay 4000 ms because they require user attention, everything
  * else 2000 ms. The message is set via textContent, never innerHTML, so
  * user-provided text can't inject markup.
+ *
+ * `{ sticky: true }` opts a message out of the auto-hide and gives it a
+ * close button — for warnings that carry detail worth reading, which the
+ * four-second fade made unreadable (resize-storm-watchdog spec). Use it
+ * sparingly: a toast that never leaves on its own is the user's problem
+ * until they click it.
  */
 
 const VISIBLE_ERROR_MS = 4000;
@@ -23,12 +29,12 @@ const ICONS = {
   info: '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><line x1="12" y1="16" x2="12" y2="12"/><line x1="12" y1="8" x2="12.01" y2="8"/></svg>'
 };
 
-function show(message, type = 'info') {
+function show(message, type = 'info', { sticky = false } = {}) {
   const existing = document.querySelector('.app-toast');
   if (existing) existing.remove();
 
   const toast = document.createElement('div');
-  toast.className = `app-toast app-toast-${type}`;
+  toast.className = `app-toast app-toast-${type}${sticky ? ' app-toast-sticky' : ''}`;
 
   const icon = document.createElement('span');
   icon.className = 'toast-icon';
@@ -40,21 +46,36 @@ function show(message, type = 'info') {
 
   toast.appendChild(icon);
   toast.appendChild(text);
+
+  const dismiss = () => {
+    toast.classList.remove('visible');
+    setTimeout(() => toast.remove(), FADE_MS);
+  };
+
+  if (sticky) {
+    const close = document.createElement('button');
+    close.className = 'toast-close';
+    close.type = 'button';
+    close.setAttribute('aria-label', 'Dismiss');
+    close.textContent = '×';
+    close.addEventListener('click', dismiss);
+    toast.appendChild(close);
+  }
+
   document.body.appendChild(toast);
 
   requestAnimationFrame(() => {
     toast.classList.add('visible');
   });
 
+  if (sticky) return;
+
   const visibleMs = type === 'error' ? VISIBLE_ERROR_MS : VISIBLE_DEFAULT_MS;
-  setTimeout(() => {
-    toast.classList.remove('visible');
-    setTimeout(() => toast.remove(), FADE_MS);
-  }, visibleMs);
+  setTimeout(dismiss, visibleMs);
 }
 
 module.exports = {
-  error: (message) => show(message, 'error'),
-  success: (message) => show(message, 'success'),
-  info: (message) => show(message, 'info')
+  error: (message, options) => show(message, 'error', options),
+  success: (message, options) => show(message, 'success', options),
+  info: (message, options) => show(message, 'info', options)
 };

--- a/src/renderer/styles/components/panels.css
+++ b/src/renderer/styles/components/panels.css
@@ -646,6 +646,31 @@
   word-break: break-word;
 }
 
+/* Sticky variant: stays until dismissed, so a warning carrying detail
+   (channel breakdown, rates) can actually be read — the four-second fade
+   made those unreadable (resize-storm-watchdog spec). The message takes the
+   free space and the × sits at the end. */
+.app-toast-sticky .toast-message {
+  flex: 1;
+  min-width: 0;
+}
+
+.app-toast .toast-close {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  color: var(--text-tertiary);
+  font-size: 18px;
+  line-height: 1;
+  padding: 0 2px;
+  cursor: pointer;
+  transition: color var(--transition-fast);
+}
+
+.app-toast .toast-close:hover {
+  color: var(--text-primary);
+}
+
 .app-toast-success .toast-icon {
   color: var(--success);
 }
@@ -655,9 +680,12 @@
 }
 
 /* Error variant: louder background tint, accent border, larger text
-   so a missed-CLI / failure message can't slip past the user. */
+   so a missed-CLI / failure message can't slip past the user.
+   The tint (--error-subtle) is 15% alpha, so it is layered over an opaque
+   base — on its own it let whatever sat behind the toast read straight
+   through the message (resize-storm-watchdog spec). */
 .app-toast-error {
-  background: var(--error-subtle);
+  background: linear-gradient(var(--error-subtle), var(--error-subtle)), var(--bg-elevated);
   border-color: var(--error);
   padding: 14px 18px;
   box-shadow: var(--shadow-lg), 0 0 0 1px var(--error);


### PR DESCRIPTION
Reported as: *"arada bir hata mesajı çıkıyor yukarıda, unusual high traffic vs gibi tam okunaklı da değil, kayboluyor, loglara düşmüş mü kontrol eder misin?"*

**Answer to the question asked: no, it never reached the log.** The warning was a renderer `console.warn` plus a 4-second toast, and `electron-log` bridges the main process only — `~/Library/Logs/Frame/main.log` held zero watchdog lines. The toast faded and nothing remained to investigate.

## What was firing

`window.addEventListener('resize')` → `terminal.fitTerminal()` → `manager.fitAll()`, **with no debounce**: one `TERMINAL_RESIZE_ID` per open terminal per frame.

| dragging the window, 3 terminals open | `terminal-resize-id` messages |
| --- | --- |
| before | **363** in 2.2s (~205/s) |
| after | **6** |

Past the watchdog's 300-per-5s threshold, so a few seconds of dragging produced the toast. The traffic is genuine waste — each message resizes a PTY, and the PTY only needs the final size — but it is not the render loop the warning accused it of.

Debounced 80ms, matching the interval the terminals view's ResizeObserver already used, so both resize paths settle alike. The terminal still ends at the right size: after shrinking the window, the xterm screen still fills its pane (349px pane / 328px screen).

**Ruled out by measurement, not assumption:** idle, streaming PTY output (already batched per terminal), touching 300 source files, git churn, and rewriting every spec `status.json` — all ~0 msg/s. Window resize was the only source.

## The warning now leaves evidence

It logs through `electron-log/renderer`, which forwards on electron-log's own internal channel — **no Frame IPC channel added**, and main's redaction hook still runs over the line:

```
[2026-08-24 22:59:47.562] [warn] [ipcWatchdog] 81 IPC msg/s sustained for 5s
  — top: out:__watchdog_selftest__ ×400, out:terminal-resize-id ×6
```

The wording no longer states a render loop as fact: it reports the rate and the top channels, and names a loop as the usual cause.

## The toast can be read

`notify.error(msg, { sticky: true })` skips the auto-hide and adds an ×; the watchdog is the only caller that opts in. Ordinary toasts keep their 4000/2000ms timing. Verified: still on screen after 5s (the old error toast was gone at 4s), dismissed by the × click.

**Found while verifying:** `.app-toast-error`'s background was `var(--error-subtle)` — a **15% alpha** colour — so the tab bar behind the toast read straight through the message. That was part of "not readable" as much as the fade was. The tint is now layered over `--bg-elevated`, opaque in both themes.

## Verification

Live in the running app for every claim above (message counts measured with an in-page IPC tally, log line read back from `main.log`, toast inspected in the DOM and in a screenshot). `npm test` → **321 pass, 0 fail**.

Spec: `.frame/specs/resize-storm-watchdog/` (spec → plan → tasks → outcome), tasks mirrored into `tasks.json`.
