### PR TITLE
fix(terminal-ipc): stop the watchdog crying wolf over agent stdin

### DIFF
--- a/.frame/PROJECT_NOTES.md
+++ b/.frame/PROJECT_NOTES.md
@@ -1958,3 +1958,71 @@ about an older generation of a Frame-written document, compare **headings
 first**; a matcher that misses may be pointing at a section that was never
 there. The pre-split document remains a real open problem — deliberately left
 to its own spec, to be diagnosed before it is decided.
+
+### [2026-08-26] The "98 IPC msg/s" warning was not a render loop — terminal stdin is chatty by nature
+
+Kaan reported the watchdog toast during ordinary use:
+`98 IPC msg/s sustained for 5s — top: out:terminal-input-id ×274,
+in:terminal-output-id ×217`, and asked what was causing it.
+
+It was not a loop in Frame. The evidence was sitting in
+`~/.frame/prompts/sample-project.log`, which records every byte that reaches
+a PTY's stdin. Parsing the last 2MB of it:
+
+| stdin traffic | count |
+| --- | --- |
+| `ESC[?<row>;<col>R` — cursor-position reply | 198,590 |
+| `ESC[<35;x;y M` — SGR mouse motion report | 9,261 |
+| `ESC[I` / `ESC[O` — focus in/out | 973 |
+| DA and other CSI replies | 11 |
+
+95% of "input" is xterm **answering the foreground TUI**. An agent TUI asks
+`ESC[?6n` on every render; the two most frequent answers were `row=39,col=3`
+(×87,527) and `row=36,col=3` (×66,050), alternating — two queries per frame.
+That explains both directions and the ratio: output is capped by ptyManager's
+16ms flush (~43/s observed), and the replies track it at ~1.26 each.
+
+Four things came out of that, all shipped together:
+
+1. **Input had never been coalesced.** Output was batched during
+   resize-storm-watchdog; stdin still cost one IPC per chunk. New
+   `src/renderer/terminalInput.js` is now the single renderer→stdin path
+   (also fixing ordering by construction, since `sendCommand` and
+   `terminalSendPromptThenEnter` used to race `onData` in principle). The
+   window is a **microtask, deliberately not a timer**: a TUI blocks its own
+   frame waiting for the answer, so holding replies for even one display
+   frame would slow the thing producing them. It merges what xterm emits
+   while parsing one output flush — the 274-vs-217 surplus — and nothing else.
+   Honest size: ~20%, not the fix.
+
+2. **The watchdog was miscalibrated, and that was the real fix.** Terminal
+   stdin/stdout are the one pair of channels whose legitimate rate is set by
+   something other than Frame. They now have their own threshold (1500/window
+   ≈ 300/s) while Frame's own channels keep the original 300/window that
+   caught the 2026-08-20 incident. Below the terminal bar the line is still
+   written to `main.log` — nothing is blinded — but no red toast. The toast
+   also stopped asserting "A render loop is the usual cause"; in this case it
+   sent the investigation the wrong way.
+
+3. **The report now names the payload, not just the channel.** This
+   investigation cost an afternoon because "out:terminal-input-id ×274" says
+   nothing about what those bytes were, and the answer was only recoverable
+   from the prompt history by accident. The line now reads
+   `— stdin: cursor-report ×274`.
+
+4. **`_sendResize` fired on unchanged geometry.** Fitting makes xterm rewrite
+   its own DOM, which re-fires the pane's ResizeObserver, which fits again —
+   a settled layout produced a steady stream of no-op resizes
+   (`out:terminal-resize-id ×30` in one window). It now sends only on change.
+
+**Separate bug found on the way in:** `promptLogger` was feeding these
+control replies into the prompt history. Dropping the bare ESC byte
+(`charCode < 32`) was not enough — the printable tail `[?39;3R` still landed
+in the buffer, so every real prompt was written prefixed with tens of
+thousands of junk characters. One line measured 48,886 characters holding 71
+characters of actual prompt, and `sample-project.log` had reached 1.5MB.
+`logInput` now consumes whole escape sequences with a scanner whose state
+carries across chunks (a reply can be split between two writes). Arrow keys
+were polluting prompts the same way and are fixed by the same change.
+
+The existing polluted history files were left alone — user data, Kaan's call.

