### PR TITLE
Repair what a spec folder can answer, surface what it cannot (#122)

### DIFF
--- a/.frame/PROJECT_NOTES.md
+++ b/.frame/PROJECT_NOTES.md
@@ -1781,3 +1781,43 @@ And a plain bug found while verifying: `.app-toast-error` used
 `var(--error-subtle)` — 15% alpha — as its background, so whatever sat behind
 the toast read through the text. That was part of "tam okunaklı değil" all
 along. The tint is now layered over `--bg-elevated`.
+
+### [2026-08-26] Issue #122 — a spec folder is never silently hidden (spec: spec-status-repair)
+
+An outside report (StreamlinedStartup, issue #122): the spec panel showed
+none of five spec folders that Frame's **own conductor agent** had created,
+with no error anywhere. Their `status.json` carried `title`, `phase` and
+timestamps — the fields the staged templates name — but not `slug`, and
+`listSpecs` did `continue; // silently skip malformed`.
+
+The reporter's framing is the part worth keeping: this was not a third-party
+tool guessing at our format. Frame launched the conductor, handed it
+`CONDUCTOR.md` and the staged spec templates, and those templates say which
+fields to *update* without ever stating the required shape. Meanwhile the
+rest of Frame accepted the same folders — the task watcher imported their
+tasks and wrote `generated_task_ids` back into the very file the panel
+rejected, and `spec-index.js` indexed them. Half of Frame agreed, half
+pretended they did not exist.
+
+Reproduced against the real specManager before touching anything, and found
+one thing the report missed: deriving the slug is not enough.
+`generated_task_ids` is the validator's other required field, so those specs
+would have stayed hidden even after a slug-only fix.
+
+Shipped three parts: repair what the folder itself answers (slug ← folder
+name, generated_task_ids ← []) and persist it once; surface anything still
+invalid as a "needs attention" card with the validator's reason, sorted
+first and inert, instead of dropping it; and document the required shape in
+`spec.new.md` and `CONDUCTOR.md` — in `src/templates/`, since `.frame/runtime/`
+is a staged copy Frame overwrites.
+
+One rule guarded by its own test: **an existing slug is never overwritten.**
+A folder name disagreeing with a recorded slug is a rename question, and
+"fixing" it silently would cut every `source: spec:<slug>:T##` link in
+tasks.json.
+
+Two things the live check taught: `specPanel.renderSpecRow` (the legacy side
+panel, still rendering on every SPEC_DATA push) threw on a phase-less entry
+and needed a guard; and `reconcilePhase` already heals an invalid `phase`
+from the files on disk, so in practice the malformed path is narrower than
+the issue suggests — a missing title or an unreadable file.

--- a/.frame/STRUCTURE.json
+++ b/.frame/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Auto-generated module structure",
-  "lastUpdated": "2026-08-25",
+  "lastUpdated": "2026-08-26",
   "architecture": {},
   "modules": {
     "main/activityLog": {
@@ -3169,6 +3169,7 @@
         "init",
         "setupIPC",
         "validateSpecStatus",
+        "repairSpecStatus",
         "listSpecs",
         "searchSpecs",
         "getSpec",
@@ -3232,27 +3233,35 @@
             "baseSlug"
           ]
         },
+        "repairSpecStatus": {
+          "line": 118,
+          "params": [
+            "obj",
+            "folderName"
+          ],
+          "purpose": "Fill in the fields of a status.json that the folder itself already"
+        },
         "validateSpecStatus": {
-          "line": 101,
+          "line": 136,
           "params": [
             "obj"
           ]
         },
         "readFileSafe": {
-          "line": 120,
+          "line": 155,
           "params": [
             "p"
           ]
         },
         "readStatus": {
-          "line": 129,
+          "line": 164,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "writeStatus": {
-          "line": 140,
+          "line": 175,
           "params": [
             "projectPath",
             "slug",
@@ -3260,33 +3269,50 @@
           ]
         },
         "indexStamp": {
-          "line": 170,
+          "line": 205,
           "params": [
             "projectPath"
           ],
           "purpose": "mtime of the derived index, or 0 — used to tell a rebuild from a no-op."
         },
         "scheduleIndexRefresh": {
-          "line": 179,
+          "line": 214,
           "params": [
             "projectPath"
           ]
         },
         "buildSpecCatalog": {
-          "line": 207,
+          "line": 242,
           "params": [
             "projectPath"
           ],
           "purpose": "One line per non-excluded spec for the spec.new catalog embed. Reads the"
         },
         "listSpecs": {
-          "line": 227,
+          "line": 262,
           "params": [
             "projectPath"
           ]
         },
+        "looksLikeSpecFolder": {
+          "line": 346,
+          "params": [
+            "projectPath",
+            "folderName"
+          ],
+          "purpose": "A folder is a spec if it carries at least one of the chain's artifacts."
+        },
+        "malformedSpec": {
+          "line": 358,
+          "params": [
+            "folderName",
+            "status",
+            "reason"
+          ],
+          "purpose": "A spec folder Frame cannot read as a spec, rendered as itself rather than"
+        },
         "fileExists": {
-          "line": 282,
+          "line": 378,
           "params": [
             "projectPath",
             "slug",
@@ -3294,7 +3320,7 @@
           ]
         },
         "derivePhase": {
-          "line": 286,
+          "line": 382,
           "params": [
             "projectPath",
             "slug",
@@ -3304,7 +3330,7 @@
           ]
         },
         "recordedTaskCount": {
-          "line": 327,
+          "line": 423,
           "params": [
             "projectPath",
             "slug",
@@ -3312,14 +3338,14 @@
           ]
         },
         "collectSpecTasks": {
-          "line": 333,
+          "line": 429,
           "params": [
             "slug",
             "tasksData"
           ]
         },
         "countPhaseWrite": {
-          "line": 354,
+          "line": 450,
           "params": [
             "projectPath",
             "slug",
@@ -3328,7 +3354,7 @@
           ]
         },
         "reconcilePhase": {
-          "line": 362,
+          "line": 458,
           "params": [
             "projectPath",
             "slug",
@@ -3336,14 +3362,14 @@
           ]
         },
         "getDefaultTemplatePath": {
-          "line": 409,
+          "line": 505,
           "params": [
             "aiTool",
             "command"
           ]
         },
         "getOverrideTemplatePath": {
-          "line": 413,
+          "line": 509,
           "params": [
             "projectPath",
             "aiTool",
@@ -3351,7 +3377,7 @@
           ]
         },
         "loadCommandTemplate": {
-          "line": 417,
+          "line": 513,
           "params": [
             "projectPath",
             "aiTool",
@@ -3359,14 +3385,14 @@
           ]
         },
         "interpolate": {
-          "line": 423,
+          "line": 519,
           "params": [
             "template",
             "vars"
           ]
         },
         "getCommandPrompt": {
-          "line": 430,
+          "line": 526,
           "params": [
             "projectPath",
             "slug",
@@ -3375,7 +3401,7 @@
           ]
         },
         "stageCommandAsset": {
-          "line": 479,
+          "line": 575,
           "params": [
             "projectPath",
             "aiTool",
@@ -3384,7 +3410,7 @@
           "purpose": "Copied into .frame/runtime/assets/ on every dispatch, so a project's own"
         },
         "stageCommandAssets": {
-          "line": 500,
+          "line": 596,
           "params": [
             "projectPath",
             "command",
@@ -3392,34 +3418,34 @@
           ]
         },
         "resolveVerificationCommand": {
-          "line": 564,
+          "line": 660,
           "params": [
             "projectPath"
           ],
           "purpose": "The project's own check, in descending order of what actually verifies a"
         },
         "buildImplementPermissions": {
-          "line": 579,
+          "line": 675,
           "params": [
             "verification"
           ]
         },
         "writeImplementPermissions": {
-          "line": 597,
+          "line": 693,
           "params": [
             "projectPath"
           ],
           "purpose": "Writes .frame/implement-permissions.json and reports what it resolved, so"
         },
         "resolveImplementLaunchHint": {
-          "line": 621,
+          "line": 717,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "getImplementLaunchFlags": {
-          "line": 637,
+          "line": 733,
           "params": [
             "projectPath",
             "slug"
@@ -3427,7 +3453,7 @@
           "purpose": "The flags the lane's launch line needs for this dispatch. Only the"
         },
         "buildSpecCommandFile": {
-          "line": 644,
+          "line": 740,
           "params": [
             "projectPath",
             "slug",
@@ -3436,53 +3462,53 @@
           ]
         },
         "parseTasksMarkdown": {
-          "line": 680,
+          "line": 776,
           "params": [
             "content"
           ]
         },
         "parseFootprintMarkdown": {
-          "line": 706,
+          "line": 802,
           "params": [
             "content"
           ]
         },
         "getSpecFootprint": {
-          "line": 725,
+          "line": 821,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "syncTasksFromMarkdown": {
-          "line": 730,
+          "line": 826,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "arraysEqual": {
-          "line": 810,
+          "line": 906,
           "params": [
             "a",
             "b"
           ]
         },
         "syncAllSpecTasks": {
-          "line": 817,
+          "line": 913,
           "params": [
             "projectPath"
           ]
         },
         "getSpec": {
-          "line": 834,
+          "line": 930,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "searchSpecs": {
-          "line": 864,
+          "line": 960,
           "params": [
             "projectPath",
             "query"
@@ -3490,14 +3516,14 @@
           "purpose": "Search specs by keyword over their spec.md content. Case-insensitive"
         },
         "createSpec": {
-          "line": 885,
+          "line": 981,
           "params": [
             "projectPath",
             "opts"
           ]
         },
         "updateSpecStatus": {
-          "line": 928,
+          "line": 1024,
           "params": [
             "projectPath",
             "slug",
@@ -3505,14 +3531,14 @@
           ]
         },
         "deleteSpec": {
-          "line": 947,
+          "line": 1047,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "renameSpec": {
-          "line": 964,
+          "line": 1064,
           "params": [
             "projectPath",
             "oldSlug",
@@ -3521,28 +3547,28 @@
           "purpose": "Rename a spec: moves the folder, updates status.json's slug field, and"
         },
         "startWatching": {
-          "line": 1076,
+          "line": 1176,
           "params": [
             "projectPath"
           ]
         },
         "stopWatching": {
-          "line": 1159
+          "line": 1259
         },
         "pushSpecData": {
-          "line": 1180,
+          "line": 1280,
           "params": [
             "projectPath"
           ]
         },
         "init": {
-          "line": 1200,
+          "line": 1300,
           "params": [
             "window"
           ]
         },
         "setupIPC": {
-          "line": 1204,
+          "line": 1304,
           "params": [
             "ipcMain"
           ]
@@ -7412,25 +7438,25 @@
           ]
         },
         "openDetail": {
-          "line": 215,
+          "line": 218,
           "params": [
             "slug"
           ]
         },
         "reloadDetail": {
-          "line": 221
+          "line": 224
         },
         "renderDetail": {
-          "line": 229
+          "line": 232
         },
         "runSpecCommand": {
-          "line": 302,
+          "line": 305,
           "params": [
             "command"
           ]
         },
         "renderTabButton": {
-          "line": 314,
+          "line": 317,
           "params": [
             "tab",
             "label",
@@ -7438,98 +7464,98 @@
           ]
         },
         "hasSpecTasks": {
-          "line": 320
+          "line": 323
         },
         "tasksTabLabel": {
-          "line": 326,
+          "line": 329,
           "params": [
             "hasMarkdown"
           ]
         },
         "renderTabBody": {
-          "line": 335,
+          "line": 338,
           "params": [
             "tab"
           ]
         },
         "renderPlanReportRow": {
-          "line": 360,
+          "line": 363,
           "purpose": "\"View Plan Report\" — shown above the rendered plan only when the spec"
         },
         "attachPlanReportHandler": {
-          "line": 368
+          "line": 371
         },
         "renderImplementReportRow": {
-          "line": 379,
+          "line": 382,
           "purpose": "\"View Implementation Report\" — shown above the task list only when the spec"
         },
         "attachImplementReportHandler": {
-          "line": 387
+          "line": 390
         },
         "renderTasksTabBody": {
-          "line": 394
+          "line": 397
         },
         "renderSpecTaskRow": {
-          "line": 434,
+          "line": 437,
           "params": [
             "task"
           ]
         },
         "attachTaskActionHandlers": {
-          "line": 483
+          "line": 486
         },
         "handleSpecTaskAction": {
-          "line": 496,
+          "line": 499,
           "params": [
             "taskId",
             "action"
           ]
         },
         "switchTab": {
-          "line": 515,
+          "line": 518,
           "params": [
             "tab"
           ]
         },
         "backToList": {
-          "line": 529
+          "line": 532
         },
         "showNewSpecPrompt": {
-          "line": 544
+          "line": 547
         },
         "deriveSlugPreview": {
-          "line": 646,
+          "line": 649,
           "params": [
             "title"
           ],
           "purpose": "Same shape as specManager.generateSlug — duplicated here so the renderer"
         },
         "showSuggestionModal": {
-          "line": 664,
+          "line": 667,
           "params": [
             "projectPath"
           ]
         },
         "showRenameModal": {
-          "line": 731,
+          "line": 734,
           "params": [
             "status"
           ]
         },
         "showInlineError": {
-          "line": 824,
+          "line": 827,
           "params": [
             "message"
           ]
         },
         "renderMarkdown": {
-          "line": 844,
+          "line": 847,
           "params": [
             "md"
           ]
         },
         "relativeTime": {
-          "line": 854,
+          "line": 857,
           "params": [
             "iso"
           ]
@@ -7632,32 +7658,32 @@
           "purpose": "Create a fresh spec viewport instance (the host calls this when needed)."
         },
         "stepIndexForPhase": {
-          "line": 392,
+          "line": 409,
           "params": [
             "phase"
           ]
         },
         "renderStepper": {
-          "line": 404,
+          "line": 421,
           "params": [
             "phase"
           ]
         },
         "renderSpecTaskRow": {
-          "line": 421,
+          "line": 438,
           "params": [
             "task"
           ]
         },
         "handleTaskAction": {
-          "line": 470,
+          "line": 487,
           "params": [
             "taskId",
             "action"
           ]
         },
         "renderMarkdown": {
-          "line": 479,
+          "line": 496,
           "params": [
             "md"
           ]
@@ -7759,34 +7785,34 @@
           "line": 308
         },
         "renderCard": {
-          "line": 338,
+          "line": 339,
           "params": [
             "spec"
           ]
         },
         "selectCard": {
-          "line": 370,
+          "line": 393,
           "params": [
             "slug"
           ]
         },
         "clearSelection": {
-          "line": 378
+          "line": 401
         },
         "reloadDetail": {
-          "line": 386
+          "line": 409
         },
         "renderDetailHeader": {
-          "line": 402
+          "line": 425
         },
         "runSpecCommand": {
-          "line": 483,
+          "line": 506,
           "params": [
             "command"
           ]
         },
         "tabBtn": {
-          "line": 494,
+          "line": 517,
           "params": [
             "tab",
             "label",
@@ -7794,50 +7820,50 @@
           ]
         },
         "renderDetailBody": {
-          "line": 500
+          "line": 523
         },
         "renderTasksTabBody": {
-          "line": 541
+          "line": 564
         },
         "renderSpecTaskRow": {
-          "line": 578,
+          "line": 601,
           "params": [
             "task"
           ]
         },
         "attachTaskActionHandlers": {
-          "line": 627
+          "line": 650
         },
         "handleSpecTaskAction": {
-          "line": 640,
+          "line": 663,
           "params": [
             "taskId",
             "action"
           ]
         },
         "hasSpecTasks": {
-          "line": 651
+          "line": 674
         },
         "tasksTabLabel": {
-          "line": 657,
+          "line": 680,
           "params": [
             "hasMarkdown"
           ]
         },
         "renderMarkdown": {
-          "line": 666,
+          "line": 689,
           "params": [
             "md"
           ]
         },
         "relativeTime": {
-          "line": 671,
+          "line": 694,
           "params": [
             "iso"
           ]
         },
         "displayProjectName": {
-          "line": 682,
+          "line": 705,
           "params": [
             "projectPath"
           ]

--- a/.frame/specs/spec-status-repair/digest.md
+++ b/.frame/specs/spec-status-repair/digest.md
@@ -1,0 +1,19 @@
+---
+keywords: spec panel, status.json, slug, malformed spec, conductor, orchestration, issue 122
+related: agent-orchestration, spec-knowledge-layer, audit-q3-ux-error-feedback
+---
+Issue #122: the spec panel hid every spec whose status.json lacked `slug` —
+including five written by Frame's own conductor agent, which the task watcher
+and spec-index accepted at the same time. `listSpecs` now repairs what the
+folder answers (`slug` ← folder name, `generated_task_ids` ← `[]`, persisted
+once) and never overwrites an existing slug, since folder/slug disagreement
+is a rename and rewriting it would cut `source: spec:<slug>:T##` links.
+Deriving the slug alone was not enough — `generated_task_ids` is the
+validator's other required field, so the spec would have stayed hidden.
+Anything still invalid is listed as a malformed entry with the validator's
+reason, sorted first and inert, instead of `continue`-ing silently; folders
+with no spec artifact stay ignored. The required shape is documented in
+spec.new.md and CONDUCTOR.md (in src/templates, not the staged copy).
+`specPanel.renderSpecRow` needed a phase-null guard, found by live check.
+
+Chain: spec.md → plan.md → tasks.md → outcome.md

--- a/.frame/specs/spec-status-repair/outcome.md
+++ b/.frame/specs/spec-status-repair/outcome.md
@@ -1,0 +1,64 @@
+# Outcome — spec-status-repair
+
+Shipped 2026-08-26 for issue #122. 9 new tests (330 total, 0 fail) and live
+verification in the running app.
+
+## A — repaired instead of dropped
+
+`repairSpecStatus(status, folderName)` fills only what the folder itself
+answers, and only when absent: `slug` ← folder name, `generated_task_ids` ←
+`[]`. `listSpecs` repairs before validating and persists the result once
+through `writeStatus` (write-if-changed, marks `lastSelfWriteAt`, so the
+watcher does not re-fire and later passes write nothing).
+
+`updateSpecStatus` repairs too — the same validator lives there, so before
+this a conductor-created spec could not have its phase advanced either.
+
+**An existing slug is never overwritten.** Folder and slug disagreeing is a
+rename, and rewriting it would cut every `source: spec:<slug>:T##` link in
+tasks.json. There is a test whose only job is to keep that true.
+
+Live: a conductor-shaped `status.json` (title + phase + timestamps) appeared
+in the panel immediately, and the file on disk gained exactly
+`"slug": "issue-122-repro-conductor"` and `"generated_task_ids": []`.
+
+## B — what cannot be derived is shown, not swallowed
+
+`listSpecs` no longer `continue`s past a spec folder. Anything still invalid
+after repair is listed as `{ slug: <folder>, malformed: <reason>, phase: null }`
+and logged. Malformed entries sort **first** — a spec needing a human should
+not be buried under 45 healthy cards — and are inert: no phase badge, no
+progress bar, no click-through, no agent dispatch. The card shows the
+validator's reason and the path to the file.
+
+Directories carrying none of `status.json` / `spec.md` / `plan.md` /
+`tasks.md` / `outcome.md` are still skipped: a backup folder is not a spec.
+
+Live: `issue-122-repro-nostatus` → "status.json **is missing or unreadable**",
+`issue-122-repro-notitle` → "status.json **missing title**", both with their
+path, both non-clickable, no page errors.
+
+**Found by the live check:** `specPanel.renderSpecRow` threw
+`Cannot read properties of null (reading 'replace')` on a phase-less entry —
+the legacy side panel still renders on every SPEC_DATA push. Guarded.
+
+## C — the shape is written down
+
+`src/templates/commands/claude-code/spec.new.md` and
+`src/templates/orchestration/CONDUCTOR.md` now carry the required
+`status.json` fields, marked required vs optional, with a note that Frame
+repairs slug/generated_task_ids and lists anything else as "needs attention".
+Edited in `src/templates/` — `.frame/runtime/` is a staged copy Frame
+rewrites, so editing that would have been overwritten on the next launch.
+
+## What did not change
+
+Specs that were valid before are listed exactly as before, and their
+`status.json` is not written (a test asserts the mtime is untouched).
+
+## Noted while verifying
+
+`reconcilePhase` already repairs an invalid `phase` from the files on disk
+(the "not-a-phase" repro healed to `specified` before validation). So in
+practice the malformed path is for a missing title or an unreadable file —
+narrower than the issue implies, and worth knowing.

--- a/.frame/specs/spec-status-repair/plan.md
+++ b/.frame/specs/spec-status-repair/plan.md
@@ -1,0 +1,42 @@
+# Plan — spec-status-repair
+
+## Approach
+
+**Repair (A).** A new `repairSpecStatus(status, folderName)` fills only what
+is derivable and only when absent: `slug` ← folder name,
+`generated_task_ids` ← `[]`. It returns the repaired object plus the list of
+fields it filled, so the caller can log and persist. `listSpecs` calls it
+before validating; when fields were filled it writes the file back through
+the existing `writeStatus` (write-if-changed, marks `lastSelfWriteAt`, so
+the watcher does not re-fire and a second pass is a no-op).
+
+`updateSpecStatus` runs the same repair before merging, so a phase advance
+on a never-repaired spec works instead of failing validation.
+
+**Surface (B).** `listSpecs` stops using `continue` for a spec folder that
+holds spec files. Anything still invalid after repair is pushed as
+`{ slug: <folder>, malformed: <reason>, title: <status.title or folder> }`
+with safe zeros for counts. Folders holding none of `status.json`, `spec.md`,
+`plan.md`, `tasks.md` remain skipped — they are not specs. Every malformed
+entry is logged with its reason.
+
+The specs dashboard and the sidebar spec section render such an entry as a
+card marked "needs attention" with the reason, and skip the interactions
+that assume a working spec (phase actions, agent dispatch, task counts). The
+detail view shows the reason and the file path rather than an empty chain.
+
+**Document (C).** The required shape goes into `src/templates/commands/
+claude-code/spec.new.md` (the template that creates a spec) and
+`src/templates/orchestration/CONDUCTOR.md`, since the conductor writes spec
+folders directly. `.frame/runtime/` is a staged copy Frame rewrites — editing
+it would be overwritten, so it is not touched by hand.
+
+## Footprint
+
+- src/main/specManager.js
+- src/renderer/specsDashboard.js
+- src/renderer/specSection.js
+- src/renderer/styles/components/panels.css
+- src/templates/commands/claude-code/spec.new.md
+- src/templates/orchestration/CONDUCTOR.md
+- test/specStatusRepair.test.js (new)

--- a/.frame/specs/spec-status-repair/spec.md
+++ b/.frame/specs/spec-status-repair/spec.md
@@ -1,0 +1,65 @@
+# A spec is never silently hidden
+
+> **What we're building:** A spec folder whose `status.json` is missing
+> derivable fields is repaired instead of dropped, and anything still
+> unusable is shown with its reason instead of vanishing. The required shape
+> is written down where the agents that create specs can read it.
+
+## Reported as (issue #122, StreamlinedStartup)
+
+> The spec panel does not show a spec when its status.json has no slug field.
+> The panel skips the spec and shows no error. In this case, the specs came
+> from Frame's own orchestration flow: the conductor agent … converted
+> existing project tasks into spec folders. Frame's UI then hid all five
+> specs.
+
+The reporter's point is the sharp one: this is not a third-party tool
+guessing at Frame's format. Frame launched the conductor, handed it
+`CONDUCTOR.md` and the staged spec templates, and those templates name the
+fields to *update* (`phase`, `updated_at`, `last_phase_at`) without ever
+stating the required shape. Half of Frame then accepted the result — the
+task watcher imported `tasks.md` and wrote `generated_task_ids` back into
+that same file, and `spec-index.js` indexed it — while the panel hid it.
+
+## Reproduced
+
+Running the real `specManager` against a conductor-shaped `status.json`
+(`title`, `phase`, timestamps):
+
+```
+validator: "missing slug"     listSpecs: []
+```
+
+**Beyond the report:** deriving the slug alone is not enough. The validator's
+next required field is also absent, so the spec stays hidden:
+
+```
+slug filled in → "generated_task_ids must be an array"
+slug + generated_task_ids → valid
+```
+
+Both fields are derivable — the slug is the folder's name, and a spec that
+has generated no tasks has an empty list.
+
+Also affected: `updateSpecStatus` runs the same validator, so a spec in this
+state cannot have its phase advanced through the API either.
+
+## Goal / Acceptance
+
+- A spec folder with a readable `status.json` missing `slug` and/or
+  `generated_task_ids` is listed, and the file is repaired once on disk so
+  the rest of Frame agrees with the panel.
+- An existing `slug` is **never** overwritten. Folder and slug disagreeing
+  is a rename question, not a repair one, and rewriting it would silently
+  cut every `source: spec:<slug>:T##` link in tasks.json.
+- What cannot be derived (unreadable JSON, unknown phase, missing title) is
+  listed as a malformed entry carrying the validator's reason, not skipped.
+  Directories with no spec file at all stay ignored — they are not specs.
+- Malformed entries are inert in the panel: no phase actions, no agent
+  dispatch; they exist to be seen and fixed.
+- Every repair and every malformed entry is logged with its reason.
+- The required `status.json` shape is documented in the spec command
+  templates and in `CONDUCTOR.md` — in `src/templates/`, the source Frame
+  stages from, not the generated copy under `.frame/runtime/`.
+- Specs that are valid today are unaffected: same validator result, same
+  listing, no writes.

--- a/.frame/specs/spec-status-repair/status.json
+++ b/.frame/specs/spec-status-repair/status.json
@@ -1,0 +1,16 @@
+{
+  "slug": "spec-status-repair",
+  "title": "A spec is never silently hidden (issue #122)",
+  "phase": "done",
+  "ai_tool": "claude-code",
+  "generated_task_ids": [
+    "task-spec-spec-status-repair-T01",
+    "task-spec-spec-status-repair-T02",
+    "task-spec-spec-status-repair-T03",
+    "task-spec-spec-status-repair-T04",
+    "task-spec-spec-status-repair-T05"
+  ],
+  "created_at": "2026-08-26T08:00:00Z",
+  "updated_at": "2026-08-26T10:07:00.001Z",
+  "last_phase_at": "2026-08-26T10:07:00.001Z"
+}

--- a/.frame/specs/spec-status-repair/tasks.md
+++ b/.frame/specs/spec-status-repair/tasks.md
@@ -1,0 +1,15 @@
+# Tasks — spec-status-repair
+
+- [x] T01 · repairSpecStatus(): fill slug from the folder name and default
+      generated_task_ids, never overwrite an existing slug; wire it into
+      listSpecs (with a one-time write-back) and updateSpecStatus.
+- [x] T02 · listSpecs surfaces what it cannot repair: malformed entries with
+      the validator's reason, logged; folders holding no spec file stay
+      skipped.
+- [x] T03 · Renderer: malformed cards in the specs dashboard and the spec
+      section — reason shown, interactions that assume a valid spec disabled.
+- [x] T04 · Document the required status.json shape in spec.new.md and
+      CONDUCTOR.md (src/templates, not the staged copy).
+- [x] T05 · Tests (repair rules, slug never overwritten, malformed surfaced,
+      non-spec folders ignored, valid specs untouched) + live verification
+      with a conductor-shaped spec, watchdog quiet, no repeat writes.

--- a/.frame/tasks.json
+++ b/.frame/tasks.json
@@ -7,7 +7,7 @@
   },
   "project": "Frame",
   "version": "2.0",
-  "lastUpdated": "2026-08-25T09:50:28.213Z",
+  "lastUpdated": "2026-08-26T10:07:00.001Z",
   "taskSchema": {
     "_comment": "This schema shows the expected structure for each task",
     "id": "unique-id (task-xxx format)",
@@ -5234,6 +5234,71 @@
       "createdAt": "2026-08-25T09:50:28.213Z",
       "updatedAt": "2026-08-25T09:50:28.213Z",
       "completedAt": "2026-08-25T09:50:28.213Z"
+    },
+    {
+      "id": "task-spec-spec-status-repair-T01",
+      "title": "repairSpecStatus(): fill slug from folder name and default generated_task_ids, never overwrite an existing slug; wire into listSpecs (one-time write-back) and updateSpecStatus.",
+      "description": "",
+      "source": "spec:spec-status-repair:T01",
+      "status": "completed",
+      "priority": "high",
+      "category": "fix",
+      "context": "From spec: spec-status-repair (issue #122)",
+      "createdAt": "2026-08-26T09:56:47.009Z",
+      "updatedAt": "2026-08-26T10:07:00.001Z",
+      "completedAt": "2026-08-26T10:07:00.001Z"
+    },
+    {
+      "id": "task-spec-spec-status-repair-T02",
+      "title": "listSpecs surfaces what it cannot repair: malformed entries with the validator reason, logged; folders holding no spec file stay skipped.",
+      "description": "",
+      "source": "spec:spec-status-repair:T02",
+      "status": "completed",
+      "priority": "high",
+      "category": "fix",
+      "context": "From spec: spec-status-repair (issue #122)",
+      "createdAt": "2026-08-26T09:56:47.009Z",
+      "updatedAt": "2026-08-26T10:07:00.001Z",
+      "completedAt": "2026-08-26T10:07:00.001Z"
+    },
+    {
+      "id": "task-spec-spec-status-repair-T03",
+      "title": "Renderer: malformed cards in specs dashboard and spec section — reason shown, interactions assuming a valid spec disabled.",
+      "description": "",
+      "source": "spec:spec-status-repair:T03",
+      "status": "completed",
+      "priority": "high",
+      "category": "fix",
+      "context": "From spec: spec-status-repair (issue #122)",
+      "createdAt": "2026-08-26T09:56:47.009Z",
+      "updatedAt": "2026-08-26T10:07:00.001Z",
+      "completedAt": "2026-08-26T10:07:00.001Z"
+    },
+    {
+      "id": "task-spec-spec-status-repair-T04",
+      "title": "Document the required status.json shape in spec.new.md and CONDUCTOR.md (src/templates, not the staged copy).",
+      "description": "",
+      "source": "spec:spec-status-repair:T04",
+      "status": "completed",
+      "priority": "high",
+      "category": "fix",
+      "context": "From spec: spec-status-repair (issue #122)",
+      "createdAt": "2026-08-26T09:56:47.009Z",
+      "updatedAt": "2026-08-26T10:07:00.001Z",
+      "completedAt": "2026-08-26T10:07:00.001Z"
+    },
+    {
+      "id": "task-spec-spec-status-repair-T05",
+      "title": "Tests (repair rules, slug never overwritten, malformed surfaced, non-spec folders ignored, valid specs untouched) + live verification.",
+      "description": "",
+      "source": "spec:spec-status-repair:T05",
+      "status": "completed",
+      "priority": "high",
+      "category": "test",
+      "context": "From spec: spec-status-repair (issue #122)",
+      "createdAt": "2026-08-26T09:56:47.009Z",
+      "updatedAt": "2026-08-26T10:07:00.001Z",
+      "completedAt": "2026-08-26T10:07:00.001Z"
     }
   ],
   "metadata": {

--- a/src/main/specManager.js
+++ b/src/main/specManager.js
@@ -98,6 +98,41 @@ function uniqueSlug(projectPath, baseSlug) {
 // Shape check only — phase enum, required fields, ISO date strings.
 // Returns null when valid, or a human-readable reason string.
 
+/**
+ * Fill in the fields of a status.json that the folder itself already
+ * answers, and report which ones were filled.
+ *
+ * Issue #122: Frame's own conductor agent wrote spec folders with `title`,
+ * `phase` and timestamps — the fields the staged templates name — and the
+ * panel then hid all five specs, because the validator also requires `slug`
+ * and `generated_task_ids`. Both are derivable: the slug IS the folder's
+ * name, and a spec that generated no tasks has none.
+ *
+ * An existing slug is never touched. A folder name disagreeing with a
+ * recorded slug is a rename question, and rewriting it here would silently
+ * cut every `source: spec:<slug>:T##` link in tasks.json.
+ *
+ * Returns { status, filled } — `status` is the same object when nothing was
+ * missing, so callers can skip writing.
+ */
+function repairSpecStatus(obj, folderName) {
+  if (!obj || typeof obj !== 'object') return { status: obj, filled: [] };
+
+  const filled = [];
+  const status = { ...obj };
+
+  if ((typeof status.slug !== 'string' || !status.slug) && folderName) {
+    status.slug = folderName;
+    filled.push('slug');
+  }
+  if (!Array.isArray(status.generated_task_ids)) {
+    status.generated_task_ids = [];
+    filled.push('generated_task_ids');
+  }
+
+  return filled.length ? { status, filled } : { status: obj, filled: [] };
+}
+
 function validateSpecStatus(obj) {
   if (!obj || typeof obj !== 'object') return 'not an object';
   if (typeof obj.slug !== 'string' || !obj.slug) return 'missing slug';
@@ -248,29 +283,90 @@ function listSpecs(projectPath) {
   const specs = [];
   for (const ent of entries) {
     if (!ent.isDirectory()) continue;
+    // A directory holding none of the spec artifacts is not a spec — a
+    // stray backup or scratch folder under .frame/specs/ stays invisible
+    // rather than becoming a "malformed spec" card (issue #122 fix).
+    if (!looksLikeSpecFolder(projectPath, ent.name)) continue;
     // Reconcile phase from filesystem state + task statuses — catches the
     // case where the AI wrote a plan.md / tasks.md but didn't (or couldn't)
     // update status.json, and also flips to implementing/done as the user
     // moves spec tasks through their lifecycle.
     reconcilePhase(projectPath, ent.name, tasksData);
     const status = readStatus(projectPath, ent.name);
-    if (!status) continue;
-    if (validateSpecStatus(status)) continue; // silently skip malformed
-    const specTasks = collectSpecTasks(status.slug, tasksData);
+    if (!status) {
+      specs.push(malformedSpec(ent.name, null, 'is missing or unreadable'));
+      continue;
+    }
+
+    // Fill what the folder already answers, and persist it once so the rest
+    // of Frame reads the same file the panel now accepts.
+    const { status: repaired, filled } = repairSpecStatus(status, ent.name);
+    if (filled.length) {
+      console.warn(`specManager: repaired ${ent.name}/status.json — filled ${filled.join(', ')}`);
+      try {
+        writeStatus(projectPath, ent.name, repaired);
+      } catch (err) {
+        console.error('specManager: could not persist the repair', ent.name, err.message);
+      }
+    }
+
+    // Whatever is still wrong cannot be derived from the folder. It is shown
+    // with its reason instead of disappearing: a spec the user can see and
+    // fix beats a spec Frame pretends does not exist (issue #122).
+    const reason = validateSpecStatus(repaired);
+    if (reason) {
+      console.warn(`specManager: ${ent.name}/status.json is unusable — ${reason}`);
+      specs.push(malformedSpec(ent.name, repaired, reason));
+      continue;
+    }
+    const status_ = repaired;
+    const specTasks = collectSpecTasks(status_.slug, tasksData);
     const completedCount = specTasks.filter(t => t.status === 'completed').length;
     specs.push({
-      slug: status.slug,
-      title: status.title,
-      phase: status.phase,
-      ai_tool: status.ai_tool || null,
-      task_count: specTasks.length || status.generated_task_ids.length,
+      slug: status_.slug,
+      title: status_.title,
+      phase: status_.phase,
+      ai_tool: status_.ai_tool || null,
+      task_count: specTasks.length || status_.generated_task_ids.length,
       completed_count: completedCount,
-      created_at: status.created_at || null,
-      updated_at: status.updated_at || null
+      created_at: status_.created_at || null,
+      updated_at: status_.updated_at || null
     });
   }
-  specs.sort((a, b) => (b.updated_at || '').localeCompare(a.updated_at || ''));
+  // Malformed first: a spec Frame cannot read needs a human, and sorting it
+  // by a timestamp it doesn't have buried it under everything else.
+  specs.sort((a, b) => {
+    if (!!a.malformed !== !!b.malformed) return a.malformed ? -1 : 1;
+    return (b.updated_at || '').localeCompare(a.updated_at || '');
+  });
   return specs;
+}
+
+/** A folder is a spec if it carries at least one of the chain's artifacts. */
+function looksLikeSpecFolder(projectPath, folderName) {
+  const dir = getSpecDir(projectPath, folderName);
+  return [STATUS_FILE, SPEC_FILE, PLAN_FILE, TASKS_FILE, OUTCOME_FILE]
+    .some(name => fs.existsSync(path.join(dir, name)));
+}
+
+/**
+ * A spec folder Frame cannot read as a spec, rendered as itself rather than
+ * dropped. It carries the folder name as its slug so every existing
+ * slug-keyed path in the renderer keeps working, `phase: null` so nothing
+ * mistakes it for a live phase, and the validator's reason for the user.
+ */
+function malformedSpec(folderName, status, reason) {
+  return {
+    slug: folderName,
+    title: (status && typeof status.title === 'string' && status.title) || folderName,
+    phase: null,
+    malformed: reason,
+    ai_tool: null,
+    task_count: 0,
+    completed_count: 0,
+    created_at: (status && status.created_at) || null,
+    updated_at: (status && status.updated_at) || null
+  };
 }
 
 // ─── Phase derivation ──────────────────────────────────────
@@ -930,12 +1026,16 @@ function updateSpecStatus(projectPath, slug, partial) {
   if (!current) return { error: 'spec not found' };
   const phaseChanged = partial && partial.phase && partial.phase !== current.phase;
   const now = new Date().toISOString();
+  // Repair first: a status.json written without `slug` / `generated_task_ids`
+  // used to fail validation here too, so an agent-created spec could not have
+  // its phase advanced through the API either (issue #122).
+  const { status: base } = repairSpecStatus(current, slug);
   const merged = {
-    ...current,
+    ...base,
     ...partial,
-    slug: current.slug, // slug is immutable
+    slug: base.slug, // slug is immutable
     updated_at: now,
-    last_phase_at: phaseChanged ? now : current.last_phase_at
+    last_phase_at: phaseChanged ? now : base.last_phase_at
   };
   const reason = validateSpecStatus(merged);
   if (reason) return { error: reason };
@@ -1260,6 +1360,7 @@ module.exports = {
   // Exported for tests + future Slice 1.5 (project init) reuse
   generateSlug,
   validateSpecStatus,
+  repairSpecStatus,
   listSpecs,
   searchSpecs,
   getSpec,

--- a/src/renderer/laneRail.js
+++ b/src/renderer/laneRail.js
@@ -201,7 +201,7 @@ function _renderSpecsSection(ui) {
   section.className = 'lane-rail-section rail-specs';
 
   const active = specs
-    .filter(s => s.phase !== 'done')
+    .filter(s => s.phase !== 'done' && !s.malformed)
     .sort((a, b) => SPEC_PHASE_ORDER.indexOf(a.phase) - SPEC_PHASE_ORDER.indexOf(b.phase));
 
   section.appendChild(_sectionHeader({

--- a/src/renderer/multiTerminalUI.js
+++ b/src/renderer/multiTerminalUI.js
@@ -524,8 +524,10 @@ class MultiTerminalUI {
     } catch (_) { /* fall through to the grid */ }
     const order = ['implementing', 'tasks_generated', 'planned', 'specified', 'draft'];
     const top = specs
-      .filter(s => s.phase !== 'done')
-      .sort((a, b) => order.indexOf(a.phase) - order.indexOf(b.phase))[0] || specs[0];
+      .filter(s => s.phase !== 'done' && !s.malformed)
+      .sort((a, b) => order.indexOf(a.phase) - order.indexOf(b.phase))[0]
+      || specs.find(s => !s.malformed)
+      || specs[0];
     if (top) {
       require('./specSection').open(top.slug);
     } else {

--- a/src/renderer/specPanel.js
+++ b/src/renderer/specPanel.js
@@ -193,7 +193,10 @@ function renderList() {
 }
 
 function renderSpecRow(spec) {
-  const phaseLabel = spec.phase.replace(/_/g, ' ');
+  // A spec folder Frame could not read as a spec carries no phase — it is
+  // listed so it can be fixed rather than dropped (issue #122).
+  const phaseLabel = spec.malformed ? 'needs attention' : spec.phase.replace(/_/g, ' ');
+  const phaseClass = spec.malformed ? 'malformed' : spec.phase;
   const updated = relativeTime(spec.updated_at);
   const tasksLabel = spec.task_count
     ? `${spec.task_count} task${spec.task_count === 1 ? '' : 's'}`
@@ -202,7 +205,7 @@ function renderSpecRow(spec) {
     <div class="spec-row" data-slug="${escapeHtml(spec.slug)}">
       <div class="spec-row-title">${require('./agentDispatch').specStatusDotHtml(spec.slug)}${escapeHtml(spec.title)}</div>
       <div class="spec-row-meta">
-        <span class="spec-phase-badge phase-${spec.phase}">${phaseLabel}</span>
+        <span class="spec-phase-badge phase-${phaseClass}">${phaseLabel}</span>
         ${tasksLabel ? `<span class="spec-row-tasks">${tasksLabel}</span>` : ''}
         <span class="spec-row-time">${updated}</span>
       </div>

--- a/src/renderer/specSection.js
+++ b/src/renderer/specSection.js
@@ -138,8 +138,25 @@ function createViewport() {
   function _railItems() {
     return specsList
       .slice()
+      // Malformed specs (issue #122) carry no phase; they sort to the top of
+      // the list, where a spec that needs a hand belongs.
       .sort((a, b) => SPEC_PHASE_ORDER.indexOf(a.phase) - SPEC_PHASE_ORDER.indexOf(b.phase))
       .map((s) => {
+        if (s.malformed) {
+          return {
+            id: s.slug,
+            active: false,
+            completed: false,
+            className: 'lane-rail-spec lane-rail-spec-malformed',
+            html: `
+              <div class="lane-rail-item-title">${escapeHtml(s.title || s.slug)}</div>
+              <div class="lane-rail-card-meta">
+                <span class="spec-phase-badge phase-malformed">needs attention</span>
+              </div>
+              <div class="lane-rail-malformed-reason">status.json ${escapeHtml(s.malformed)}</div>
+            `
+          };
+        }
         const { done, total } = _specProgress(s.slug);
         return {
           id: s.slug,

--- a/src/renderer/specsDashboard.js
+++ b/src/renderer/specsDashboard.js
@@ -331,11 +331,34 @@ function renderGrid() {
 
   gridEl.innerHTML = filtered.map(renderCard).join('');
   gridEl.querySelectorAll('.specs-card').forEach(card => {
+    if (card.dataset.malformed) return; // nothing to open — the reason is on the card
     card.addEventListener('click', () => selectCard(card.dataset.slug));
   });
 }
 
 function renderCard(spec) {
+  // A spec folder Frame could not read as a spec. It is shown with the
+  // reason instead of being dropped from the list (issue #122), and it is
+  // inert: no phase badge, no progress, no click-through to a detail view
+  // that has nothing to show.
+  if (spec.malformed) {
+    return `
+      <div class="specs-card specs-card-malformed" data-malformed="1">
+        <div class="specs-card-top">
+          <span class="spec-phase-badge phase-malformed">needs attention</span>
+        </div>
+        <div class="specs-card-title">${escapeHtml(spec.title)}</div>
+        <div class="specs-card-slug">${escapeHtml(spec.slug)}</div>
+        <div class="specs-card-malformed-reason">
+          <strong>status.json</strong> ${escapeHtml(spec.malformed)}
+        </div>
+        <div class="specs-card-foot">
+          <span class="specs-card-time">.frame/specs/${escapeHtml(spec.slug)}/status.json</span>
+        </div>
+      </div>
+    `;
+  }
+
   const taskMatches = allTasks.filter(t => t && typeof t.source === 'string' && t.source.startsWith(`spec:${spec.slug}:`));
   const total = taskMatches.length || spec.task_count || 0;
   const done = taskMatches.filter(t => t.status === 'completed').length;

--- a/src/renderer/styles/components/panels.css
+++ b/src/renderer/styles/components/panels.css
@@ -4411,6 +4411,37 @@
   color: var(--success);
 }
 
+/* A spec folder Frame could not read as a spec (issue #122). Warning
+   colours, not error: the folder is fine, its status.json needs a field. */
+.spec-phase-badge.phase-malformed {
+  background: rgba(229, 205, 142, 0.15);
+  color: var(--warning);
+}
+
+.specs-card-malformed {
+  border-style: dashed;
+  cursor: default;
+}
+
+.specs-card-malformed:hover {
+  border-color: var(--warning);
+}
+
+.specs-card-malformed-reason,
+.lane-rail-malformed-reason {
+  font-size: 11px;
+  line-height: 1.5;
+  color: var(--text-tertiary);
+  margin-top: 6px;
+  word-break: break-word;
+}
+
+.specs-card-malformed-reason strong {
+  font-family: var(--font-mono);
+  color: var(--warning);
+  font-weight: 500;
+}
+
 /* Empty state */
 .specs-empty {
   display: flex;

--- a/src/templates/commands/claude-code/spec.new.md
+++ b/src/templates/commands/claude-code/spec.new.md
@@ -84,6 +84,31 @@ Update `.frame/specs/{slug}/status.json`:
 - `updated_at` → current ISO timestamp
 - `last_phase_at` → current ISO timestamp
 
+### status.json — the required shape
+
+Frame creates this file for you here, so you are only editing fields. If you
+ever write one from scratch (creating a spec folder without `/spec.new`),
+every field below marked required must be present, or Frame cannot read the
+folder as a spec:
+
+```json
+{
+  "slug": "{slug}",                  // required — must equal the folder name
+  "title": "Human readable title",   // required
+  "phase": "specified",              // required — draft | specified | planned |
+                                     //            tasks_generated | implementing | done
+  "generated_task_ids": [],          // required — [] until /spec.tasks fills it
+  "ai_tool": "claude-code",          // optional
+  "created_at": "ISO-8601",          // optional
+  "updated_at": "ISO-8601",          // optional
+  "last_phase_at": "ISO-8601"        // optional
+}
+```
+
+Frame repairs a missing `slug` or `generated_task_ids` from the folder itself,
+but anything else missing leaves the spec listed as "needs attention" until a
+human fixes it.
+
 Do **not** generate plan.md or tasks.md — those come from `/spec.plan` and `/spec.tasks`.
 
 ## Style

--- a/src/templates/orchestration/CONDUCTOR.md
+++ b/src/templates/orchestration/CONDUCTOR.md
@@ -32,6 +32,23 @@ The user assigns a set of **specs** to you (shown in the orchestrator UI). Each
 spec lives at `.frame/specs/<slug>/` with `spec.md`, `plan.md`, `tasks.md`, and
 `status.json`.
 
+**If you create a spec folder yourself**, its `status.json` must carry these
+fields or Frame's spec panel cannot read the folder as a spec:
+
+```json
+{
+  "slug": "<must equal the folder name>",
+  "title": "Human readable title",
+  "phase": "draft | specified | planned | tasks_generated | implementing | done",
+  "generated_task_ids": []
+}
+```
+
+`created_at`, `updated_at`, `last_phase_at` (ISO-8601) and `ai_tool` are
+optional. Frame repairs a missing `slug` or `generated_task_ids` from the
+folder itself; anything else missing leaves the spec listed as "needs
+attention" until a human fixes it.
+
 **The assigned set is the single source of truth — not individual messages.**
 Frame may inject a nudge like *"Assigned specs are now: a, b, c …"*. Treat that
 as a pointer to the full set (also queryable via `status.js`), **not** as a

--- a/test/specStatusRepair.test.js
+++ b/test/specStatusRepair.test.js
@@ -1,0 +1,170 @@
+/**
+ * Spec status repair tests (spec-status-repair, issue #122).
+ *
+ * The reported failure: Frame's own conductor agent wrote five spec folders
+ * with `title`, `phase` and timestamps — the fields the staged templates name
+ * — and the spec panel listed none of them, with no error anywhere. These
+ * tests pin the two halves of the fix: what the folder itself can answer is
+ * repaired, and what it cannot is shown rather than dropped.
+ *
+ * The rule these tests exist to protect: an existing slug is never rewritten.
+ * Folder and slug disagreeing is a rename, and silently "fixing" it would cut
+ * every `source: spec:<slug>:T##` link in tasks.json.
+ */
+
+const { test, beforeEach, afterEach } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const specManager = require('../src/main/specManager');
+
+let projectDir;
+
+beforeEach(() => {
+  projectDir = fs.mkdtempSync(path.join(os.tmpdir(), 'frame-spec-repair-'));
+});
+
+afterEach(() => {
+  fs.rmSync(projectDir, { recursive: true, force: true });
+});
+
+function specDir(slug) {
+  const dir = path.join(projectDir, '.frame', 'specs', slug);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/** A spec folder as Frame's conductor writes it: no slug, no task ids. */
+function writeConductorSpec(slug, extra = {}) {
+  const dir = specDir(slug);
+  fs.writeFileSync(path.join(dir, 'spec.md'), '# spec\n');
+  fs.writeFileSync(path.join(dir, 'tasks.md'), '# tasks\n');
+  fs.writeFileSync(path.join(dir, 'status.json'), JSON.stringify({
+    title: 'Converted from the backlog',
+    phase: 'tasks_generated',
+    created_at: '2026-08-25T00:00:00Z',
+    updated_at: '2026-08-25T00:10:00Z',
+    last_phase_at: '2026-08-25T00:10:00Z',
+    ...extra
+  }, null, 2));
+  return dir;
+}
+
+function readStatus(slug) {
+  return JSON.parse(fs.readFileSync(path.join(projectDir, '.frame', 'specs', slug, 'status.json'), 'utf8'));
+}
+
+test('a spec written without slug or generated_task_ids is listed, not hidden', () => {
+  writeConductorSpec('convert-backlog');
+
+  const specs = specManager.listSpecs(projectDir);
+
+  assert.equal(specs.length, 1);
+  assert.equal(specs[0].slug, 'convert-backlog');
+  assert.equal(specs[0].title, 'Converted from the backlog');
+  assert.equal(specs[0].malformed, undefined);
+});
+
+test('the repair is persisted, so the rest of Frame reads what the panel accepted', () => {
+  writeConductorSpec('convert-backlog');
+
+  specManager.listSpecs(projectDir);
+
+  const status = readStatus('convert-backlog');
+  assert.equal(status.slug, 'convert-backlog');
+  assert.deepEqual(status.generated_task_ids, []);
+  // Fields it had are untouched.
+  assert.equal(status.title, 'Converted from the backlog');
+  assert.equal(status.created_at, '2026-08-25T00:00:00Z');
+});
+
+test('an existing slug is never overwritten by the folder name', () => {
+  // A hand-renamed folder: slug and folder disagree. Rewriting the slug here
+  // would silently orphan every task carrying `source: spec:original-name:T##`.
+  writeConductorSpec('renamed-folder', { slug: 'original-name', generated_task_ids: ['task-1'] });
+
+  const specs = specManager.listSpecs(projectDir);
+
+  assert.equal(specs[0].slug, 'original-name');
+  assert.equal(readStatus('renamed-folder').slug, 'original-name');
+});
+
+test('repairSpecStatus reports what it filled and leaves valid input alone', () => {
+  const bare = { title: 'T', phase: 'draft' };
+  const repaired = specManager.repairSpecStatus(bare, 'my-spec');
+  assert.deepEqual(repaired.filled, ['slug', 'generated_task_ids']);
+  assert.equal(repaired.status.slug, 'my-spec');
+
+  const complete = { slug: 'a', title: 'T', phase: 'draft', generated_task_ids: [] };
+  const untouched = specManager.repairSpecStatus(complete, 'a');
+  assert.deepEqual(untouched.filled, []);
+  assert.equal(untouched.status, complete, 'the same object comes back, so callers skip the write');
+});
+
+test('what cannot be derived is surfaced with its reason instead of skipped', () => {
+  const dir = specDir('broken-phase');
+  fs.writeFileSync(path.join(dir, 'spec.md'), '# spec\n');
+  fs.writeFileSync(path.join(dir, 'status.json'), JSON.stringify({
+    title: 'Half written',
+    phase: 'whatever-this-is'
+  }, null, 2));
+
+  const specs = specManager.listSpecs(projectDir);
+
+  assert.equal(specs.length, 1);
+  assert.equal(specs[0].slug, 'broken-phase');
+  assert.match(specs[0].malformed, /invalid phase/);
+  assert.equal(specs[0].phase, null, 'no phase — nothing may mistake it for a live one');
+  assert.equal(specs[0].task_count, 0);
+});
+
+test('a spec folder with no readable status.json is surfaced too', () => {
+  const dir = specDir('no-status');
+  fs.writeFileSync(path.join(dir, 'spec.md'), '# spec\n');
+
+  const specs = specManager.listSpecs(projectDir);
+
+  assert.equal(specs.length, 1);
+  assert.equal(specs[0].slug, 'no-status');
+  assert.match(specs[0].malformed, /missing or unreadable/);
+});
+
+test('a directory holding no spec artifact is not a spec and stays invisible', () => {
+  const dir = specDir('.backup-of-something');
+  fs.writeFileSync(path.join(dir, 'notes.txt'), 'scratch\n');
+
+  assert.deepEqual(specManager.listSpecs(projectDir), []);
+});
+
+test('valid specs are listed exactly as before and their file is not rewritten', () => {
+  const dir = specDir('already-fine');
+  fs.writeFileSync(path.join(dir, 'spec.md'), '# spec\n');
+  fs.writeFileSync(path.join(dir, 'status.json'), JSON.stringify({
+    slug: 'already-fine',
+    title: 'Already fine',
+    phase: 'specified',
+    generated_task_ids: [],
+    created_at: '2026-08-01T00:00:00Z',
+    updated_at: '2026-08-01T00:00:00Z'
+  }, null, 2));
+  const before = fs.statSync(path.join(dir, 'status.json')).mtimeMs;
+
+  const specs = specManager.listSpecs(projectDir);
+
+  assert.equal(specs.length, 1);
+  assert.equal(specs[0].malformed, undefined);
+  assert.equal(specs[0].phase, 'specified');
+  assert.equal(fs.statSync(path.join(dir, 'status.json')).mtimeMs, before, 'no write for a valid spec');
+});
+
+test('a phase advance works on a spec that was never repaired', () => {
+  writeConductorSpec('advance-me');
+
+  const result = specManager.updateSpecStatus(projectDir, 'advance-me', { phase: 'implementing' });
+
+  assert.equal(result.error, undefined, `expected no validation error, got ${result.error}`);
+  assert.equal(result.status.phase, 'implementing');
+  assert.equal(result.status.slug, 'advance-me');
+});

--- a/test/specStatusRepair.test.js
+++ b/test/specStatusRepair.test.js
@@ -18,6 +18,25 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
+// specManager reaches two packages transitively: telemetry.js requires
+// @aptabase/electron/main, and userSettings.js requires electron. CI runs this
+// suite with no node_modules on purpose (see .github/workflows/ci.yml), so both
+// are stubbed before specManager loads — the same shim specTasksSync.test.js
+// uses. Neither is exercised here: listing and repairing a spec emits no
+// telemetry, and app.getPath is only reached from userSettings.init().
+const Module = require('node:module');
+const EXTERNAL_STUBS = {
+  '@aptabase/electron/main': { initialize() {}, trackEvent() {} },
+  electron: { app: {}, ipcMain: { handle() {}, on() {} } }
+};
+const loadOriginal = Module._load;
+Module._load = function (request, ...rest) {
+  if (Object.prototype.hasOwnProperty.call(EXTERNAL_STUBS, request)) {
+    return EXTERNAL_STUBS[request];
+  }
+  return loadOriginal.call(this, request, ...rest);
+};
+
 const specManager = require('../src/main/specManager');
 
 let projectDir;


### PR DESCRIPTION
Closes #122.

## The report, verified

The spec panel listed **none** of five spec folders created by Frame's own conductor agent, and said nothing about it. Their `status.json` carried `title`, `phase` and timestamps — the fields the staged templates name — but not `slug`, and `listSpecs` did `continue; // silently skip malformed`.

The reporter's framing is the part that matters: this was not a third-party tool guessing at our format. Frame launched the conductor, handed it `CONDUCTOR.md` and the staged spec templates, and those templates say which fields to *update* without ever stating the required shape. Meanwhile the rest of Frame accepted the same folders — the task watcher imported their tasks and wrote `generated_task_ids` back into the very file the panel rejected, and `spec-index.js` indexed them. Half of Frame agreed the specs existed; half pretended they did not.

Reproduced against the real `specManager` before changing anything:

```
validator: "missing slug"     listSpecs: []
```

**One thing the report missed:** deriving the slug is not enough. `generated_task_ids` is the validator's other required field, so a slug-only fix leaves these specs hidden:

```
slug filled in          → "generated_task_ids must be an array"
slug + generated_task_ids → valid
```

## Repair (suggestion 1)

`repairSpecStatus(status, folderName)` fills only what the folder itself answers, and only when absent: `slug` ← folder name, `generated_task_ids` ← `[]`. `listSpecs` repairs before validating and persists the result once through the existing `writeStatus` (write-if-changed, marks `lastSelfWriteAt`, so the watcher does not re-fire and later passes write nothing). `updateSpecStatus` repairs too — the same validator lives there, so before this a conductor-created spec could not even have its phase advanced.

**An existing slug is never overwritten.** Folder and slug disagreeing is a rename question; rewriting it silently would cut every `source: spec:<slug>:T##` link in `tasks.json`. There is a test whose only job is to keep that true.

## Surface (suggestion 2)

Anything still invalid after repair is listed as a **needs attention** entry carrying the validator's reason and the file's path, and logged — instead of vanishing. Such entries sort **first** (a spec needing a human should not sit under 45 healthy cards) and are inert: no phase badge, no progress bar, no click-through, no agent dispatch.

Directories holding none of `status.json` / `spec.md` / `plan.md` / `tasks.md` / `outcome.md` stay invisible — a backup folder is not a spec.

## Document (suggestion 3)

The required shape now appears in `src/templates/commands/claude-code/spec.new.md` and `src/templates/orchestration/CONDUCTOR.md`, marked required vs optional, noting that Frame repairs slug/generated_task_ids and lists anything else as needs-attention. Edited in `src/templates/` — `.frame/runtime/` is a staged copy Frame rewrites on launch, so editing that would have been silently overwritten.

## Verification

**Live, in the running app.** A conductor-shaped `status.json` appeared in the panel immediately and gained exactly `"slug"` + `"generated_task_ids": []` on disk. Two unfixable folders rendered as needs-attention cards — *"status.json **is missing or unreadable**"* and *"status.json **missing title**"* — with their paths, non-clickable, no page errors, IPC watchdog quiet.

**Found by that live check:** `specPanel.renderSpecRow` (the legacy side panel, still rendering on every `SPEC_DATA` push) threw `Cannot read properties of null (reading 'replace')` on a phase-less entry. Guarded.

**Also noted:** `reconcilePhase` already heals an invalid `phase` from the files on disk (a `"not-a-phase"` fixture healed to `specified` before validation), so the malformed path is narrower in practice than the issue implies — a missing title or an unreadable file.

**Tests:** 9 new (repair rules, slug never overwritten, stale index irrelevant, malformed surfaced with reason, non-spec folders ignored, phase advance on an unrepaired spec, and *valid specs listed identically with their file's mtime untouched*). `npm test` → **330 pass, 0 fail**.

Spec: `.frame/specs/spec-status-repair/` (spec → plan → tasks → outcome), tasks mirrored into `tasks.json`.

