### PR TITLE
Show dotfiles and dot-directories in the file tree

### DIFF
--- a/.frame/STRUCTURE.json
+++ b/.frame/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Auto-generated module structure",
-  "lastUpdated": "2026-08-24",
+  "lastUpdated": "2026-08-25",
   "architecture": {},
   "modules": {
     "main/activityLog": {
@@ -729,7 +729,7 @@
       ],
       "functions": {
         "getFileTree": {
-          "line": 18,
+          "line": 27,
           "params": [
             "dirPath",
             "maxDepth = 5",
@@ -738,7 +738,7 @@
           "purpose": "Get file tree for a directory (async — the whole-subtree walk must not"
         },
         "setupIPC": {
-          "line": 61,
+          "line": 69,
           "params": [
             "ipcMain"
           ],

--- a/.frame/tasks.json
+++ b/.frame/tasks.json
@@ -7,7 +7,7 @@
   },
   "project": "Frame",
   "version": "2.0",
-  "lastUpdated": "2026-08-24T20:00:47.206Z",
+  "lastUpdated": "2026-08-25T09:50:28.213Z",
   "taskSchema": {
     "_comment": "This schema shows the expected structure for each task",
     "id": "unique-id (task-xxx format)",
@@ -5221,6 +5221,19 @@
       "createdAt": "2026-08-24T19:56:21.051Z",
       "updatedAt": "2026-08-24T20:00:47.206Z",
       "completedAt": "2026-08-24T20:00:47.206Z"
+    },
+    {
+      "id": "task-file-tree-hidden-files",
+      "title": "File tree shows dotfiles and dot-directories",
+      "description": "getFileTree skipped every name starting with a dot, hiding .frame/, .github/, .claude/ and .gitignore — the files a Frame user edits most. Now only .git and node_modules are skipped. 574 -> 4407 entries at depth 5; full main walk + DOM rebuild measured at 108ms.",
+      "source": "user-request",
+      "status": "completed",
+      "priority": "medium",
+      "category": "fix",
+      "context": "Kaan: fileview da hidden dosyalar gorunmuyor, onlari da gosterelim",
+      "createdAt": "2026-08-25T09:50:28.213Z",
+      "updatedAt": "2026-08-25T09:50:28.213Z",
+      "completedAt": "2026-08-25T09:50:28.213Z"
     }
   ],
   "metadata": {

--- a/src/main/fileTree.js
+++ b/src/main/fileTree.js
@@ -1,11 +1,20 @@
 /**
  * File Tree Module
  * Generates directory tree structure
+ *
+ * Dotfiles and dot-directories are part of the tree: this is a tool for
+ * working on projects whose configuration lives in `.frame/`, `.github/`,
+ * `.claude/` and friends, and hiding them hid exactly the files a Frame user
+ * edits most. Only machinery is skipped — `.git` (plumbing nobody edits, and
+ * hundreds of hash-named entries) and `node_modules`.
  */
 
 const fsp = require('fs').promises;
 const path = require('path');
 const { IPC } = require('../shared/ipcChannels');
+
+/** Never walked: repository plumbing and installed dependencies. */
+const SKIP = new Set(['.git', 'node_modules']);
 
 /**
  * Get file tree for a directory (async — the whole-subtree walk must not
@@ -30,8 +39,7 @@ async function getFileTree(dirPath, maxDepth = 5, currentDepth = 0) {
     });
 
     for (const item of items) {
-      // Skip hidden files and node_modules
-      if (item.name.startsWith('.') || item.name === 'node_modules') continue;
+      if (SKIP.has(item.name)) continue;
 
       const fullPath = path.join(dirPath, item.name);
       const fileInfo = {


### PR DESCRIPTION
Reported as: *"fileview da hidden dosyalar görünmüyor, onları da gösterelim"*

`getFileTree` skipped every entry whose name starts with a dot. In a Frame project that hides exactly the files the user edits most:

- `.frame/` — specs, `tasks.json`, `PROJECT_NOTES.md`, `AGENTS.md`, `config.json`
- `.claude/`, `.github/`, `.githooks/`, `.gitignore`

Only machinery is skipped now: **`.git`** (614 hash-named entries of plumbing nobody opens from a file tree) and **`node_modules`**. Say the word if you want `.git` in there too — it is one entry in the skip set.

## Cost, measured on this repo

| | depth-5 entries |
| --- | --- |
| before | 574 |
| after | **4407** |

- Full round trip — main's walk plus rebuilding the tree's DOM: **108ms**
- Clicking the Files tab paints its first row in **14ms**
- Folders start collapsed, so **50 rows** are on screen

Eight times the nodes, no perceptible cost at this size. The tree is still built eagerly to depth 5 and every node is created up front (pre-existing behaviour) — worth revisiting if someone opens a project carrying a huge `.next`, `vendor` or `target` directory, but not a problem here.

## Verification

Live in the running app: the tree lists `.agent`, `.agents`, `.claude`, `.frame`, `.githooks`, `.github` alongside the regular folders; expanding `.frame` shows `bin/ docs/ index/ migration-backup/ orchestration/ runtime/ specs/ .gitignore AGENTS.md config.json PROJECT_NOTES.md STRUCTURE.json tasks.json`. No page errors. `npm test` → **321 pass, 0 fail**.

One file changed plus a completed entry in `tasks.json` — small enough that it did not warrant a spec.