--- a/.frame/STRUCTURE.json
+++ b/.frame/STRUCTURE.json
@@ -2908,32 +2908,40 @@
       ],
       "functions": {
         "init": {
-          "line": 29,
+          "line": 33,
           "params": [
             "app"
           ],
           "purpose": "Initialize prompt logger"
         },
         "setProject": {
-          "line": 44,
+          "line": 48,
           "params": [
             "projectPath"
           ],
           "purpose": "Set active project — switches log file to project-specific path"
         },
         "getLogFilePath": {
-          "line": 53,
+          "line": 57,
           "purpose": "Get log file path"
         },
         "logInput": {
-          "line": 61,
+          "line": 73,
           "params": [
             "data"
           ],
           "purpose": "Process and log input data"
         },
+        "_consumeEscape": {
+          "line": 112,
+          "params": [
+            "state",
+            "char"
+          ],
+          "purpose": "One step of the escape-sequence scanner. Returns the next state; 'text'"
+        },
         "appendAndRotate": {
-          "line": 89,
+          "line": 138,
           "params": [
             "filePath",
             "entry"
@@ -2941,18 +2949,18 @@
           "purpose": "Append a line, then rotate past the cap: the live file moves to"
         },
         "getHistory": {
-          "line": 102,
+          "line": 151,
           "purpose": "Get prompt history (live file only — bounded by MAX_LOG_SIZE)"
         },
         "setupIPC": {
-          "line": 116,
+          "line": 165,
           "params": [
             "ipcMain"
           ],
           "purpose": "Setup IPC handlers"
         },
         "flush": {
-          "line": 126,
+          "line": 175,
           "purpose": "Await all queued appends — tests and shutdown ordering."
         }
       },
@@ -5737,26 +5745,34 @@
       ],
       "depends": [
         "electron",
+        "shared/ipcChannels",
         "electron-log/renderer",
         "notify"
       ],
       "functions": {
         "toMainLog": {
-          "line": 29,
+          "line": 30,
           "params": [
             "message"
           ],
           "purpose": "electron-log's renderer entry forwards to the main process's file"
         },
         "bump": {
-          "line": 45,
+          "line": 75,
           "params": [
             "direction",
             "channel"
           ]
         },
+        "classifyInput": {
+          "line": 83,
+          "params": [
+            "args"
+          ],
+          "purpose": "Tally the escape sequences in one stdin payload. Never throws."
+        },
         "init": {
-          "line": 51
+          "line": 96
         }
       }
     },
