### PR TITLE
fix(specs): finish the 2026-07-06 split for projects older than it

### DIFF
--- a/.frame/PROJECT_NOTES.md
+++ b/.frame/PROJECT_NOTES.md
@@ -1956,5 +1956,15 @@ maintenance ceremony inline (`## Task Management`, `## PROJECT_NOTES.md Rules`,
 root-relative meta mentions and no `.frame/` prefixes at all. So: when reasoning
 about an older generation of a Frame-written document, compare **headings
 first**; a matcher that misses may be pointing at a section that was never
-there. The pre-split document remains a real open problem — deliberately left
-to its own spec, to be diagnosed before it is decided.
+there.
+
+**Then fixed, the same day, after the diagnosis the first attempt skipped.**
+Measured across every released generation that wrote them (v1.0.0 → v2.4.0):
+the six ceremony sections are byte-identical, independent of project name and
+of the init date — the creation stamp sits in the footer, past the thematic
+break that bounds the last section. So they are matchable exactly the way the
+spec section was. `migrateLegacyCeremony` now removes all six on open and puts
+the pointer table the split intended in their place, all-or-nothing: one
+edited section and nothing is touched, because stripping five and stranding
+the sixth is worse than leaving all six. A real pre-split AGENTS.md goes from
+234 lines with 14 root-relative meta references to 48 lines with none.

--- a/.frame/STRUCTURE.json
+++ b/.frame/STRUCTURE.json
@@ -986,15 +986,22 @@
             "file"
           ]
         },