@@ -9020,51 +9036,52 @@
       "depends": [
         "electron",
         "shared/ipcChannels",
-        "multiTerminalUI"
+        "multiTerminalUI",
+        "terminalInput"
       ],
       "functions": {
         "initTerminal": {
-          "line": 16,
+          "line": 17,
           "params": [
             "containerId"
           ],
           "purpose": "Initialize terminal (now creates MultiTerminalUI)"
         },
         "writeToTerminal": {
-          "line": 24,
+          "line": 25,
           "params": [
             "data"
           ],
           "purpose": "Write to active terminal"
         },
         "writelnToTerminal": {
-          "line": 33,
+          "line": 34,
           "params": [
             "data"
           ],
           "purpose": "Write line to active terminal"
         },
         "fitTerminal": {
-          "line": 42,
+          "line": 43,
           "purpose": "Fit all terminals"
         },
         "getTerminal": {
-          "line": 51,
+          "line": 52,
           "purpose": "Get terminal manager"
         },
         "startTerminal": {
-          "line": 61,
+          "line": 62,
           "purpose": "Start terminal (no longer needed - auto-starts)"
         },
         "restartTerminal": {
-          "line": 69,
+          "line": 70,
           "params": [
             "projectPath"
           ],
           "purpose": "Restart terminal with new path (creates new terminal in path for current project)"
         },
         "sendCommand": {
-          "line": 85,
+          "line": 86,
           "params": [
             "command",
             "terminalId = null"
@@ -9072,14 +9089,14 @@
           "purpose": "Send command to active terminal or specific terminal"
         },
         "setActiveTerminal": {
-          "line": 94,
+          "line": 95,
           "params": [
             "terminalId"
           ],
           "purpose": "Set active terminal"
         },
         "getMultiTerminalUI": {
-          "line": 149,
+          "line": 144,
           "purpose": "Get MultiTerminalUI instance"
         }
       },
@@ -9087,10 +9104,7 @@
         "listens": [
           "RUN_COMMAND"
         ],
-        "emits": [
-          "TERMINAL_INPUT_ID",
-          "TERMINAL_INPUT_ID"
-        ]
+        "emits": []
       }
     },
     "renderer/terminalGrid": {
@@ -9115,6 +9129,36 @@
         }
       }
     },
+    "renderer/terminalInput": {
+      "file": "src/renderer/terminalInput.js",
+      "description": "Terminal Input — the single renderer→PTY stdin path.",
+      "exports": [
+        "send"
+      ],
+      "depends": [
+        "electron",
+        "shared/ipcChannels"
+      ],
+      "functions": {
+        "flush": {
+          "line": 35
+        },
+        "send": {
+          "line": 49,
+          "params": [
+            "terminalId",
+            "data"
+          ],
+          "purpose": "Queue input for a terminal. Chunks queued in the same tick are sent as"
+        }
+      },
+      "ipc": {
+        "listens": [],
+        "emits": [
+          "TERMINAL_INPUT_ID"
+        ]
+      }
+    },
     "renderer/terminalManager": {
       "file": "src/renderer/terminalManager.js",
       "description": "Terminal Manager Module",
@@ -9125,21 +9169,22 @@
         "electron",
         "xterm",
         "xterm-addon-fit",
-        "shared/ipcChannels"
+        "shared/ipcChannels",
+        "terminalInput"
       ],
       "functions": {
         "getTerminalTheme": {
-          "line": 12,
+          "line": 13,
           "purpose": "Terminal theme based on current app theme"
         },
         "escapePathForShell": {
-          "line": 74,
+          "line": 75,
           "params": [
             "p"
           ]
         },
         "installGlobalDropGuard": {
-          "line": 90
+          "line": 91
         }
       },
       "ipc": {
@@ -9152,9 +9197,7 @@
         "emits": [
           "TERMINAL_CREATE",
           "GET_AVAILABLE_SHELLS",
-          "TERMINAL_INPUT_ID",
           "TERMINAL_DESTROY",
-          "TERMINAL_INPUT_ID",
           "TERMINAL_RESIZE_ID"
         ]
       }

--- a/src/main/promptLogger.js
+++ b/src/main/promptLogger.js
@@ -19,6 +19,10 @@ const MAX_LOG_SIZE = 5 * 1024 * 1024;
 
 let logFilePath = null;
 let inputBuffer = '';
+// Where the escape-sequence scanner stands between chunks: 'text', or the
+// kind of sequence still being consumed. Carried across calls because a
+// terminal reply can be split across two writes.
+let escapeState = 'text';
 let framePromptsDir = null;
 // Serialized append queue — keeps line order without blocking the loop.
 let writeQueue = Promise.resolve();
@@ -57,9 +61,25 @@ function getLogFilePath() {
 /**
  * Process and log input data
  * @param {string} data - Input data from terminal
+ *
+ * stdin carries more than typing: xterm answers the foreground TUI's
+ * questions on the same channel (cursor position `ESC[?6n` → `ESC[?39;3R`,
+ * mouse motion, focus in/out), and arrow keys arrive as `ESC[A`. Dropping
+ * the bare ESC byte was not enough — the printable tail (`[?39;3R`) still
+ * landed in the buffer, so every real prompt was written prefixed with tens
+ * of thousands of junk characters (measured: one 48KB line holding 71
+ * characters of actual prompt). Whole sequences are consumed instead.
  */
 function logInput(data) {
   for (let char of data) {
+    if (escapeState !== 'text') {
+      escapeState = _consumeEscape(escapeState, char);
+      continue;
+    }
+    if (char === '\x1b') {
+      escapeState = 'esc';
+      continue;
+    }
     if (char === '\r' || char === '\n') {
       // Enter pressed - save the line
       if (inputBuffer.trim().length > 0) {
@@ -78,6 +98,35 @@ function logInput(data) {
       // Printable character (including Unicode)
       inputBuffer += char;
     }
+  }
+}
+
+/**
+ * One step of the escape-sequence scanner. Returns the next state; 'text'
+ * means the sequence ended and this char was the last of it.
+ *   ESC [ … <final 0x40-0x7E>   CSI — cursor reports, mouse, arrow keys
+ *   ESC ] … <BEL | ESC \>       OSC — title/colour queries
+ *   ESC O <char>                SS3 — application-mode arrows
+ *   ESC <char>                  anything else, two bytes
+ */
+function _consumeEscape(state, char) {
+  const code = char.charCodeAt(0);
+  switch (state) {
+    case 'esc':
+      if (char === '[') return 'csi';
+      if (char === ']') return 'osc';
+      if (char === 'O') return 'ss3';
+      return 'text';
+    case 'csi':
+      return code >= 0x40 && code <= 0x7e ? 'text' : 'csi';
+    case 'osc':
+      // BEL ends it; so does ST (ESC \), whose ESC re-enters this state
+      // and whose backslash then lands here as the terminator.
+      return (char === '\x07' || char === '\\') ? 'text' : 'osc';
+    case 'ss3':
+      return 'text';
+    default:
+      return 'text';
   }
 }
 

--- a/src/renderer/ipcWatchdog.js
+++ b/src/renderer/ipcWatchdog.js
@@ -19,6 +19,7 @@
  */
 
 const { ipcRenderer } = require('electron');
+const { IPC } = require('../shared/ipcChannels');
 
 /**
  * electron-log's renderer entry forwards to the main process's file
@@ -38,20 +39,65 @@ const WINDOW_MS = 5000;
 const THRESHOLD = 300;       // messages per window (~60/s sustained)
 const REARM_MS = 60000;      // at most one user-facing warning per minute
 
+/**
+ * A PTY's stdin and stdout are accounted separately, against a much higher
+ * bar. They are the one pair of channels whose legitimate rate is set by
+ * something other than Frame: an agent TUI renders continuously and asks
+ * the terminal a question (`ESC[?6n`) on each frame, and xterm answers on
+ * stdin. ptyManager's 16ms flush caps output near 62 msg/s per terminal and
+ * the replies track it, so a working agent sits around 100 msg/s with
+ * nothing wrong — which is what used to raise a red "render loop" toast
+ * during ordinary use. They are still counted, still written to the log
+ * whenever the window is busy, and still able to raise the toast on their
+ * own — but only past a rate no number of rendering terminals explains.
+ */
+const TERMINAL_CHANNELS = new Set([IPC.TERMINAL_INPUT_ID, IPC.TERMINAL_OUTPUT_ID]);
+const TERMINAL_THRESHOLD = 1500;  // per window (~300/s)
+
+/**
+ * What the stdin traffic actually was. The first investigation of this
+ * warning cost an afternoon because the report named the channel but not
+ * the payload — and the answer (95% cursor-position replies) was only
+ * recoverable from the prompt history by accident.
+ */
+const INPUT_SHAPES = [
+  ['cursor-report', /\x1b\[\??\d+;\d+R/g],
+  ['mouse', /\x1b\[<\d+;\d+;\d+[Mm]/g],
+  ['focus', /\x1b\[[IO]/g]
+];
+
 let counts = {};
 let total = 0;
+let terminalTotal = 0;
+let inputShapes = {};
 let lastWarnAt = 0;
 
 function bump(direction, channel) {
   const key = `${direction}:${channel}`;
   counts[key] = (counts[key] || 0) + 1;
   total++;
+  if (TERMINAL_CHANNELS.has(channel)) terminalTotal++;
+}
+
+/** Tally the escape sequences in one stdin payload. Never throws. */
+function classifyInput(args) {
+  try {
+    const data = args && args[0] && args[0].data;
+    if (typeof data !== 'string' || data.indexOf('\x1b') === -1) return;
+    let matched = 0;
+    for (const [name, re] of INPUT_SHAPES) {
+      const n = (data.match(re) || []).length;
+      if (n) { inputShapes[name] = (inputShapes[name] || 0) + n; matched += n; }
+    }
+    if (!matched) inputShapes.other = (inputShapes.other || 0) + 1;
+  } catch (_) { /* accounting must never break the send it observes */ }
 }
 
 function init() {
   const origSend = ipcRenderer.send.bind(ipcRenderer);
   ipcRenderer.send = (channel, ...args) => {
     bump('out', channel);
+    if (channel === IPC.TERMINAL_INPUT_ID) classifyInput(args);
     return origSend(channel, ...args);
   };
 
@@ -68,23 +114,32 @@ function init() {
   };
 
   setInterval(() => {
+    // Frame's own channels keep the original bar — that is what caught the
+    // 2026-08-20 feedback loop. Terminal I/O has to clear its own.
+    const frameTotal = total - terminalTotal;
+    const isStorm = frameTotal > THRESHOLD || terminalTotal > TERMINAL_THRESHOLD;
     if (total > THRESHOLD) {
       const top = Object.entries(counts)
         .sort((a, b) => b[1] - a[1])
         .slice(0, 3)
         .map(([ch, n]) => `${ch} ×${n}`)
         .join(', ');
+      const shapes = Object.entries(inputShapes)
+        .sort((a, b) => b[1] - a[1])
+        .map(([name, n]) => `${name} ×${n}`)
+        .join(', ');
       const perSec = Math.round(total / (WINDOW_MS / 1000));
-      const detail = `${perSec} IPC msg/s sustained for ${WINDOW_MS / 1000}s — top: ${top}`;
-      console.warn(`[ipcWatchdog] ${detail}`);
+      const detail = `${perSec} IPC msg/s sustained for ${WINDOW_MS / 1000}s — top: ${top}`
+        + (shapes ? ` — stdin: ${shapes}` : '');
+      console.warn(`[ipcWatchdog] ${detail}${isStorm ? '' : ' (terminal I/O, within budget)'}`);
       toMainLog(detail);
-      if (Date.now() - lastWarnAt > REARM_MS) {
+      if (isStorm && Date.now() - lastWarnAt > REARM_MS) {
         lastWarnAt = Date.now();
         try {
           // Sticky: this text names the channels, which is the whole point —
           // it has to survive long enough to be read or copied.
           require('./notify').error(
-            `Frame is sending ${detail}. A render loop is the usual cause; the full breakdown is in the log.`,
+            `Frame is sending ${detail}. The full breakdown is in the log.`,
             { sticky: true }
           );
         } catch (_) { /* notify not ready — the console and log lines already fired */ }
@@ -92,6 +147,8 @@ function init() {
     }
     counts = {};
     total = 0;
+    terminalTotal = 0;
+    inputShapes = {};
   }, WINDOW_MS);
 }
 

--- a/src/renderer/terminal.js
+++ b/src/renderer/terminal.js
@@ -7,6 +7,7 @@
 const { ipcRenderer } = require('electron');
 const { IPC } = require('../shared/ipcChannels');
 const { MultiTerminalUI } = require('./multiTerminalUI');
+const terminalInput = require('./terminalInput');
 
 let multiTerminalUI = null;
 
@@ -111,15 +112,9 @@ window.terminalSendPromptThenEnter = function(prompt, terminalId = null) {
   const manager = multiTerminalUI.getManager();
   const targetId = terminalId || (manager && manager.activeTerminalId);
   if (!targetId) return;
-  ipcRenderer.send(IPC.TERMINAL_INPUT_ID, {
-    terminalId: targetId,
-    data: prompt
-  });
+  terminalInput.send(targetId, prompt);
   setTimeout(() => {
-    ipcRenderer.send(IPC.TERMINAL_INPUT_ID, {
-      terminalId: targetId,
-      data: '\r'
-    });
+    terminalInput.send(targetId, '\r');
   }, 300);
 };
 

--- a/src/renderer/terminalInput.js
+++ b/src/renderer/terminalInput.js
@@ -1,0 +1,58 @@
+/**
+ * Terminal Input — the single renderer→PTY stdin path.
+ *
+ * Every byte the renderer sends to a PTY goes through send(). Two reasons
+ * it is one funnel rather than a bare ipcRenderer.send at each call site:
+ *
+ * 1. Order. stdin is a stream; a keystroke that overtakes a queued chunk
+ *    corrupts what the shell reads. One queue per terminal makes ordering
+ *    a property of the module instead of a thing each caller must not break.
+ *
+ * 2. Volume. Input is not only typing — xterm answers the foreground TUI's
+ *    questions on the same channel. An agent TUI asks for the cursor
+ *    position (`ESC[?6n`) on every render, so a working agent produced a
+ *    steady ~55 msg/s of replies here, unbatched, while the output
+ *    direction had been coalesced since the resize-storm work
+ *    (ptyManager's 16ms flush). Measured over one session's stdin: 198,590
+ *    cursor-position replies, 9,261 mouse reports, 973 focus reports.
+ *
+ * The coalescing window is deliberately a microtask, not a timer. A TUI
+ * that asks a question *blocks its own frame* until the answer arrives, so
+ * holding replies for even one display frame would slow the very thing
+ * producing them. A microtask adds no measurable delay and still merges
+ * every chunk xterm emits while parsing one output flush — which is where
+ * the surplus lives (a 5s window held 274 input messages against 217
+ * output flushes: the queries come in pairs per frame).
+ */
+
+const { ipcRenderer } = require('electron');
+const { IPC } = require('../shared/ipcChannels');
+
+/** terminalId → text queued for this tick. Insertion-ordered. */
+const pending = new Map();
+let flushScheduled = false;
+
+function flush() {
+  flushScheduled = false;
+  for (const [terminalId, data] of pending) {
+    ipcRenderer.send(IPC.TERMINAL_INPUT_ID, { terminalId, data });
+  }
+  pending.clear();
+}
+
+/**
+ * Queue input for a terminal. Chunks queued in the same tick are sent as
+ * one message, in the order they were queued.
+ * @param {string} terminalId
+ * @param {string} data
+ */
+function send(terminalId, data) {
+  if (!terminalId || !data) return;
+  pending.set(terminalId, (pending.get(terminalId) || '') + data);
+  if (!flushScheduled) {
+    flushScheduled = true;
+    queueMicrotask(flush);
+  }
+}
+
+module.exports = { send };

--- a/src/renderer/terminalManager.js
+++ b/src/renderer/terminalManager.js
@@ -7,6 +7,7 @@ const { ipcRenderer, clipboard } = require('electron');
 const { Terminal } = require('xterm');
 const { FitAddon } = require('xterm-addon-fit');
 const { IPC } = require('../shared/ipcChannels');
+const terminalInput = require('./terminalInput');
 
 // Terminal theme based on current app theme
 function getTerminalTheme() {
@@ -516,9 +517,11 @@ class TerminalManager {
       terminal.paste(paths.join(' '));
     });
 
-    // Handle input
+    // Handle input. Routed through terminalInput so xterm's answers to the
+    // foreground TUI (cursor-position reports, mouse, focus) coalesce with
+    // whatever else this tick produced instead of costing one IPC each.
     terminal.onData((data) => {
-      ipcRenderer.send(IPC.TERMINAL_INPUT_ID, { terminalId, data });
+      terminalInput.send(terminalId, data);
     });
 
     // If first terminal or no active terminal, make it active
@@ -736,23 +739,24 @@ class TerminalManager {
     const targetId = terminalId || this.activeTerminalId;
     
     if (targetId) {
-      ipcRenderer.send(IPC.TERMINAL_INPUT_ID, {
-        terminalId: targetId,
-        data: command + '\r'
-      });
+      terminalInput.send(targetId, command + '\r');
     }
   }
 
   // Private methods
   _sendResize(terminalId) {
     const instance = this.terminals.get(terminalId);
-    if (instance) {
-      ipcRenderer.send(IPC.TERMINAL_RESIZE_ID, {
-        terminalId,
-        cols: instance.terminal.cols,
-        rows: instance.terminal.rows
-      });
-    }
+    if (!instance) return;
+    const { cols, rows } = instance.terminal;
+    // A fit that lands on the same grid is not a resize. Fitting makes xterm
+    // rewrite its own DOM, which re-fires the pane's ResizeObserver, which
+    // fits again — so an unguarded send turned a settled layout into a
+    // steady stream of no-op messages (seen as out:terminal-resize-id ×30
+    // in one 5s watchdog window). The PTY only cares about changes.
+    if (instance.lastSentCols === cols && instance.lastSentRows === rows) return;
+    instance.lastSentCols = cols;
+    instance.lastSentRows = rows;
+    ipcRenderer.send(IPC.TERMINAL_RESIZE_ID, { terminalId, cols, rows });
   }
 
   _notifyStateChange() {

--- a/test/logger.test.js
+++ b/test/logger.test.js
@@ -112,3 +112,25 @@ test('promptLogger rotates the history file past 5MB to <name>.log.1', async () 
   const fresh = fs.readFileSync(livePath, 'utf8');
   assert.ok(fresh.includes('fresh-line') && !fresh.includes('first-line'), 'appends land in a fresh live file');
 });
+
+test('promptLogger keeps terminal replies out of the prompt history', async () => {
+  const promptLogger = initPromptLogger();
+  // What a working agent TUI actually puts on stdin: cursor-position
+  // replies, mouse motion, focus reports and an arrow key, wrapped around
+  // the one thing the user typed.
+  promptLogger.logInput('\x1b[?39;3R\x1b[?36;3Rgit ');
+  promptLogger.logInput('\x1b[<35;41;2Mstatus\x1b[I\x1b[O\x1b[A\x1b]11;?\x07\r');
+  await promptLogger.flush();
+  const logged = fs.readFileSync(promptLogger.getLogFilePath(), 'utf8');
+  const line = logged.trim().split('\n').pop();
+  assert.ok(line.endsWith('] git status'), `prompt polluted by replies: ${JSON.stringify(line)}`);
+});
+
+test('promptLogger survives a terminal reply split across two chunks', async () => {
+  const promptLogger = initPromptLogger();
+  promptLogger.logInput('\x1b[?39;');   // sequence cut mid-flight
+  promptLogger.logInput('3Rnpm test\r');
+  await promptLogger.flush();
+  const logged = fs.readFileSync(promptLogger.getLogFilePath(), 'utf8');
+  assert.ok(logged.trim().endsWith('] npm test'), `split sequence leaked: ${logged}`);
+});


### PR DESCRIPTION
## What this fixes

The watchdog toast that fires during ordinary use:

```
Frame is sending 98 IPC msg/s sustained for 5s — top: out:terminal-input-id ×274,
in:terminal-output-id ×217. A render loop is the usual cause…
```

It is not a render loop. It is normal traffic, and the toast was sending the
investigation the wrong way.

## The evidence

`~/.frame/prompts/` records every byte that reaches a PTY's stdin. Parsing the
last 2MB of one session:

| stdin traffic | count |
| --- | --- |
| `ESC[?<row>;<col>R` — cursor-position reply | 198,590 |
| `ESC[<35;x;y M` — SGR mouse motion report | 9,261 |
| `ESC[I` / `ESC[O` — focus in/out | 973 |
| DA and other CSI replies | 11 |

95% of "input" is **xterm answering the foreground TUI**. An agent TUI asks
`ESC[?6n` on every render; the two most frequent answers were `row=39,col=3`
(×87,527) and `row=36,col=3` (×66,050), alternating — two queries per frame.
That accounts for both directions: output is capped by ptyManager's 16ms flush
(~43/s observed) and the replies track it at ~1.26 each.

## Changes

**`ipcWatchdog` — the actual fix.** Terminal stdin/stdout are the one pair of
channels whose legitimate rate is set by something other than Frame, so they
get their own threshold (1500/window ≈ 300/s). Frame's own channels keep the
300/window bar that caught the 2026-08-20 feedback loop. Below the terminal bar
the line still reaches `main.log` — nothing is blinded — but no red toast.

**`ipcWatchdog` — report the payload, not just the channel.** This
investigation was expensive because `×274` says nothing about what those bytes
were, and the answer was only recoverable from the prompt history by accident.
The line now carries `— stdin: cursor-report ×274`.

**`terminalInput.js` (new)** — one renderer→stdin path, coalescing on a
**microtask, deliberately not a timer**: a TUI blocks its own frame waiting for
the answer, so holding replies for even one display frame would slow the thing
producing them. It merges what xterm emits while parsing a single output flush
— the 274-vs-217 surplus — and nothing else. Honest size: ~20%, not the fix.
Side benefit: ordering becomes a property of the module instead of something
`sendCommand` / `terminalSendPromptThenEnter` / `onData` must each not break.

**`_sendResize`** — skip unchanged geometry. Fitting makes xterm rewrite its own
DOM, which re-fires the pane's `ResizeObserver`, which fits again; a settled
layout produced a steady stream of no-op resizes (`out:terminal-resize-id ×30`
in one window).

**`promptLogger`** — separate bug found on the way in. It was feeding these
control replies into the prompt history. Dropping the bare ESC byte
(`charCode < 32`) was not enough: the printable tail `[?39;3R` still landed in
the buffer, so every real prompt was written prefixed with tens of thousands of
junk characters. One line measured 48,886 characters holding 71 characters of
actual prompt. Whole sequences are now consumed, with scanner state carried
across chunks because a reply can be split between two writes. Arrow keys were
leaking the same way and are fixed by the same change.

## Verification

Replayed the reported window against the watchdog with the exact counts:

```
agent window (274 stdin / 217 stdout) → no toast; log:
  98 IPC msg/s sustained for 5s — top: … — stdin: cursor-report ×274
Frame-channel window (same volume)    → toast, unchanged
```

Coalescer checked for same-tick merge, per-terminal isolation, order
preservation, and that nothing is held across ticks.

370 tests pass (2 new, covering reply stripping and a sequence split across
chunks).

## Not done, on purpose

- Existing polluted history files were left alone — user data.
- Mouse motion reports (4% of stdin) come from the TUI's own mouse tracking;
  suppressing them would break its hover behaviour.