+        "migrateLegacyCeremony": {
+          "line": 878,
+          "params": [
+            "projectPath"
+          ],
+          "purpose": "Finish the 2026-07-06 split for a project created before it."
+        },
         "upgradeSpecDocs": {
-          "line": 861,
+          "line": 910,
           "params": [
             "projectPath"
           ],
           "purpose": "Upgrade the Frame-managed sections and report what could not be settled."
         },
         "appendSpecSection": {
-          "line": 944,
+          "line": 997,
           "params": [
             "projectPath",
             "rel"
@@ -1002,30 +1009,31 @@
           "purpose": "Append the managed spec section to a document the pass deliberately refused"
         },
         "docsHealthFor": {
-          "line": 983,
+          "line": 1036,
           "params": [
             "projectPath"
           ],
           "purpose": "The report on its own, without running the repair pass — what the UI asks"
         },
         "recordDocsActivity": {
-          "line": 1005,
+          "line": 1058,
           "params": [
             "written",
             "appended",
+            "ceremony",
             "report"
           ],
           "purpose": "Put the pass's result on the record. This is the half that was missing when"
         },
         "removeFrame": {
-          "line": 1040,
+          "line": 1101,
           "params": [
             "projectPath"
           ],
           "purpose": "Delete everything Frame authored in this project and forget it:"
         },
         "dropEmptySettingsFile": {
-          "line": 1094,
+          "line": 1155,
           "params": [
             "projectPath",
             "file"
@@ -1033,21 +1041,21 @@
           "purpose": "Delete a Claude settings file that now parses to `{}` — Frame wrote it to"
         },
         "isFrameOwnedHookResidue": {
-          "line": 1120,
+          "line": 1181,
           "params": [
             "text"
           ],
           "purpose": "What Frame's own pre-commit file looks like once its managed block is gone:"
         },
         "removeHookSnippet": {
-          "line": 1136,
+          "line": 1197,
           "params": [
             "projectPath"
           ],
           "purpose": "Strip Frame's marker-wrapped block from whichever pre-commit hook carries"
         },
         "setupIPC": {
-          "line": 1176,
+          "line": 1237,
           "params": [
             "ipcMain"
           ],
@@ -9301,32 +9309,32 @@
       "depends": [],
       "functions": {
         "isRegistered": {
-          "line": 280,
+          "line": 282,
           "params": [
             "name"
           ]
         },
         "kindOf": {
-          "line": 284,
+          "line": 286,
           "params": [
             "name"
           ]
         },
         "isSuppression": {
-          "line": 288,
+          "line": 290,
           "params": [
             "name"
           ]
         },
         "fieldPasses": {
-          "line": 292,
+          "line": 294,
           "params": [
             "spec",
             "value"
           ]
         },
         "validateEvent": {
-          "line": 315,
+          "line": 317,
           "params": [
             "name",
             "fields"
@@ -9334,7 +9342,7 @@
           "purpose": "Validate an (event, fields) pair against the registry."
         },
         "formatLabel": {
-          "line": 332,
+          "line": 334,
           "params": [
             "name",
             "fields"
@@ -9342,7 +9350,7 @@
           "purpose": "The one-line sentence the panel's default view shows, or null when the"
         },
         "buildRecord": {
-          "line": 353,
+          "line": 355,
           "params": [
             "name",
             "fields"
@@ -9426,6 +9434,8 @@
         "findBlock",
         "upgradeDoc",
         "appendBlock",
+        "removeLegacySections",
+        "insertBeforeFooter",
         "renderBlock",
         "BLOCK_NAME",
         "SPEC_BLOCK_NAME",
@@ -9504,16 +9514,39 @@
           ],
           "purpose": "Where a new block goes in a document that has none: before the trailing"
         },
-        "appendBlock": {
+        "insertBeforeFooter": {
           "line": 172,
           "params": [
             "text",
-            "options"
+            "body",
+            "footerMarker"
           ],
           "purpose": "Add a managed block to a document that carries none, rewriting nothing:"
         },
+        "appendBlock": {
+          "line": 184,
+          "params": [
+            "text",
+            "options"
+          ]
+        },
+        "collapseSeparators": {
+          "line": 199,
+          "params": [
+            "text"
+          ],
+          "purpose": "Two thematic breaks with nothing between them, and runs of blank lines, are"
+        },
+        "removeLegacySections": {
+          "line": 223,
+          "params": [
+            "text",
+            "matchers"
+          ],
+          "purpose": "Remove whole sections Frame itself shipped and has since moved elsewhere."
+        },
         "upgradeDoc": {
-          "line": 210,
+          "line": 271,
           "params": [
             "text",
             "options"
@@ -9562,6 +9595,8 @@
         "getQuickstartTemplate",
         "getFrameConfigTemplate",
         "getClaudeRuleTemplate",
+        "METAFILES_SECTION",
+        "LEGACY_AGENTS_CEREMONY",
         "getFrameGitignoreBlock",
         "FRAME_GITIGNORE_MARKER_START",
         "FRAME_GITIGNORE_MARKER_END",
@@ -9609,28 +9644,28 @@
           "line": 304
         },
         "formatProjectFacts": {
-          "line": 325,
+          "line": 496,
           "params": [
             "project"
           ],
           "purpose": "Render the Project Facts section for AGENTS.md from the detected project"
         },
         "getAgentsTemplate": {
-          "line": 354,
+          "line": 525,
           "params": [
             "projectName",
             "options"
           ]
         },
         "getReferenceTemplate": {
-          "line": 453,
+          "line": 610,
           "params": [
             "projectName"
           ],
           "purpose": "REFERENCE.md template — the reference-on-demand companion to the lean"
         },
         "getStructureTemplate": {
-          "line": 629,
+          "line": 786,
           "params": [
             "projectName",
             "project"
@@ -9638,21 +9673,21 @@
           "purpose": "STRUCTURE.json template"
         },
         "getNotesTemplate": {
-          "line": 654,
+          "line": 811,
           "params": [
             "projectName"
           ],
           "purpose": "PROJECT_NOTES.md template"
         },
         "getTasksTemplate": {
-          "line": 674,
+          "line": 831,
           "params": [
             "projectName"
           ],
           "purpose": "tasks.json template"
         },
         "getQuickstartTemplate": {
-          "line": 720,
+          "line": 877,
           "params": [
             "projectName",
             "project"
@@ -9660,28 +9695,28 @@
           "purpose": "QUICKSTART.md template"
         },
         "getFrameConfigTemplate": {
-          "line": 801,
+          "line": 958,
           "params": [
             "projectName"
           ],
           "purpose": ".frame/config.json template"
         },
         "getClaudeRuleTemplate": {
-          "line": 844,
+          "line": 1001,
           "params": [
             "agentsText"
           ],
           "purpose": "`.claude/rules/frame.md` — the file Claude Code loads at session start."
         },
         "getFrameGitignoreBlock": {
-          "line": 859
+          "line": 1016
         },
         "getCodexWrapperTemplate": {
-          "line": 916,
+          "line": 1073,
           "purpose": "Codex CLI wrapper script"
         },
         "getGenericWrapperTemplate": {
-          "line": 953,
+          "line": 1110,
           "params": [
             "toolCommand",
             "promptFlag = ''"
@@ -9689,27 +9724,27 @@
           "purpose": "Generic AI tool wrapper template"
         },
         "getStructureHookSnippet": {
-          "line": 999
+          "line": 1156
         },
         "getStructurePreCommitHookTemplate": {
-          "line": 1038,
+          "line": 1195,
           "purpose": "Full pre-commit hook file content for the \"no existing hook\" case."
         },
         "getOrchBusHeader": {
-          "line": 1061,
+          "line": 1218,
           "purpose": "Orchestration command-channel scripts (.frame/bin/)"
         },
         "getOrchRequestScript": {
-          "line": 1073,
+          "line": 1230,
           "params": [
             "type"
           ]
         },
         "getOrchStatusScript": {
-          "line": 1093
+          "line": 1250
         },
         "getOrchBinScripts": {
-          "line": 1111,
+          "line": 1268,
           "purpose": "Map of filename → script body for the orchestration bin scripts. The"
         }
       }

--- a/src/main/frameProject.js
+++ b/src/main/frameProject.js
@@ -853,6 +853,55 @@ function readTextOrNull(file) {
 }
 
 /**
+ * Finish the 2026-07-06 split for a project created before it.
+ *
+ * That change moved the whole maintenance ceremony — Task Management,
+ * PROJECT_NOTES.md Rules, Context Preservation, STRUCTURE.json Rules,
+ * QUICKSTART.md Rules, General Rules — out of AGENTS.md and into
+ * `.frame/docs/REFERENCE.md`, leaving a pointer table in its place. It applied
+ * to projects created afterwards and to nobody else, because AGENTS.md belongs
+ * to the project, not to Frame.
+ *
+ * So a project created before it still carries all six sections inline, naming
+ * `tasks.json` and `PROJECT_NOTES.md` at the project root — where they have not
+ * been since the `.frame/` move. That is not a cosmetic staleness: AGENTS.md is
+ * the always-on document, so the copy an agent reads every session is the wrong
+ * one, and a task it dutifully adds to a root `tasks.json` is a task Frame never
+ * reads back (`frameStore.resolvePath` is overlay-first, and the root fallback
+ * needs the `config.files` record that migration removes).
+ *
+ * Safe because the six sections are constants: verified byte-identical across
+ * every released generation that wrote them (v1.0.0 → v2.4.0), independent of
+ * project name and init date. All six must match or nothing is removed — see
+ * `removeLegacySections`.
+ */
+function migrateLegacyCeremony(projectPath) {
+  const file = frameStore.resolvePath(projectPath, FRAME_FILES.AGENTS);
+  const text = readTextOrNull(file);
+  if (text === null) return { changed: false, matched: 0, total: 0 };
+
+  const result = docsManagedBlock.removeLegacySections(text, templates.LEGACY_AGENTS_CEREMONY);
+  const outcome = { changed: false, matched: result.matched, total: result.total };
+  if (result.text === null) return outcome;
+
+  // What the split put in their place, from the same constant the template
+  // uses — so a migrated document ends up shaped like a freshly written one.
+  const next = docsManagedBlock.insertBeforeFooter(
+    result.text,
+    templates.METAFILES_SECTION,
+    FRAME_DOC_FOOTER
+  );
+  try {
+    fs.writeFileSync(file, next, 'utf8');
+  } catch (err) {
+    console.warn('[frame] could not finish the split for AGENTS.md (non-fatal):', err.message);
+    return outcome;
+  }
+  outcome.changed = true;
+  return outcome;
+}
+
+/**
  * Upgrade the Frame-managed sections and report what could not be settled.
  * Returns the docsHealth report (or null when this is not a Frame project),
  * so the caller can record and surface a broken invariant rather than let it
@@ -860,6 +909,10 @@ function readTextOrNull(file) {
  */
 function upgradeSpecDocs(projectPath) {
   if (!projectPath || !isFrameProject(projectPath)) return null;
+
+  // Finish the split first, so everything below surveys the document the
+  // agent will actually read rather than the previous generation of it.
+  const ceremony = migrateLegacyCeremony(projectPath);
 
   const descriptors = specDocDescriptors(projectPath);
   const exists = (rel) => fs.existsSync(path.join(projectPath, rel));
@@ -924,7 +977,7 @@ function upgradeSpecDocs(projectPath) {
   syncClaudeRule(projectPath); // an upgraded AGENTS.md means a stale copy
 
   const after = survey();
-  recordDocsActivity(written, appended, after);
+  recordDocsActivity(written, appended, ceremony, after);
   return after;
 }
 
@@ -1002,14 +1055,22 @@ function docsHealthFor(projectPath) {
  * project that stays broken is reopened every day, and three lines an open is
  * a report, while thirty is noise nobody reads.
  */
-function recordDocsActivity(written, appended, report) {
+function recordDocsActivity(written, appended, ceremony, report) {
   const emit = (name, fields) => {
     try {
       activityLog.record(name, fields);
     } catch (_) { /* bookkeeping never breaks an open */ }
   };
 
-  if (written > 0) emit('docs.repaired', { docs: written, appended });
+  if (written > 0 || ceremony.changed) {
+    emit('docs.repaired', { docs: written + (ceremony.changed ? 1 : 0), appended });
+  }
+
+  // A pre-split document whose ceremony someone edited: Frame will not strip
+  // five of six sections and strand the sixth, so it says so instead.
+  if (!ceremony.changed && ceremony.matched > 0) {
+    emit('docs.degraded', { reason: 'legacy-ceremony', count: ceremony.matched });
+  }
 
   const groups = [
     ['missing-path', report.missingPaths.map((m) => m.path)],

--- a/src/shared/activityEvents.js
+++ b/src/shared/activityEvents.js
@@ -62,7 +62,8 @@ const HOSTS = ['app', 'claude-hook', 'git-precommit', 'orch-bus', 'cli'];
 const DOCS_DEGRADED_REASONS = [
   'missing-path', // the prose names a file that is not on disk
   'unmatched-section', // a section Frame cannot prove is its own — never written over
-  'unreadable' // the document itself could not be read
+  'unreadable', // the document itself could not be read
+  'legacy-ceremony' // a pre-split AGENTS.md whose maintenance sections were edited
 ];
 
 // Field types. Kept deliberately narrow: enums, numbers, and the two string
@@ -246,7 +247,8 @@ const HINT_REASON_TEXT = {
 const DOCS_DEGRADED_TEXT = {
   'missing-path': 'An agent doc points at a file that is not there',
   'unmatched-section': 'A doc carries its own spec section — left untouched',
-  unreadable: 'An agent doc could not be read'
+  unreadable: 'An agent doc could not be read',
+  'legacy-ceremony': "AGENTS.md still carries the pre-split maintenance rules, edited — left as it is"
 };
 
 const MIGRATION_SKIP_TEXT = {

--- a/src/shared/docsManagedBlock.js
+++ b/src/shared/docsManagedBlock.js
@@ -169,6 +169,18 @@ function firstFooterIndex(text, footerMarker) {
  *
  * Returns null on the same invalid inputs `upgradeDoc` rejects.
  */
+function insertBeforeFooter(text, body, footerMarker) {
+  const footerIdx = firstFooterIndex(text, footerMarker);
+  if (footerIdx >= 0) {
+    // Drop the separator that preceded the footer so the inserted text does
+    // not leave two rules stacked on each other.
+    const head = text.slice(0, footerIdx).replace(/\n*(-{3,}[ \t]*\n)?\s*$/, '');
+    const tail = text.slice(footerIdx);
+    return `${head}\n\n---\n\n${body}\n\n---\n\n${tail}`;
+  }
+  return `${text.replace(/\n*$/, '')}\n\n---\n\n${body}\n`;
+}
+
 function appendBlock(text, options) {
   if (typeof text !== 'string' || !options || typeof options.body !== 'string') return null;
   const version = options.version;
@@ -176,16 +188,65 @@ function appendBlock(text, options) {
 
   const blockName = options.blockName || SPEC_BLOCK_NAME;
   const rendered = renderBlock(options.body, version, blockName);
-  const footerIdx = firstFooterIndex(text, options.footerMarker);
+  return insertBeforeFooter(text, rendered, options.footerMarker);
+}
 
-  if (footerIdx >= 0) {
-    // Drop the separator that preceded the footer so the inserted block does
-    // not leave two rules stacked on each other.
-    const head = text.slice(0, footerIdx).replace(/\n*(-{3,}[ \t]*\n)?\s*$/, '');
-    const tail = text.slice(footerIdx);
-    return `${head}\n\n---\n\n${rendered}\n\n---\n\n${tail}`;
+/**
+ * Two thematic breaks with nothing between them, and runs of blank lines, are
+ * what removing a section leaves behind. Collapsed only where the separators
+ * are genuinely adjacent, so a `---` inside a fenced block is never touched.
+ */
+function collapseSeparators(text) {
+  let out = text;
+  let previous;
+  do {
+    previous = out;
+    out = out.replace(/\n-{3,}[ \t]*\n\s*\n-{3,}[ \t]*\n/g, '\n---\n');
+  } while (out !== previous);
+  return out.replace(/\n{3,}/g, '\n\n');
+}
+
+/**
+ * Remove whole sections Frame itself shipped and has since moved elsewhere.
+ *
+ * Unlike an upgrade, this deletes rather than replaces, so the confidence gate
+ * is stricter: **every** matcher must pass or nothing is removed. A document
+ * where five of six sections are Frame's and the sixth was edited is a
+ * document someone worked on, and stripping the five would leave their one
+ * section stranded among prose that no longer surrounds it.
+ *
+ * Returns `{ text, matched, total }` — `text` is null unless every matcher
+ * hit, and `matched` lets the caller tell "not this generation at all" (0)
+ * apart from "this generation, edited" (between 1 and total), which are
+ * different things to say to a user.
+ */
+function removeLegacySections(text, matchers) {
+  const list = Array.isArray(matchers) ? matchers : [];
+  const result = { text: null, matched: 0, total: list.length };
+  if (typeof text !== 'string' || list.length === 0) return result;
+
+  const spans = [];
+  for (const matcher of list) {
+    const span = findLegacySpan(text, matcher);
+    if (span) {
+      spans.push(span);
+      result.matched += 1;
+    }
   }
-  return `${text.replace(/\n*$/, '')}\n\n---\n\n${rendered}\n`;
+  if (result.matched !== result.total) return result;
+
+  // Back to front, so earlier offsets stay valid as later spans go.
+  spans.sort((a, b) => b.start - a.start);
+  let out = text;
+  let lastStart = Infinity;
+  for (const span of spans) {
+    if (span.end > lastStart) return result; // overlapping matches — refuse
+    lastStart = span.start;
+    out = out.slice(0, span.start) + out.slice(span.end);
+  }
+
+  result.text = collapseSeparators(out);
+  return result;
 }
 
 /**
@@ -243,6 +304,8 @@ module.exports = {
   findBlock,
   upgradeDoc,
   appendBlock,
+  removeLegacySections,
+  insertBeforeFooter,
   renderBlock,
   BLOCK_NAME,
   SPEC_BLOCK_NAME,

--- a/src/shared/frameTemplates.js
+++ b/src/shared/frameTemplates.js
@@ -318,6 +318,177 @@ function renderSpecCoreSection() {
  *               opted out must not get the section back on re-emit.
  */
 /**
+ * The pointer table the 2026-07-06 split put in place of the maintenance
+ * ceremony it moved to REFERENCE.md. Held as a constant so the template and
+ * the pre-split migration emit exactly the same text.
+ */
+/**
+ * The six maintenance sections every pre-split AGENTS.md carries, frozen
+ * byte-for-byte. Verified identical across every released generation that
+ * wrote them — v1.0.0 through v2.4.0, 2026-02-18 to 06-24 — and independent
+ * of the project name and of the init date (the creation stamp lives in the
+ * footer, past the thematic break that bounds the last section).
+ *
+ * The 2026-07-06 split moved all of this into .frame/docs/REFERENCE.md and
+ * left a pointer table in its place, but only for projects created after it.
+ * These matchers are how a project created before it gets the same treatment.
+ * Never edit them — they must match what older Frames actually wrote.
+ */
+const LEGACY_AGENTS_CEREMONY = [
+  `## Task Management (tasks.json)
+
+### Task Recognition Rules
+
+**These ARE TASKS - add to tasks.json:**
+- When the user requests a feature or change
+- Decisions like "Let's do this", "Let's add this", "Improve this"
+- Deferred work when we say "We'll do this later", "Let's leave it for now"
+- Gaps or improvement opportunities discovered while coding
+- Situations requiring bug fixes
+
+**These are NOT TASKS:**
+- Error messages and debugging sessions
+- Questions, explanations, information exchange
+- Temporary experiments and tests
+- Work already completed and closed
+- Instant fixes (like typo fixes)
+
+### Task Creation Flow
+
+1. Detect task patterns during conversation
+2. Ask the user at an appropriate moment: "I identified these tasks from our conversation, should I add them to tasks.json?"
+3. If the user approves, add to tasks.json
+
+### Task Structure
+
+\`\`\`json
+{
+  "id": "unique-id",
+  "title": "Short and clear title",
+  "description": "Detailed explanation",
+  "status": "pending | in_progress | completed",
+  "priority": "high | medium | low",
+  "context": "Where/how this task originated",
+  "createdAt": "ISO date",
+  "updatedAt": "ISO date",
+  "completedAt": "ISO date | null"
+}
+\`\`\`
+
+### Task Status Updates
+
+- When starting work on a task: \`status: "in_progress"\`
+- When task is completed: \`status: "completed"\`, update \`completedAt\`
+- After commit: Check and update the status of related tasks`,
+  `## PROJECT_NOTES.md Rules
+
+### When to Update?
+- When an important architectural decision is made
+- When a technology choice is made
+- When an important problem is solved and the solution method is noteworthy
+- When an approach is determined together with the user
+
+### Format
+Free format. Date + title is sufficient:
+\`\`\`markdown
+### [2026-01-26] Topic title
+Conversation/decision as is, with its context...
+\`\`\`
+
+### Update Flow
+- Update immediately after a decision is made
+- You can add without asking the user (for important decisions)
+- You can accumulate small decisions and add them in bulk`,
+  `## 📝 Context Preservation (Automatic Note Taking)
+
+Frame's core purpose is to prevent context loss. Therefore, capture important moments and ask the user.
+
+### When to Ask?
+
+Ask the user when one of the following situations occurs: **"Should I add this conversation to PROJECT_NOTES.md?"**
+
+- When a task is successfully completed
+- When an important architectural/technical decision is made
+- When a bug is fixed and the solution method is noteworthy
+- When "let's do this later" is said (in this case, also add to tasks.json)
+- When a new pattern or best practice is discovered
+
+### Completion Detection
+
+Pay attention to these signals:
+- User approval: "okay", "done", "it worked", "nice", "fixed", "yes"
+- Moving from one topic to another
+- User continuing after build/run succeeds
+
+### How to Add?
+
+1. **DON'T write a summary** - Add the conversation as is, with its context
+2. **Add date** - In \`### [YYYY-MM-DD] Title\` format
+3. **Add to Session Notes section** - At the end of PROJECT_NOTES.md
+
+### When NOT to Ask
+
+- For every small change (it becomes spam)
+- Typo fixes, simple corrections
+- If the user already said "no" or "not needed", don't ask again for the same topic in that session
+
+### If User Says "No"
+
+No problem, continue. The user can also say what they consider important themselves: "add this to notes"`,
+  `## STRUCTURE.json Rules
+
+**This file is the map of the codebase.**
+
+### When to Update?
+- When a new file/folder is created
+- When a file/folder is deleted or moved
+- When module dependencies change
+- When an important architectural pattern is discovered (architectureNotes)
+
+### Format
+\`\`\`json
+{
+  "modules": {
+    "moduleName": {
+      "path": "src/module",
+      "purpose": "What this module does",
+      "depends": ["otherModule"]
+    }
+  },
+  "architectureNotes": {}
+}
+\`\`\``,
+  `## QUICKSTART.md Rules
+
+### When to Update?
+- When installation steps change
+- When new requirements are added
+- When important commands change`,
+  `## General Rules
+
+1. **Language:** Write documentation in English (except code examples)
+2. **Date Format:** ISO 8601 (YYYY-MM-DDTHH:mm:ssZ)
+3. **After Commit:** Check tasks.json and STRUCTURE.json
+4. **Session Start:** Review pending tasks in tasks.json`,
+];
+
+const METAFILES_SECTION = `## Writing Frame meta files — read the reference first
+
+| Before writing…              | Read in \`.frame/docs/REFERENCE.md\` |
+| ---------------------------- | ------------------------------------ |
+| \`.frame/tasks.json\`          | "Task Management" (schema + rules)   |
+| \`.frame/PROJECT_NOTES.md\`    | "PROJECT_NOTES.md Rules"             |
+| \`.frame/STRUCTURE.json\`      | "STRUCTURE.json Rules"               |
+| \`.frame/QUICKSTART.md\`       | "QUICKSTART.md Rules"                |
+
+Quick reminders that always apply:
+- Task work: \`status: "in_progress"\` when starting, \`"completed"\` +
+  \`completedAt\` when done; re-check statuses after commits.
+- Important decisions: append to \`.frame/PROJECT_NOTES.md\` as
+  \`### [YYYY-MM-DD] Title\` with the conversation's context (not a summary).
+- Documentation in English; dates in ISO 8601.`;
+
+/**
  * Render the Project Facts section for AGENTS.md from the detected project
  * block. The section exists even without detection — its job is to make the
  * agent RECORD the user's real stack, not to celebrate Frame's bookkeeping.
@@ -414,21 +585,7 @@ ${renderSpecCoreSection()}
 
 ` : ''}---
 
-## Writing Frame meta files — read the reference first
-
-| Before writing…              | Read in \`.frame/docs/REFERENCE.md\` |
-| ---------------------------- | ------------------------------------ |
-| \`.frame/tasks.json\`          | "Task Management" (schema + rules)   |
-| \`.frame/PROJECT_NOTES.md\`    | "PROJECT_NOTES.md Rules"             |
-| \`.frame/STRUCTURE.json\`      | "STRUCTURE.json Rules"               |
-| \`.frame/QUICKSTART.md\`       | "QUICKSTART.md Rules"                |
-
-Quick reminders that always apply:
-- Task work: \`status: "in_progress"\` when starting, \`"completed"\` +
-  \`completedAt\` when done; re-check statuses after commits.
-- Important decisions: append to \`.frame/PROJECT_NOTES.md\` as
-  \`### [YYYY-MM-DD] Title\` with the conversation's context (not a summary).
-- Documentation in English; dates in ISO 8601.
+${METAFILES_SECTION}
 
 ---
 
@@ -1126,6 +1283,8 @@ module.exports = {
   getQuickstartTemplate,
   getFrameConfigTemplate,
   getClaudeRuleTemplate,
+  METAFILES_SECTION,
+  LEGACY_AGENTS_CEREMONY,
   getFrameGitignoreBlock,
   FRAME_GITIGNORE_MARKER_START,
   FRAME_GITIGNORE_MARKER_END,

--- a/test/docsManagedBlock.test.js
+++ b/test/docsManagedBlock.test.js
@@ -308,3 +308,68 @@ test('append rejects the same invalid inputs upgradeDoc does', () => {
   assert.equal(appendBlock('# Doc', { body: NEW_BODY, version: 1.5 }), null);
   assert.equal(appendBlock('# Doc', { version: 2 }), null);
 });
+
+// ─── Removing sections Frame has since moved elsewhere ────────
+
+const { removeLegacySections } = require('../src/shared/docsManagedBlock');
+
+const SEC_A = '## Alpha Rules\n\nFirst shipped section.';
+const SEC_B = '## Beta Rules\n\nSecond shipped section.';
+
+const threeSectionDoc = `# Doc
+
+Intro.
+
+---
+
+${SEC_A}
+
+---
+
+${SEC_B}
+
+---
+
+## The User's Own
+
+Theirs.
+
+---
+
+${FOOTER}
+`;
+
+test('every matcher must hit, or nothing is removed', () => {
+  const both = removeLegacySections(threeSectionDoc, [SEC_A, SEC_B]);
+  assert.equal(both.matched, 2);
+  assert.ok(both.text);
+  assert.ok(!both.text.includes('First shipped section.'));
+  assert.ok(!both.text.includes('Second shipped section.'));
+  // Everything that was not matched survives.
+  assert.ok(both.text.includes("## The User's Own"));
+  assert.ok(both.text.includes('Intro.'));
+  assert.ok(both.text.includes(FOOTER));
+
+  // One section edited: five-of-six is exactly the case that must not fire,
+  // because stripping the rest strands the one the user worked on.
+  const edited = threeSectionDoc.replace('Second shipped section.', 'Mine now.');
+  const partial = removeLegacySections(edited, [SEC_A, SEC_B]);
+  assert.equal(partial.text, null);
+  assert.equal(partial.matched, 1);
+  assert.equal(partial.total, 2);
+  // `matched` is what separates "not this generation" from "this one, edited".
+  assert.equal(removeLegacySections('# Unrelated\n\nProse.', [SEC_A, SEC_B]).matched, 0);
+});
+
+test('removal leaves no stacked separators or blank-line runs', () => {
+  const { text } = removeLegacySections(threeSectionDoc, [SEC_A, SEC_B]);
+  assert.ok(!/-{3,}[ \t]*\n\s*\n-{3,}/.test(text), 'two rules left stacked');
+  assert.ok(!/\n{3,}/.test(text), 'blank-line run left behind');
+});
+
+test('removal refuses non-strings, empty matcher lists and unknown sections', () => {
+  assert.equal(removeLegacySections(null, [SEC_A]).text, null);
+  assert.equal(removeLegacySections(threeSectionDoc, []).text, null);
+  assert.equal(removeLegacySections(threeSectionDoc, []).total, 0);
+  assert.equal(removeLegacySections(threeSectionDoc, ['## Nope\n\nNever shipped.']).text, null);
+});

--- a/test/specDocsUpgrade.test.js
+++ b/test/specDocsUpgrade.test.js
@@ -383,3 +383,120 @@ test('a value outside the declared reasons is stripped rather than recorded', ()
   assert.equal(record.reason, undefined);
   assert.equal(record.count, 1);
 });
+
+// ─── Finishing the 2026-07-06 split for a project older than it ──
+//
+// A pre-split AGENTS.md carries the whole maintenance ceremony inline, naming
+// `tasks.json` and `PROJECT_NOTES.md` at the project root — where they have
+// not been since the `.frame/` move. AGENTS.md is the always-on document, so
+// that is the copy an agent reads every session.
+
+const CEREMONY = templates.LEGACY_AGENTS_CEREMONY;
+
+function preSplitFull() {
+  return `# demo - Frame Project
+
+Intro prose the user wrote.
+
+---
+
+${CEREMONY[0]}
+
+---
+
+${templates.LEGACY_SPEC_DRIVEN_SECTION}
+
+---
+
+${CEREMONY.slice(1).join('\n\n---\n\n')}
+
+---
+
+*This file was automatically created by Frame.*
+*Creation date: 2026-04-12*
+`;
+}
+
+test('the frozen ceremony is what pre-split Frames actually wrote', () => {
+  // Six sections, and none of them parameterized — the property the whole
+  // byte-match gate rests on. A generation that interpolated the project name
+  // or the init date could never be matched this way.
+  assert.equal(CEREMONY.length, 6);
+  for (const section of CEREMONY) {
+    assert.ok(/^## /.test(section));
+    assert.ok(!section.includes('${'));
+    assert.ok(!/\bdemo\b/.test(section));
+  }
+});
+
+test('opening a pre-split project finishes the split', () => {
+  const dir = makeProject({ agents: preSplitFull() });
+  const before = read(agentsPath(dir));
+  assert.ok(before.includes('## Task Management (tasks.json)'));
+  assert.ok(before.includes('## General Rules'));
+
+  open(dir);
+
+  const agents = read(agentsPath(dir));
+  // The ceremony is gone…
+  for (const section of CEREMONY) {
+    const heading = section.split('\n')[0];
+    assert.ok(!agents.includes(heading), `${heading} survived`);
+  }
+  // …replaced by the pointer table the split put in its place…
+  assert.ok(agents.includes('## Writing Frame meta files'));
+  assert.ok(agents.includes('`.frame/tasks.json`'));
+  // …the spec flow is settled…
+  assert.ok(!agents.includes(STALE_MARKER));
+  assert.ok(managedBlock.findBlock(agents));
+  // …and the user's own prose and the footer are untouched.
+  assert.ok(agents.includes('Intro prose the user wrote.'));
+  assert.ok(agents.includes('*Creation date: 2026-04-12*'));
+  assert.ok(!/\n{3,}/.test(agents));
+});
+
+test('a second open changes nothing — the migration is idempotent', () => {
+  const dir = makeProject({ agents: preSplitFull() });
+  open(dir);
+  const settled = read(agentsPath(dir));
+  open(dir);
+  assert.equal(read(agentsPath(dir)), settled);
+});
+
+test('an edited ceremony is left entirely alone', () => {
+  // One section the user rewrote. Frame will not strip the other five and
+  // strand theirs among prose that no longer surrounds it.
+  const edited = preSplitFull().replace(
+    '## QUICKSTART.md Rules',
+    '## QUICKSTART.md Rules (our version)'
+  );
+  const dir = makeProject({ agents: edited });
+
+  open(dir);
+
+  const agents = read(agentsPath(dir));
+  assert.ok(agents.includes('## Task Management (tasks.json)'));
+  assert.ok(agents.includes('## QUICKSTART.md Rules (our version)'));
+  assert.ok(!agents.includes('## Writing Frame meta files'));
+  // The spec flow is still repaired — the two are independent spans.
+  assert.ok(!agents.includes(STALE_MARKER));
+});
+
+test('a post-split project is not touched by the ceremony migration', () => {
+  const agents = `# demo
+
+Intro.
+
+---
+
+${templates.renderSpecCoreSection()}
+
+---
+
+*This file was automatically created by Frame.*
+`;
+  const dir = makeProject({ agents, reference: currentReference });
+  const before = read(agentsPath(dir));
+  open(dir);
+  assert.equal(read(agentsPath(dir)), before);
+});


### PR DESCRIPTION
Follow-up to #126, which fixed the spec flow for pre-split projects and deliberately left this part out — I wanted to diagnose it before deciding, having got that order wrong once already in that PR.

## What is wrong

The 2026-07-06 split moved the maintenance ceremony — Task Management, PROJECT_NOTES.md Rules, Context Preservation, STRUCTURE.json Rules, QUICKSTART.md Rules, General Rules — out of `AGENTS.md` into `.frame/docs/REFERENCE.md`, leaving a pointer table in its place. It applied to projects created afterwards and to nobody else, because `AGENTS.md` belongs to the project, not to Frame.

So a project created before it (v1.0.0 → v2.4.0, Feb–Jun 2026) still carries all six sections inline, naming `tasks.json` and `PROJECT_NOTES.md` at the project root — where they have not been since the `.frame/` move.

This is not cosmetic staleness. `AGENTS.md` is the **always-on** document, loaded every session through `.claude/rules/frame.md`, while `REFERENCE.md` is read on demand. So the copy an agent reads every time is the wrong one, and the correct one is the one it has to go looking for. Concretely: an agent follows "add to `tasks.json`", writes a root `tasks.json`, and Frame never reads it back — `frameStore.resolvePath` is overlay-first, and the root fallback needs the `config.files` record that migration removes. The task disappears with no error anywhere.

## The diagnosis, before the decision

Measured across every released generation that wrote them — v1.0.0, v2.0.0, v2.0.5, v2.1.2, v2.2.2, v2.3.0, v2.4.0:

```
sections: 6   hash:d2553eb346   stable across project names: true   any date: false
```

Identical in all seven. The one thing that looked like a blocker — a `2026-…` creation stamp — turned out to sit in the **footer**, past the thematic break that already bounds the last section, so it never enters a matcher. Frozen constants verified to round-trip byte-exact and to hit **6/6** on a real pre-split document.

That check is the step the navigation-block attempt in #126 skipped, which is why it was reversed mid-implementation.

## What this does

`migrateLegacyCeremony` removes the six sections on project open and inserts the pointer table the split intended, from the same constant the template uses — so a migrated document ends up shaped like a freshly written one.

**All-or-nothing.** `removeLegacySections` deletes rather than replaces, so its confidence gate is stricter than an upgrade's: every matcher must pass or nothing is removed. One edited section and the document is left entirely alone, because stripping the other five would strand the one someone worked on. `matched` separates "not this generation at all" (silent) from "this generation, edited" (reported as `docs.degraded` with a new `legacy-ceremony` reason).

`METAFILES_SECTION` is extracted from the template so both paths emit the same text; new-project output is asserted byte-identical, so the extraction is a pure refactor.

## Result

On a real pre-split project:

| | lines | root-relative meta refs | `.frame/` refs |
| --- | --- | --- | --- |
| before | 234 | 14 | 0 |
| after | 48 | 0 | 5 |

Idempotent on a second open. 376/376 tests, including: the frozen ceremony is unparameterized, the migration is idempotent, an edited ceremony is left entirely alone, a post-split project is untouched, and removal leaves no stacked separators.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DoJ4dNnADy9kY7WfqhHG38