### PR TITLE
Give a terminal session the spec flow the button gets

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -37,6 +37,14 @@
             "command": "node scripts/spec-hint.js prompt"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node scripts/spec-command-hint.js prompt"
+          }
+        ]
       }
     ],
     "SessionStart": [

--- a/.frame/PROJECT_NOTES.md
+++ b/.frame/PROJECT_NOTES.md
@@ -2409,3 +2409,42 @@ task from an earlier session, *"Make the find-module/grep orientation step
 deterministic"*, describes this work and can now be closed; the older spec
 `audit-q3-deterministic-graph-hints` covers the graph-based variant and was
 deliberately left untouched.
+
+### [2026-08-28] The spec decision gate never reached a terminal session, and why the protocol alone would not have fixed it
+
+**The symptom.** Spec-driven work started from the Frame button behaves as
+designed; the same command typed in a terminal produced a plan with no
+decision gate — the stage that resolves business and technical forks *with
+the user* through `AskUserQuestion` and records each answer under
+`### Resolved plan-time decisions`. Plans made that way also lack
+`## Footprint`, which is what orchestration's collision detection reads.
+
+**Two independent breaks, and one of them was self-inflicted.** The flow lives
+only in `spec.plan.md` (17 KB), never in REFERENCE.md. The button reaches it
+through `buildSpecCommandFile`, which interpolates the template and hands the
+agent one sentence. A terminal session was supposed to reach it through the
+self-serve protocol `cli-spec-command-parity` wrote into REFERENCE.md — but
+this repository's docs carry no managed-block marker, so Frame classifies them
+`unmatched` and, by design, refuses to write over them. The protocol shipped
+in 2026-07 and was never installed here. Frame's own repo had been outside its
+own upgrade path for a month; a fresh project was fine the whole time.
+
+**Fixed by installing the marker-wrapped section** (`renderSpecSection()`,
+v=2), which both closes the break and hands the section back to Frame so
+future upgrades land. That alone would still have left the flow depending on
+an agent reading five prose steps, which this codebase now has a number for:
+prose-delivered instructions run at 1–44%.
+
+**So the protocol got a mechanism.** `spec-command-hint.js` on
+`UserPromptSubmit` does what the button does — resolve the spec, interpolate
+the current template, write it to `.frame/runtime/prompts/`, inject the
+pointer. Two decisions worth keeping. Ambiguity is never guessed: one
+candidate is taken silently, several are listed for the agent to ask about
+with nothing staged, none is reported as none. And the hook duplicates
+`specManager`'s resolution because it ships to `.frame/bin/` and cannot
+require Electron main code — so a test asserts the staged prompt is
+byte-identical to `getCommandPrompt`'s, because a silent divergence there
+would return the terminal to exactly the state this fixes.
+
+**Untested link.** Everything above is asserted; that a real session then
+reads the staged file and runs the gate is not, and will be seen in use.

--- a/.frame/STRUCTURE.json
+++ b/.frame/STRUCTURE.json
@@ -9756,32 +9756,32 @@
       "depends": [],
       "functions": {
         "isRegistered": {
-          "line": 334,
+          "line": 347,
           "params": [
             "name"
           ]
         },
         "kindOf": {
-          "line": 338,
+          "line": 351,
           "params": [
             "name"
           ]
         },
         "isSuppression": {
-          "line": 342,
+          "line": 355,
           "params": [
             "name"
           ]
         },
         "fieldPasses": {
-          "line": 346,
+          "line": 359,
           "params": [
             "spec",
             "value"
           ]
         },
         "validateEvent": {
-          "line": 369,
+          "line": 382,
           "params": [
             "name",
             "fields"
@@ -9789,7 +9789,7 @@
           "purpose": "Validate an (event, fields) pair against the registry."
         },
         "formatLabel": {
-          "line": 386,
+          "line": 399,
           "params": [
             "name",
             "fields"
@@ -9797,7 +9797,7 @@
           "purpose": "The one-line sentence the panel's default view shows, or null when the"
         },
         "buildRecord": {
-          "line": 407,
+          "line": 420,
           "params": [
             "name",
             "fields"
@@ -10132,11 +10132,11 @@
           "line": 859
         },
         "getCodexWrapperTemplate": {
-          "line": 954,
+          "line": 964,
           "purpose": "Codex CLI wrapper script"
         },
         "getGenericWrapperTemplate": {
-          "line": 991,
+          "line": 1001,
           "params": [
             "toolCommand",
             "promptFlag = ''"
@@ -10144,27 +10144,27 @@
           "purpose": "Generic AI tool wrapper template"
         },
         "getStructureHookSnippet": {
-          "line": 1037
+          "line": 1047
         },
         "getStructurePreCommitHookTemplate": {
-          "line": 1076,
+          "line": 1086,
           "purpose": "Full pre-commit hook file content for the \"no existing hook\" case."
         },
         "getOrchBusHeader": {
-          "line": 1099,
+          "line": 1109,
           "purpose": "Orchestration command-channel scripts (.frame/bin/)"
         },
         "getOrchRequestScript": {
-          "line": 1111,
+          "line": 1121,
           "params": [
             "type"
           ]
         },
         "getOrchStatusScript": {
-          "line": 1131
+          "line": 1141
         },
         "getOrchBinScripts": {
-          "line": 1149,
+          "line": 1159,
           "purpose": "Map of filename → script body for the orchestration bin scripts. The"
         }
       }

--- a/.frame/bin/docs-hint.js
+++ b/.frame/bin/docs-hint.js
@@ -67,7 +67,19 @@ const CAP = 1980;
 
 // Delivered every session: the rules that govern conversation-level choices
 // and have no single moment of use.
-const SESSION_SECTIONS = ['Spec-driven development', 'General Rules'];
+//
+// The spec section carries both a conversation rule (when to offer a spec)
+// and the self-serve protocol for running a spec command — 2.5 KB of "find
+// the staged template and follow it exactly". Only the first belongs in
+// every session; the protocol belongs to the moment a command is invoked,
+// and sending it here would push the payload past the host's inline ceiling
+// and cost the session rules their delivery too. Until that moment has a
+// trigger of its own, the protocol stays reachable through
+// `docs-hint.js section "Spec-Driven"`.
+const SESSION_SECTIONS = [
+  { section: 'Spec-driven', subsections: ['When to suggest a spec'] },
+  { section: 'General Rules' }
+];
 
 // Delivered when the agent is about to write that file.
 const FILE_SECTIONS = [
@@ -221,9 +233,11 @@ function sessionStart(input) {
   if (!sections) return note(root, 'hint.quiet', 'session-start', { reason: 'no-index' });
 
   const bodies = SESSION_SECTIONS
-    .map((p) => byPrefix(sections, p))
-    .filter(Boolean)
-    .map((s) => renderSection(s));
+    .map((entry) => {
+      const found = byPrefix(sections, entry.section);
+      return found ? renderSection(found, entry.subsections) : null;
+    })
+    .filter(Boolean);
   if (!bodies.length) return note(root, 'hint.quiet', 'session-start', { reason: 'no-match' });
 
   const text = capped(root, SESSION_PREAMBLE, bodies);

--- a/.frame/bin/spec-command-hint.js
+++ b/.frame/bin/spec-command-hint.js
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+/**
+ * Spec command hint — Claude Code hook entry
+ *
+ * Makes a spec command entered from the terminal behave the way the button
+ * does. Frame's UI path (`buildSpecCommandFile` in specManager.js) resolves
+ * the spec, interpolates the current command template, writes it to
+ * `.frame/runtime/prompts/` and hands the agent one sentence: *"Read <path>
+ * and follow its instructions exactly."* Nothing in that chain fires for a
+ * CLI session, so the same command typed in a terminal reached only the
+ * docs, and the flow was improvised.
+ *
+ * What that costs is concrete, not theoretical: `spec.plan`'s Stage 2 is a
+ * decision gate that resolves business and technical forks **with the user**
+ * through the AskUserQuestion tool, and records each answer under
+ * `### Resolved plan-time decisions`. It exists only inside the template
+ * (17 KB), never in REFERENCE.md. A plan improvised without it also lacks
+ * `## Footprint`, which is what orchestration's collision detection reads.
+ *
+ * Why this writes a file rather than injecting the template: the host inlines
+ * a hook's additionalContext up to 2000 characters and spills the rest to a
+ * file, and specManager already documents the sibling constraint — Claude
+ * Code's terminal collapses large pastes into `[Pasted text #N]`. Both point
+ * the same way, so this hook does exactly what the button does: materialise
+ * the prompt on disk, hand over a short pointer.
+ *
+ * Scope. `spec.plan`, `spec.tasks` and `spec.implement` act on a spec that
+ * already exists, so the target can be resolved and the prompt written.
+ * `spec.new` has no target yet — the protocol's own step 1 treats it
+ * differently — so it gets the template path and nothing more.
+ *
+ * Hard contract (same as scripts/spec-hint.js):
+ *   - NEVER block, NEVER break: any failure → exit 0, empty output.
+ *   - Ambiguity is handed to the agent, never guessed: zero or several
+ *     candidate specs → say which, and let it ask.
+ *   - No imports from siblings; `catalogLines` below is a deliberate copy of
+ *     the six-line formatter in spec-index.js, not a require of the builder.
+ *
+ * Drift guard: test/spec-command-hint.test.js asserts this produces the
+ * byte-identical prompt specManager's own `getCommandPrompt` produces, so the
+ * duplication cannot quietly diverge from the path the button takes.
+ *
+ * Dependency-free plain node; ships to user projects' .frame/bin/.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const SUPPORTED = ['spec.new', 'spec.plan', 'spec.tasks', 'spec.implement'];
+
+// How many candidate specs a "which one?" hint may name. Chosen so the whole
+// payload stays under the host's 2000-character inline ceiling even with long
+// slugs and titles; test/spec-command-hint.test.js asserts it against 40.
+const LIST_CAP = 10;
+
+// Which phase each command acts on, per the self-serve protocol in
+// REFERENCE.md. spec.new is absent: it creates rather than advances.
+const ACTS_ON = {
+  'spec.plan': ['specified'],
+  'spec.tasks': ['planned'],
+  'spec.implement': ['tasks_generated', 'implementing']
+};
+
+// Conversational entry, kept deliberately narrow. A bare "plan" or
+// "implement" is ordinary English and fires on half of all prompts, so a verb
+// only counts when the word "spec" appears with it. Turkish forms are here
+// because this project is worked in Turkish; the same reasoning applies —
+// each is a verb that needs "spec" beside it to mean anything.
+const VERBS = {
+  'spec.plan': /\b(plan|planla|planlayalim|planlayalım)\b/i,
+  'spec.tasks': /\b(tasks?|task'?lar|görevler|gorevler)\b/i,
+  'spec.implement': /\b(implement|implemente|uygula|kodla)\b/i
+};
+
+function readStdin() {
+  try { return fs.readFileSync(0, 'utf8'); } catch { return ''; }
+}
+
+function readJson(p) {
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return null; }
+}
+
+function readText(p) {
+  try { return fs.readFileSync(p, 'utf8'); } catch { return null; }
+}
+
+function resolveRoot(hookCwd) {
+  if (process.env.FRAME_PROJECT_ROOT) return path.resolve(process.env.FRAME_PROJECT_ROOT);
+  if (hookCwd && fs.existsSync(path.join(hookCwd, '.frame'))) return hookCwd;
+  if (path.basename(__dirname) === 'bin' && path.basename(path.dirname(__dirname)) === '.frame') {
+    return path.dirname(path.dirname(__dirname));
+  }
+  return process.cwd();
+}
+
+// ─── activity record ──────────────────────────────────────
+
+let activity = null;
+try {
+  activity = require('./activity-log');
+} catch {
+  /* older .frame/bin generation — no record, same behavior as before */
+}
+
+function note(root, ev, fields) {
+  if (!activity || !root) return;
+  try {
+    activity.appendSync(activity.projectKey(root), {
+      ev,
+      kind: ev === 'hint.injected' ? 'action' : 'suppression',
+      host: 'claude-hook',
+      mode: 'spec-command',
+      ...fields
+    });
+  } catch {
+    /* the record is never worth a failed prompt */
+  }
+}
+
+const quiet = (root, reason) => note(root, 'hint.quiet', { reason });
+
+function emit(context) {
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: { hookEventName: 'UserPromptSubmit', additionalContext: context }
+  }));
+}
+
+// ─── intent ───────────────────────────────────────────────
+
+/** Which spec command this prompt is asking for, or null. */
+function commandOf(prompt) {
+  const p = String(prompt || '');
+  for (const cmd of SUPPORTED) {
+    // `/spec.plan`, `spec.plan`, `spec plan` — the explicit forms. These are
+    // what a user types when the slash command does not exist, which is the
+    // case this hook is here for.
+    const bare = cmd.replace('.', '[. ]');
+    if (new RegExp(`(^|\\s)/?${bare}\\b`, 'i').test(p)) return cmd;
+  }
+  if (!/\bspec\b/i.test(p)) return null; // a verb alone is just English
+  for (const [cmd, re] of Object.entries(VERBS)) {
+    if (re.test(p)) return cmd;
+  }
+  return null;
+}
+
+/** A slug the prompt names outright — an explicit target always wins. */
+function namedSlug(root, prompt) {
+  const dir = path.join(root, '.frame', 'specs');
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true }).filter((d) => d.isDirectory());
+  } catch {
+    return null;
+  }
+  const p = String(prompt || '').toLowerCase();
+  // Longest first, so "auth-tokens" is not shadowed by "auth".
+  return entries.map((d) => d.name).sort((a, b) => b.length - a.length)
+    .find((slug) => p.includes(slug.toLowerCase())) || null;
+}
+
+/** Specs whose phase this command acts on. */
+function candidates(root, command) {
+  const phases = ACTS_ON[command];
+  if (!phases) return [];
+  const dir = path.join(root, '.frame', 'specs');
+  let names;
+  try {
+    names = fs.readdirSync(dir, { withFileTypes: true }).filter((d) => d.isDirectory()).map((d) => d.name);
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const slug of names) {
+    const status = readJson(path.join(dir, slug, 'status.json'));
+    if (status && phases.includes(status.phase)) out.push({ slug, title: status.title || slug, phase: status.phase });
+  }
+  return out;
+}
+
+// ─── the prompt the button would have built ───────────────
+
+const RUNTIME_PROMPTS_REL = '.frame/runtime/prompts';
+const RUNTIME_ASSETS_REL = '.frame/runtime/assets';
+
+function templatePath(root, tool, command) {
+  const override = path.join(root, '.frame', 'templates', 'commands', tool, `${command}.md`);
+  if (fs.existsSync(override)) return override;
+  return path.join(root, '.frame', 'runtime', 'commands', tool, `${command}.md`);
+}
+
+function interpolate(template, vars) {
+  if (!template) return '';
+  return template.replace(/\{(\w+)\}/g, (m, key) => (vars[key] != null ? String(vars[key]) : m));
+}
+
+/** Six-line copy of spec-index.js's formatter — see the header note. */
+function catalogLines(index) {
+  return Object.entries(index.topics).map(([slug, t]) => {
+    const title = t.title.length > 90 ? `${t.title.slice(0, 87)}…` : t.title;
+    return `- ${slug} · ${title} · ${t.phase}${t.keywords.length ? ` · ${t.keywords.slice(0, 8).join(', ')}` : ''}`;
+  });
+}
+
+function specCatalog(root) {
+  const idx = readJson(path.join(root, '.frame', 'index', 'spec-index.json'));
+  if (!idx || !idx.topics) return '';
+  const lines = catalogLines(idx);
+  return lines.length ? lines.join('\n') : '';
+}
+
+function buildPrompt(root, slug, command, tool) {
+  const template = readText(templatePath(root, tool, command));
+  if (!template) return null;
+  const status = readJson(path.join(root, '.frame', 'specs', slug, 'status.json'));
+  if (!status) return null;
+  return interpolate(template, {
+    project_path: root,
+    slug,
+    title: status.title,
+    description: '',
+    report_template_path: `${RUNTIME_ASSETS_REL}/plan-report-template.html`,
+    report_generator_path: `${RUNTIME_ASSETS_REL}/build-implement-report.mjs`,
+    spec_catalog: command === 'spec.new' ? specCatalog(root) : ''
+  });
+}
+
+// ─── mode ─────────────────────────────────────────────────
+
+function promptMode(input) {
+  const root = resolveRoot(input.cwd);
+  const command = commandOf(input.prompt);
+  if (!command) return; // not a spec command — silent and unrecorded
+
+  const tool = 'claude-code';
+  const tpl = templatePath(root, tool, command);
+  if (!fs.existsSync(tpl)) {
+    // The protocol's own instruction for this case: say so, and stop.
+    note(root, 'hint.quiet', { reason: 'no-index' });
+    return emit(`\`${command}\` was asked for, but no template is staged at ` +
+      `\`${path.relative(root, tpl)}\`. Tell the user to open this project in Frame once so it stages ` +
+      `the current templates, and stop — do not reconstruct the flow from memory.`);
+  }
+  const tplRel = path.relative(root, tpl).split(path.sep).join('/');
+
+  if (command === 'spec.new') {
+    note(root, 'hint.injected', { reason: undefined });
+    return emit(`\`spec.new\` was asked for. Its flow lives in \`${tplRel}\` — read that file and ` +
+      `follow it exactly, interpolating {project_path}, {slug}, {title}, {description} and ` +
+      `{spec_catalog}. Do not write spec.md from memory; the template is the flow.`);
+  }
+
+  const named = namedSlug(root, input.prompt);
+  const pool = candidates(root, command);
+  const target = named || (pool.length === 1 ? pool[0].slug : null);
+
+  if (!target) {
+    note(root, 'hint.quiet', { reason: pool.length ? 'no-stale-free-match' : 'no-match' });
+    // The list is bounded because additionalContext is inlined only up to
+    // 2000 characters — an unbounded list would push the pointer itself past
+    // the ceiling and get the whole hint spilled to a file. What is dropped
+    // is stated rather than silently cut: a truncated list that reads as
+    // complete would have the agent offer the user a choice that is missing
+    // options.
+    const shown = pool.slice(0, LIST_CAP);
+    const rest = pool.length - shown.length;
+    const listed = pool.length
+      ? `Candidates in a phase \`${command}\` acts on:\n${shown.map((s) => `- ${s.slug} · ${s.title} · ${s.phase}`).join('\n')}`
+        + (rest ? `\n(+${rest} more — run \`node .frame/bin/spec-command-hint.js\` targets, or list .frame/specs/*/status.json)` : '')
+        + `\nAsk the user which one, then read \`${tplRel}\` and follow it exactly.`
+      : `No spec is in a phase \`${command}\` acts on (${(ACTS_ON[command] || []).join(' or ')}). Say so rather than picking one.`;
+    return emit(`\`${command}\` was asked for. ${listed}`);
+  }
+
+  const prompt = buildPrompt(root, target, command, tool);
+  if (!prompt) return quiet(root, 'no-context');
+
+  let relPath;
+  try {
+    const dir = path.join(root, RUNTIME_PROMPTS_REL);
+    fs.mkdirSync(dir, { recursive: true });
+    const file = `${target}__${command}.md`;
+    fs.writeFileSync(path.join(dir, file), prompt, 'utf8');
+    relPath = `${RUNTIME_PROMPTS_REL}/${file}`;
+  } catch {
+    // Could not stage it — point at the template instead of failing.
+    note(root, 'hint.injected', {});
+    return emit(`\`${command}\` on spec \`${target}\`. Read \`${tplRel}\` and follow it exactly, ` +
+      `interpolating {project_path}=${root}, {slug}=${target}.`);
+  }
+
+  note(root, 'hint.injected', {});
+  emit(`\`${command}\` on spec \`${target}\`. Frame has staged the interpolated flow for you: ` +
+    `**read \`${relPath}\` and follow its instructions exactly.** It is the current template, ` +
+    `including every stage and every \`status.json\` update it prescribes — do not improvise the flow.`);
+}
+
+try {
+  const input = JSON.parse(readStdin() || '{}');
+  if (process.argv[2] === 'prompt') promptMode(input);
+} catch { /* silence is the contract */ }
+
+// `exitCode`, not `process.exit(0)` — an explicit exit can tear the process
+// down before a stdout write has drained. Same reason as docs-hint.js.
+process.exitCode = 0;

--- a/.frame/docs/REFERENCE.md
+++ b/.frame/docs/REFERENCE.md
@@ -195,29 +195,91 @@ manual insight; it is preserved verbatim across regens).
 
 ---
 
-## Spec-driven development — how to suggest
+<!-- frame:managed:spec-section v=2 -->
+## Spec-Driven Development (.frame/specs/)
 
-When a significant request appears, ask once, in plain language, before coding:
+Frame supports a structured `spec → plan → tasks → implement` workflow. When the user asks you to define, plan, or implement a feature, prefer this workflow over ad-hoc edits — it preserves intent and keeps `.frame/tasks.json` in sync.
 
-> "This is a sizable feature. Want me to handle it as a **spec** — I'll draft
-> `spec.md`, then we plan it and generate tasks — or should I just implement it
-> directly?"
+### File layout
 
-- If the user agrees → start the spec flow (create the spec, then plan, then
-  tasks). If they have the slash commands set up, point them at `/spec` etc.;
-  otherwise scaffold `.frame/specs/<slug>/` per the existing structure.
-- If the user says "just do it" / declines → proceed directly and **don't ask
-  again for that same piece of work** in the session.
-- Never force it. The spec is an offer, not a gate. The user's stated
-  preference always wins.
+Each spec lives in its own folder:
 
-**Do NOT suggest a spec for:** typos, one-line fixes, small tweaks, renames,
-small discrete tracked work (that's a task), questions, debugging,
-explanations, experiments, or anything the user says to "just do".
+```
+.frame/specs/<slug>/
+  spec.md       — what we're building
+  plan.md       — how (architecture, files, footprint, sequencing)
+  tasks.md      — flat bullet list, "- T01 · description"
+  status.json   — phase + metadata
+```
 
-**For the plan step:** every `plan.md` must declare a `## Footprint` — a flat
-`- <path>` list of the source files the spec touches (meta files excluded).
-This is what the conductor and Frame use to schedule safely.
+`<slug>` is kebab-case, derived from the spec title.
+
+### Lifecycle phases
+
+`draft` → `specified` → `planned` → `tasks_generated` → `implementing` → `done`
+
+Frame auto-advances phase from filesystem state (file presence). The command templates below tell you exactly which `status.json` updates to make; Frame's watcher reconciles if anything is missed.
+
+### Running spec commands — the self-serve protocol
+
+The four spec commands are `spec.new`, `spec.plan`, `spec.tasks` and `spec.implement`. Whether the user types them as slash commands or asks conversationally ("plan the auth spec", "implement the tasks"), the flow is **never improvised from memory** — each command's current flow lives in a template file that Frame keeps staged in the project. Run one like this:
+
+**1. Resolve the target spec.** An explicitly named spec always wins. Otherwise list the specs (`.frame/specs/*/status.json`) whose phase the command acts on — `spec.plan` → `specified`, `spec.tasks` → `planned`, `spec.implement` → `tasks_generated` or `implementing`. Exactly one candidate → take it silently; zero or several → present the candidates and ask. `spec.new` creates a new spec: derive the kebab-case slug from the title.
+
+**2. Resolve the template.** Take the first that exists:
+
+1. `.frame/templates/commands/<tool>/<command>.md` — project override
+2. `.frame/runtime/commands/<tool>/<command>.md` — staged by Frame on project open
+
+`<tool>` is the directory matching your CLI (Claude Code → `claude-code`). If neither file exists, say so and ask the user to open this project in Frame once so it stages the current templates — then stop. **Do not reconstruct the flow from this file, from memory, or from an older prompt.**
+
+**3. Interpolate the placeholders.** Replace each `{placeholder}` token in the template:
+
+| Placeholder | Value |
+| --- | --- |
+| `{project_path}` | absolute path of the project root |
+| `{slug}` | the spec's slug |
+| `{title}` | the spec's title (from `status.json`; for `spec.new`, the new title) |
+| `{description}` | the user's description (`spec.new` only; empty otherwise) |
+| `{report_template_path}` | `.frame/runtime/commands/<tool>/plan-report-template.html` |
+| `{report_generator_path}` | `.frame/runtime/commands/<tool>/build-implement-report.mjs` |
+
+**4. Follow the interpolated template exactly**, including every `status.json` update it prescribes. The template is the flow; this section only tells you how to find it.
+
+**5. Autonomous implement ceiling.** `spec.implement`'s autonomous mode needs permission flags that only a fresh, flagged launch can carry — a running session cannot acquire them. If the user picks autonomous conversationally, do what the template says: record the choice in the spec's `status.json` and hand off — the user clicks Implement on the spec's page in Frame and picks Autonomous, or runs `node .frame/bin/implement-launch.js <slug>` in a fresh terminal. Never run a degraded imitation silently.
+
+### .frame/tasks.json linkage
+
+After `spec.tasks`, **do not** also write entries to `.frame/tasks.json` — Frame's watcher imports them automatically with `source: "spec:<slug>:T<n>"` markers. Spec-generated tasks carry that `source` field; treat them like any other task — start them, complete them, update status. User-set status is preserved across spec re-imports; only title/description sync from `tasks.md`.
+
+### When to suggest a spec (steer the conversation)
+
+Spec-driven is Frame's core way of working, so when a user describes meaningful
+new work **mid-conversation**, gently steer them toward a spec instead of
+silently diving into code. Suggest a spec only for **significant work** — don't
+make this a reflex on every message.
+
+**Suggest a spec for:**
+- A new **feature** or capability ("users should be able to …", "add a … system")
+- A change that will touch **multiple files / modules** or affect architecture
+- Anything that clearly benefits from a **plan and ordered tasks** before coding
+- Work the user describes vaguely/largely that would benefit from being scoped first
+
+**Do NOT suggest a spec for:**
+- Typos, one-line fixes, small tweaks, renames → just do it
+- Small, discrete tracked work → that's a task (`.frame/tasks.json`)
+- Questions, debugging, explanations, experiments
+- Anything the user explicitly says to "just do" / "do directly"
+
+Rough ladder: *trivial → just do it · small but worth tracking → task · sizable
+feature or multi-file change → spec.*
+
+Ask once, in plain language, before coding. If they agree, start the spec flow
+(`spec.new` → `spec.plan` → `spec.tasks`). If they decline or say "just do
+it", proceed directly and **don't ask again for that same piece of work** in the
+session. Never force it — the spec is an offer, not a gate; the user's stated
+preference always wins.
+<!-- /frame:managed:spec-section -->
 
 ---
 

--- a/scripts/docs-hint.js
+++ b/scripts/docs-hint.js
@@ -67,7 +67,19 @@ const CAP = 1980;
 
 // Delivered every session: the rules that govern conversation-level choices
 // and have no single moment of use.
-const SESSION_SECTIONS = ['Spec-driven development', 'General Rules'];
+//
+// The spec section carries both a conversation rule (when to offer a spec)
+// and the self-serve protocol for running a spec command — 2.5 KB of "find
+// the staged template and follow it exactly". Only the first belongs in
+// every session; the protocol belongs to the moment a command is invoked,
+// and sending it here would push the payload past the host's inline ceiling
+// and cost the session rules their delivery too. Until that moment has a
+// trigger of its own, the protocol stays reachable through
+// `docs-hint.js section "Spec-Driven"`.
+const SESSION_SECTIONS = [
+  { section: 'Spec-driven', subsections: ['When to suggest a spec'] },
+  { section: 'General Rules' }
+];
 
 // Delivered when the agent is about to write that file.
 const FILE_SECTIONS = [
@@ -221,9 +233,11 @@ function sessionStart(input) {
   if (!sections) return note(root, 'hint.quiet', 'session-start', { reason: 'no-index' });
 
   const bodies = SESSION_SECTIONS
-    .map((p) => byPrefix(sections, p))
-    .filter(Boolean)
-    .map((s) => renderSection(s));
+    .map((entry) => {
+      const found = byPrefix(sections, entry.section);
+      return found ? renderSection(found, entry.subsections) : null;
+    })
+    .filter(Boolean);
   if (!bodies.length) return note(root, 'hint.quiet', 'session-start', { reason: 'no-match' });
 
   const text = capped(root, SESSION_PREAMBLE, bodies);

--- a/scripts/spec-command-hint.js
+++ b/scripts/spec-command-hint.js
@@ -1,0 +1,307 @@
+#!/usr/bin/env node
+/**
+ * Spec command hint — Claude Code hook entry
+ *
+ * Makes a spec command entered from the terminal behave the way the button
+ * does. Frame's UI path (`buildSpecCommandFile` in specManager.js) resolves
+ * the spec, interpolates the current command template, writes it to
+ * `.frame/runtime/prompts/` and hands the agent one sentence: *"Read <path>
+ * and follow its instructions exactly."* Nothing in that chain fires for a
+ * CLI session, so the same command typed in a terminal reached only the
+ * docs, and the flow was improvised.
+ *
+ * What that costs is concrete, not theoretical: `spec.plan`'s Stage 2 is a
+ * decision gate that resolves business and technical forks **with the user**
+ * through the AskUserQuestion tool, and records each answer under
+ * `### Resolved plan-time decisions`. It exists only inside the template
+ * (17 KB), never in REFERENCE.md. A plan improvised without it also lacks
+ * `## Footprint`, which is what orchestration's collision detection reads.
+ *
+ * Why this writes a file rather than injecting the template: the host inlines
+ * a hook's additionalContext up to 2000 characters and spills the rest to a
+ * file, and specManager already documents the sibling constraint — Claude
+ * Code's terminal collapses large pastes into `[Pasted text #N]`. Both point
+ * the same way, so this hook does exactly what the button does: materialise
+ * the prompt on disk, hand over a short pointer.
+ *
+ * Scope. `spec.plan`, `spec.tasks` and `spec.implement` act on a spec that
+ * already exists, so the target can be resolved and the prompt written.
+ * `spec.new` has no target yet — the protocol's own step 1 treats it
+ * differently — so it gets the template path and nothing more.
+ *
+ * Hard contract (same as scripts/spec-hint.js):
+ *   - NEVER block, NEVER break: any failure → exit 0, empty output.
+ *   - Ambiguity is handed to the agent, never guessed: zero or several
+ *     candidate specs → say which, and let it ask.
+ *   - No imports from siblings; `catalogLines` below is a deliberate copy of
+ *     the six-line formatter in spec-index.js, not a require of the builder.
+ *
+ * Drift guard: test/spec-command-hint.test.js asserts this produces the
+ * byte-identical prompt specManager's own `getCommandPrompt` produces, so the
+ * duplication cannot quietly diverge from the path the button takes.
+ *
+ * Dependency-free plain node; ships to user projects' .frame/bin/.
+ */
+
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+
+const SUPPORTED = ['spec.new', 'spec.plan', 'spec.tasks', 'spec.implement'];
+
+// How many candidate specs a "which one?" hint may name. Chosen so the whole
+// payload stays under the host's 2000-character inline ceiling even with long
+// slugs and titles; test/spec-command-hint.test.js asserts it against 40.
+const LIST_CAP = 10;
+
+// Which phase each command acts on, per the self-serve protocol in
+// REFERENCE.md. spec.new is absent: it creates rather than advances.
+const ACTS_ON = {
+  'spec.plan': ['specified'],
+  'spec.tasks': ['planned'],
+  'spec.implement': ['tasks_generated', 'implementing']
+};
+
+// Conversational entry, kept deliberately narrow. A bare "plan" or
+// "implement" is ordinary English and fires on half of all prompts, so a verb
+// only counts when the word "spec" appears with it. Turkish forms are here
+// because this project is worked in Turkish; the same reasoning applies —
+// each is a verb that needs "spec" beside it to mean anything.
+const VERBS = {
+  'spec.plan': /\b(plan|planla|planlayalim|planlayalım)\b/i,
+  'spec.tasks': /\b(tasks?|task'?lar|görevler|gorevler)\b/i,
+  'spec.implement': /\b(implement|implemente|uygula|kodla)\b/i
+};
+
+function readStdin() {
+  try { return fs.readFileSync(0, 'utf8'); } catch { return ''; }
+}
+
+function readJson(p) {
+  try { return JSON.parse(fs.readFileSync(p, 'utf8')); } catch { return null; }
+}
+
+function readText(p) {
+  try { return fs.readFileSync(p, 'utf8'); } catch { return null; }
+}
+
+function resolveRoot(hookCwd) {
+  if (process.env.FRAME_PROJECT_ROOT) return path.resolve(process.env.FRAME_PROJECT_ROOT);
+  if (hookCwd && fs.existsSync(path.join(hookCwd, '.frame'))) return hookCwd;
+  if (path.basename(__dirname) === 'bin' && path.basename(path.dirname(__dirname)) === '.frame') {
+    return path.dirname(path.dirname(__dirname));
+  }
+  return process.cwd();
+}
+
+// ─── activity record ──────────────────────────────────────
+
+let activity = null;
+try {
+  activity = require('./activity-log');
+} catch {
+  /* older .frame/bin generation — no record, same behavior as before */
+}
+
+function note(root, ev, fields) {
+  if (!activity || !root) return;
+  try {
+    activity.appendSync(activity.projectKey(root), {
+      ev,
+      kind: ev === 'hint.injected' ? 'action' : 'suppression',
+      host: 'claude-hook',
+      mode: 'spec-command',
+      ...fields
+    });
+  } catch {
+    /* the record is never worth a failed prompt */
+  }
+}
+
+const quiet = (root, reason) => note(root, 'hint.quiet', { reason });
+
+function emit(context) {
+  process.stdout.write(JSON.stringify({
+    hookSpecificOutput: { hookEventName: 'UserPromptSubmit', additionalContext: context }
+  }));
+}
+
+// ─── intent ───────────────────────────────────────────────
+
+/** Which spec command this prompt is asking for, or null. */
+function commandOf(prompt) {
+  const p = String(prompt || '');
+  for (const cmd of SUPPORTED) {
+    // `/spec.plan`, `spec.plan`, `spec plan` — the explicit forms. These are
+    // what a user types when the slash command does not exist, which is the
+    // case this hook is here for.
+    const bare = cmd.replace('.', '[. ]');
+    if (new RegExp(`(^|\\s)/?${bare}\\b`, 'i').test(p)) return cmd;
+  }
+  if (!/\bspec\b/i.test(p)) return null; // a verb alone is just English
+  for (const [cmd, re] of Object.entries(VERBS)) {
+    if (re.test(p)) return cmd;
+  }
+  return null;
+}
+
+/** A slug the prompt names outright — an explicit target always wins. */
+function namedSlug(root, prompt) {
+  const dir = path.join(root, '.frame', 'specs');
+  let entries;
+  try {
+    entries = fs.readdirSync(dir, { withFileTypes: true }).filter((d) => d.isDirectory());
+  } catch {
+    return null;
+  }
+  const p = String(prompt || '').toLowerCase();
+  // Longest first, so "auth-tokens" is not shadowed by "auth".
+  return entries.map((d) => d.name).sort((a, b) => b.length - a.length)
+    .find((slug) => p.includes(slug.toLowerCase())) || null;
+}
+
+/** Specs whose phase this command acts on. */
+function candidates(root, command) {
+  const phases = ACTS_ON[command];
+  if (!phases) return [];
+  const dir = path.join(root, '.frame', 'specs');
+  let names;
+  try {
+    names = fs.readdirSync(dir, { withFileTypes: true }).filter((d) => d.isDirectory()).map((d) => d.name);
+  } catch {
+    return [];
+  }
+  const out = [];
+  for (const slug of names) {
+    const status = readJson(path.join(dir, slug, 'status.json'));
+    if (status && phases.includes(status.phase)) out.push({ slug, title: status.title || slug, phase: status.phase });
+  }
+  return out;
+}
+
+// ─── the prompt the button would have built ───────────────
+
+const RUNTIME_PROMPTS_REL = '.frame/runtime/prompts';
+const RUNTIME_ASSETS_REL = '.frame/runtime/assets';
+
+function templatePath(root, tool, command) {
+  const override = path.join(root, '.frame', 'templates', 'commands', tool, `${command}.md`);
+  if (fs.existsSync(override)) return override;
+  return path.join(root, '.frame', 'runtime', 'commands', tool, `${command}.md`);
+}
+
+function interpolate(template, vars) {
+  if (!template) return '';
+  return template.replace(/\{(\w+)\}/g, (m, key) => (vars[key] != null ? String(vars[key]) : m));
+}
+
+/** Six-line copy of spec-index.js's formatter — see the header note. */
+function catalogLines(index) {
+  return Object.entries(index.topics).map(([slug, t]) => {
+    const title = t.title.length > 90 ? `${t.title.slice(0, 87)}…` : t.title;
+    return `- ${slug} · ${title} · ${t.phase}${t.keywords.length ? ` · ${t.keywords.slice(0, 8).join(', ')}` : ''}`;
+  });
+}
+
+function specCatalog(root) {
+  const idx = readJson(path.join(root, '.frame', 'index', 'spec-index.json'));
+  if (!idx || !idx.topics) return '';
+  const lines = catalogLines(idx);
+  return lines.length ? lines.join('\n') : '';
+}
+
+function buildPrompt(root, slug, command, tool) {
+  const template = readText(templatePath(root, tool, command));
+  if (!template) return null;
+  const status = readJson(path.join(root, '.frame', 'specs', slug, 'status.json'));
+  if (!status) return null;
+  return interpolate(template, {
+    project_path: root,
+    slug,
+    title: status.title,
+    description: '',
+    report_template_path: `${RUNTIME_ASSETS_REL}/plan-report-template.html`,
+    report_generator_path: `${RUNTIME_ASSETS_REL}/build-implement-report.mjs`,
+    spec_catalog: command === 'spec.new' ? specCatalog(root) : ''
+  });
+}
+
+// ─── mode ─────────────────────────────────────────────────
+
+function promptMode(input) {
+  const root = resolveRoot(input.cwd);
+  const command = commandOf(input.prompt);
+  if (!command) return; // not a spec command — silent and unrecorded
+
+  const tool = 'claude-code';
+  const tpl = templatePath(root, tool, command);
+  if (!fs.existsSync(tpl)) {
+    // The protocol's own instruction for this case: say so, and stop.
+    note(root, 'hint.quiet', { reason: 'no-index' });
+    return emit(`\`${command}\` was asked for, but no template is staged at ` +
+      `\`${path.relative(root, tpl)}\`. Tell the user to open this project in Frame once so it stages ` +
+      `the current templates, and stop — do not reconstruct the flow from memory.`);
+  }
+  const tplRel = path.relative(root, tpl).split(path.sep).join('/');
+
+  if (command === 'spec.new') {
+    note(root, 'hint.injected', { reason: undefined });
+    return emit(`\`spec.new\` was asked for. Its flow lives in \`${tplRel}\` — read that file and ` +
+      `follow it exactly, interpolating {project_path}, {slug}, {title}, {description} and ` +
+      `{spec_catalog}. Do not write spec.md from memory; the template is the flow.`);
+  }
+
+  const named = namedSlug(root, input.prompt);
+  const pool = candidates(root, command);
+  const target = named || (pool.length === 1 ? pool[0].slug : null);
+
+  if (!target) {
+    note(root, 'hint.quiet', { reason: pool.length ? 'no-stale-free-match' : 'no-match' });
+    // The list is bounded because additionalContext is inlined only up to
+    // 2000 characters — an unbounded list would push the pointer itself past
+    // the ceiling and get the whole hint spilled to a file. What is dropped
+    // is stated rather than silently cut: a truncated list that reads as
+    // complete would have the agent offer the user a choice that is missing
+    // options.
+    const shown = pool.slice(0, LIST_CAP);
+    const rest = pool.length - shown.length;
+    const listed = pool.length
+      ? `Candidates in a phase \`${command}\` acts on:\n${shown.map((s) => `- ${s.slug} · ${s.title} · ${s.phase}`).join('\n')}`
+        + (rest ? `\n(+${rest} more — run \`node .frame/bin/spec-command-hint.js\` targets, or list .frame/specs/*/status.json)` : '')
+        + `\nAsk the user which one, then read \`${tplRel}\` and follow it exactly.`
+      : `No spec is in a phase \`${command}\` acts on (${(ACTS_ON[command] || []).join(' or ')}). Say so rather than picking one.`;
+    return emit(`\`${command}\` was asked for. ${listed}`);
+  }
+
+  const prompt = buildPrompt(root, target, command, tool);
+  if (!prompt) return quiet(root, 'no-context');
+
+  let relPath;
+  try {
+    const dir = path.join(root, RUNTIME_PROMPTS_REL);
+    fs.mkdirSync(dir, { recursive: true });
+    const file = `${target}__${command}.md`;
+    fs.writeFileSync(path.join(dir, file), prompt, 'utf8');
+    relPath = `${RUNTIME_PROMPTS_REL}/${file}`;
+  } catch {
+    // Could not stage it — point at the template instead of failing.
+    note(root, 'hint.injected', {});
+    return emit(`\`${command}\` on spec \`${target}\`. Read \`${tplRel}\` and follow it exactly, ` +
+      `interpolating {project_path}=${root}, {slug}=${target}.`);
+  }
+
+  note(root, 'hint.injected', {});
+  emit(`\`${command}\` on spec \`${target}\`. Frame has staged the interpolated flow for you: ` +
+    `**read \`${relPath}\` and follow its instructions exactly.** It is the current template, ` +
+    `including every stage and every \`status.json\` update it prescribes — do not improvise the flow.`);
+}
+
+try {
+  const input = JSON.parse(readStdin() || '{}');
+  if (process.argv[2] === 'prompt') promptMode(input);
+} catch { /* silence is the contract */ }
+
+// `exitCode`, not `process.exit(0)` — an explicit exit can tear the process
+// down before a stdout write has drained. Same reason as docs-hint.js.
+process.exitCode = 0;

--- a/src/main/structureBootstrap.js
+++ b/src/main/structureBootstrap.js
@@ -39,7 +39,7 @@ const {
 // the repo root; under electron-builder's asar the same relative path holds
 // because the asar mirrors the source tree.
 const SCRIPTS_SOURCE_DIR = path.join(__dirname, '..', '..', 'scripts');
-const PARSER_FILES = ['update-structure.js', 'find-module.js', 'check-freshness.js', 'detect-project.js', 'intent-map.json', 'spec-index.js', 'spec-context.js', 'spec-hint.js', 'module-hint.js', 'docs-hint.js', 'redact.js', 'activity-log.js'];
+const PARSER_FILES = ['update-structure.js', 'find-module.js', 'check-freshness.js', 'detect-project.js', 'intent-map.json', 'spec-index.js', 'spec-context.js', 'spec-hint.js', 'module-hint.js', 'docs-hint.js', 'spec-command-hint.js', 'redact.js', 'activity-log.js'];
 
 /**
  * Copy parser scripts from Frame's bundled scripts/ into the project's

--- a/src/shared/activityEvents.js
+++ b/src/shared/activityEvents.js
@@ -88,7 +88,7 @@ const EVENTS = {
   'hint.injected': {
     kind: 'action',
     fields: {
-      host: enumOf(HOSTS), mode: enumOf(['pre-edit', 'prompt', 'search', 'session-start', 'meta-write']),
+      host: enumOf(HOSTS), mode: enumOf(['pre-edit', 'prompt', 'search', 'session-start', 'meta-write', 'spec-command']),
       path: PATH, specs: COUNT, concept: SLUG, modules: COUNT, bytes: COUNT
     },
     label: (r) => {
@@ -97,6 +97,9 @@ const EVENTS = {
       }
       if (r.mode === 'meta-write') {
         return `Frame's rules for this meta file delivered before the write${r.bytes ? ` (${r.bytes} chars)` : ''}`;
+      }
+      if (r.mode === 'spec-command') {
+        return 'Spec command flow staged for a terminal session';
       }
       if (r.mode === 'search') {
         return `Module map answered "${r.concept || 'a search'}"${r.modules ? ` (${r.modules} file${r.modules === 1 ? '' : 's'})` : ''}`;
@@ -108,8 +111,10 @@ const EVENTS = {
   },
   'hint.quiet': {
     kind: 'suppression',
-    fields: { host: enumOf(HOSTS), mode: enumOf(['pre-edit', 'prompt', 'search', 'session-start', 'meta-write']), reason: enumOf(HINT_REASONS), path: PATH, repeats: REPEATS },
-    label: (r) => (r.mode === 'session-start' || r.mode === 'meta-write'
+    fields: { host: enumOf(HOSTS), mode: enumOf(['pre-edit', 'prompt', 'search', 'session-start', 'meta-write', 'spec-command']), reason: enumOf(HINT_REASONS), path: PATH, repeats: REPEATS },
+    label: (r) => (r.mode === 'spec-command'
+      ? `Spec command flow not staged — ${SPEC_COMMAND_REASON_TEXT[r.reason] || HINT_REASON_TEXT[r.reason] || r.reason}`
+      : r.mode === 'session-start' || r.mode === 'meta-write'
       ? `Frame rules not delivered — ${DOCS_HINT_REASON_TEXT[r.reason] || HINT_REASON_TEXT[r.reason] || r.reason}`
       : r.mode === 'search'
         ? `Module hint skipped — ${SEARCH_REASON_TEXT[r.reason] || HINT_REASON_TEXT[r.reason] || r.reason}`
@@ -293,6 +298,14 @@ const DOCS_HINT_REASON_TEXT = {
   'no-index': 'this project has no .frame/docs/REFERENCE.md',
   'no-match': 'REFERENCE.md carries no section for it',
   'no-context': 'REFERENCE.md is empty'
+};
+
+// And once more for the terminal-entry staging of a spec command.
+const SPEC_COMMAND_REASON_TEXT = {
+  'no-index': 'no command template is staged for this project',
+  'no-match': 'no spec is in a phase the command acts on',
+  'no-stale-free-match': 'several specs qualify — the agent was asked to pick',
+  'no-context': 'the template or the spec status could not be read'
 };
 
 const DOCS_DEGRADED_TEXT = {

--- a/src/shared/frameTemplates.js
+++ b/src/shared/frameTemplates.js
@@ -915,6 +915,16 @@ const SPEC_HINT_HOOKS = {
         type: 'command',
         command: "sh -c '[ ! -f .frame/bin/spec-hint.js ] || exec node .frame/bin/spec-hint.js prompt'"
       }]
+    },
+    // A spec command typed in a terminal, staged the way the button stages
+    // it. Without this the UI path's chain never fires for a CLI session and
+    // the flow is improvised — losing spec.plan's decision gate, which is
+    // the only place the user is asked about business forks.
+    {
+      hooks: [{
+        type: 'command',
+        command: "sh -c '[ ! -f .frame/bin/spec-command-hint.js ] || exec node .frame/bin/spec-command-hint.js prompt'"
+      }]
     }
   ],
   // REFERENCE.md every session. Between 2026-01-25 and 2026-07-06 these

--- a/test/frameProjectInit.test.js
+++ b/test/frameProjectInit.test.js
@@ -163,11 +163,11 @@ test('hook entries are guarded and land in settings.json under repo sharing', as
 
   const settings = JSON.parse(fs.readFileSync(path.join(projectDir, '.claude', 'settings.json'), 'utf8'));
   const commands = Object.values(settings.hooks).flat().flatMap((e) => e.hooks.map((h) => h.command));
-  assert.equal(commands.length, 5); // spec-hint x2, module-hint, docs-hint x2
+  assert.equal(commands.length, 6); // spec-hint x2, module-hint, docs-hint x2, spec-command-hint
   for (const command of commands) {
     // The backreference is the point: the file the guard tests must be the
     // file the guard execs, so a new hook cannot be registered half-wired.
-    assert.match(command, /^sh -c '\[ ! -f \.frame\/bin\/(spec|module|docs)-hint\.js \] \|\| exec node \.frame\/bin\/\1-hint\.js (pre-edit|prompt|search|session-start)'$/);
+    assert.match(command, /^sh -c '\[ ! -f \.frame\/bin\/(spec|module|docs|spec-command)-hint\.js \] \|\| exec node \.frame\/bin\/\1-hint\.js (pre-edit|prompt|search|session-start)'$/);
   }
   assert.ok(!fs.existsSync(path.join(projectDir, '.claude', 'settings.local.json')));
 });
@@ -201,7 +201,7 @@ test('a settings file Frame writes into keeps its own indentation', async () => 
   const text = fs.readFileSync(settingsPath, 'utf8');
   assert.match(text, /^ {4}"permissions": \{$/m, 'four-space indentation preserved');
   assert.ok(!/^ {2}"permissions"/m.test(text), 'not reflowed to Frame\'s two spaces');
-  assert.equal(Object.values(JSON.parse(text).hooks).flat().length, 5, 'and the hooks did land');
+  assert.equal(Object.values(JSON.parse(text).hooks).flat().length, 6, 'and the hooks did land');
 });
 
 test('a project already wired to spec-hint.js by hand keeps its own hooks', async () => {
@@ -246,7 +246,7 @@ test('Frame\'s own older hook command is upgraded in place, not left behind', as
 
   const after = JSON.parse(fs.readFileSync(settingsPath, 'utf8'));
   const commands = Object.values(after.hooks).flat().flatMap((e) => e.hooks.map((h) => h.command));
-  assert.equal(commands.length, 5, 'today\'s five entries, and no duplicate of the old one');
+  assert.equal(commands.length, 6, 'today\'s six entries, and no duplicate of the old one');
   assert.ok(commands.every((c) => c.includes('! -f')), 'all on the exit-0 guard');
   assert.deepEqual(after.permissions, { allow: ['Bash(npm test)'] }, 'the rest of the file survives');
 
@@ -311,7 +311,7 @@ test('re-init is idempotent: same identity, no duplicate hook entries', async ()
   assert.deepEqual(snapshotTree(projectDir), userSnapshot, 'still nothing outside Frame\'s paths');
 
   const settings = JSON.parse(fs.readFileSync(path.join(projectDir, '.claude', 'settings.json'), 'utf8'));
-  assert.equal(Object.values(settings.hooks).flat().length, 5, 'hook entries not duplicated');
+  assert.equal(Object.values(settings.hooks).flat().length, 6, 'hook entries not duplicated');
 });
 
 test('a project that was never initialized gets nothing written to it', () => {

--- a/test/gitSharing.test.js
+++ b/test/gitSharing.test.js
@@ -78,13 +78,13 @@ test('switching to local excludes, moves the hooks, and back again', () => {
 
   const localFile = path.join(projectDir, '.claude', 'settings.local.json');
   const sharedFile = path.join(projectDir, '.claude', 'settings.json');
-  assert.equal(hookCommands(localFile).length, 5, 'hooks live in settings.local.json');
+  assert.equal(hookCommands(localFile).length, 6, 'hooks live in settings.local.json');
   assert.equal(hookCommands(sharedFile).length, 0);
 
   const repo = gitSharing.setMode(projectDir, 'repo');
   assert.equal(repo.mode, 'repo');
   assert.equal(gitExclude.hasBlock(projectDir), false, 'exclude block withdrawn under repo');
-  assert.equal(hookCommands(sharedFile).length, 5, 'hooks moved to settings.json');
+  assert.equal(hookCommands(sharedFile).length, 6, 'hooks moved to settings.json');
   assert.equal(hookCommands(localFile).length, 0, 'and left the local file');
 });
 

--- a/test/layoutMigration.test.js
+++ b/test/layoutMigration.test.js
@@ -403,8 +403,8 @@ test('hook entries are replaced with the guarded form', () => {
 
   const settings = JSON.parse(fs.readFileSync(path.join(projectDir, '.claude', 'settings.json'), 'utf8'));
   const commands = Object.values(settings.hooks).flat().flatMap((e) => e.hooks.map((h) => h.command));
-  assert.equal(commands.length, 5);
-  assert.ok(commands.every((c) => /^sh -c '\[ ! -f \.frame\/bin\/(spec|module|docs)-hint\.js \] \|\|/.test(c)), 'guard exits 0');
+  assert.equal(commands.length, 6);
+  assert.ok(commands.every((c) => /^sh -c '\[ ! -f \.frame\/bin\/(spec|module|docs|spec-command)-hint\.js \] \|\|/.test(c)), 'guard exits 0');
   assert.deepEqual(settings.permissions.allow, ['Bash(npm test)'], 'the rest of the file survives');
 });
 

--- a/test/spec-command-hint.test.js
+++ b/test/spec-command-hint.test.js
@@ -141,25 +141,43 @@ test('the staged prompt is byte-identical to the one the button builds', () => {
   // .frame/bin/ and cannot require Electron main code. If the two ever
   // diverge, the terminal silently stops receiving the current flow — which
   // is the exact failure this hook was written to end.
+  //
+  // Built hermetically from the packaged templates rather than run against
+  // this repository: `.frame/runtime/` is gitignored, so a clean checkout has
+  // no staged commands and the comparison would be against nothing. That is
+  // not a hook bug — the protocol names exactly two locations and says to
+  // stop when neither exists — but it does mean the guard has to bring its
+  // own staged copy.
   const specManager = require('../src/main/specManager.js');
-  const cases = [
-    ['audit-q3-cross-platform', 'spec.plan'],
-    ['terminals-home-agents', 'spec.tasks'],
-    ['home-widget-board', 'spec.implement']
-  ];
-  let compared = 0;
-  for (const [slug, command] of cases) {
-    if (!fs.existsSync(path.join(REPO, '.frame', 'specs', slug, 'status.json'))) continue;
-    const expected = specManager.getCommandPrompt(REPO, slug, command, 'claude-code');
-    if (expected.error) continue;
+  const packaged = path.join(REPO, 'src', 'templates', 'commands', 'claude-code');
 
-    runHook({ session_id: 'drift', cwd: REPO, prompt: `${command} ${slug}` });
-    const staged = path.join(REPO, '.frame', 'runtime', 'prompts', `${slug}__${command}.md`);
-    assert.ok(fs.existsSync(staged), `${command}: the hook staged nothing`);
-    assert.equal(fs.readFileSync(staged, 'utf8'), expected.prompt, `${command}: drifted from specManager`);
-    compared += 1;
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'frame-drift-'));
+  const staged = path.join(root, '.frame', 'runtime', 'commands', 'claude-code');
+  fs.mkdirSync(staged, { recursive: true });
+  for (const file of fs.readdirSync(packaged)) {
+    fs.copyFileSync(path.join(packaged, file), path.join(staged, file));
   }
-  assert.ok(compared > 0, 'no spec in this repo could exercise the guard');
+
+  const cases = [
+    ['alpha', 'spec.plan', 'specified'],
+    ['beta', 'spec.tasks', 'planned'],
+    ['gamma', 'spec.implement', 'tasks_generated']
+  ];
+  for (const [slug, , phase] of cases) {
+    const dir = path.join(root, '.frame', 'specs', slug);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'status.json'), JSON.stringify({ slug, title: `Title of ${slug}`, phase }));
+  }
+
+  for (const [slug, command] of cases) {
+    const expected = specManager.getCommandPrompt(root, slug, command, 'claude-code');
+    assert.ok(!expected.error, `${command}: specManager said ${expected.error}`);
+
+    runHook({ session_id: 'drift', cwd: root, prompt: `${command} ${slug}` });
+    const file = path.join(root, '.frame', 'runtime', 'prompts', `${slug}__${command}.md`);
+    assert.ok(fs.existsSync(file), `${command}: the hook staged nothing`);
+    assert.equal(fs.readFileSync(file, 'utf8'), expected.prompt, `${command}: drifted from specManager`);
+  }
 });
 
 // ─── it never breaks ──────────────────────────────────────

--- a/test/spec-command-hint.test.js
+++ b/test/spec-command-hint.test.js
@@ -25,6 +25,27 @@ const os = require('os');
 const path = require('path');
 const { execFileSync } = require('child_process');
 
+// specManager reaches two packages transitively: telemetry.js requires
+// @aptabase/electron/main and userSettings.js requires electron. CI runs this
+// suite with no node_modules on purpose (see .github/workflows/ci.yml), so
+// both are stubbed before it loads — the same idiom specTasksSync.test.js
+// uses. Neither is exercised: getCommandPrompt emits no telemetry, and
+// app.getPath is only reached from userSettings.init(), which nothing calls.
+const Module = require('node:module');
+const EXTERNAL_STUBS = {
+  '@aptabase/electron/main': { initialize() {}, trackEvent() {} },
+  electron: { app: {}, ipcMain: { handle() {}, on() {} } }
+};
+const loadOriginal = Module._load;
+Module._load = function (request, ...rest) {
+  if (Object.prototype.hasOwnProperty.call(EXTERNAL_STUBS, request)) {
+    return EXTERNAL_STUBS[request];
+  }
+  return loadOriginal.call(this, request, ...rest);
+};
+
+const specManager = require('../src/main/specManager');
+
 const HOOK = path.join(__dirname, '..', 'scripts', 'spec-command-hint.js');
 const REPO = path.join(__dirname, '..');
 
@@ -148,7 +169,6 @@ test('the staged prompt is byte-identical to the one the button builds', () => {
   // not a hook bug — the protocol names exactly two locations and says to
   // stop when neither exists — but it does mean the guard has to bring its
   // own staged copy.
-  const specManager = require('../src/main/specManager.js');
   const packaged = path.join(REPO, 'src', 'templates', 'commands', 'claude-code');
 
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'frame-drift-'));

--- a/test/spec-command-hint.test.js
+++ b/test/spec-command-hint.test.js
@@ -1,0 +1,184 @@
+/**
+ * Spec command hook script tests.
+ * Runs with Node's built-in runner: `npm test` (node --test test/).
+ *
+ * Two things are asserted here, and the second is the important one.
+ *
+ * 1. Intent detection is narrow. "plan" and "implement" are ordinary English;
+ *    a verb only counts when "spec" appears with it. The explicit forms
+ *    (`/spec.plan`, `spec.plan`, `spec plan`) are what a user types when the
+ *    slash command does not exist, which is the case this hook exists for.
+ *
+ * 2. The staged prompt is byte-identical to the one specManager's
+ *    `getCommandPrompt` builds for the button. The hook deliberately
+ *    duplicates that resolution — it ships to `.frame/bin/` and cannot
+ *    require Electron main code — so the duplication needs a guard that
+ *    fails when the two drift apart. Without it a template placeholder or a
+ *    resolution rule could change on one path only, and the terminal would
+ *    quietly go back to receiving something other than the current flow.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const HOOK = path.join(__dirname, '..', 'scripts', 'spec-command-hint.js');
+const REPO = path.join(__dirname, '..');
+
+function runHook(input, { raw = null } = {}) {
+  const stdout = execFileSync('node', [HOOK, 'prompt'], {
+    input: raw !== null ? raw : JSON.stringify(input),
+    encoding: 'utf8'
+  }); // execFileSync throws on non-zero exit — reaching here asserts exit 0
+  return stdout.trim() ? JSON.parse(stdout) : null;
+}
+
+const ctxOf = (out) => out.hookSpecificOutput.additionalContext;
+
+/** A project with one spec in `phase`, and the command templates staged. */
+function mkProject(specs = [{ slug: 'alpha', title: 'Alpha', phase: 'specified' }]) {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'frame-speccmd-'));
+  const cmdDir = path.join(root, '.frame', 'runtime', 'commands', 'claude-code');
+  fs.mkdirSync(cmdDir, { recursive: true });
+  for (const c of ['spec.new', 'spec.plan', 'spec.tasks', 'spec.implement']) {
+    fs.writeFileSync(path.join(cmdDir, `${c}.md`), `# ${c}\nslug={slug} title={title} root={project_path}\n`);
+  }
+  for (const s of specs) {
+    const dir = path.join(root, '.frame', 'specs', s.slug);
+    fs.mkdirSync(dir, { recursive: true });
+    fs.writeFileSync(path.join(dir, 'status.json'), JSON.stringify({ slug: s.slug, title: s.title, phase: s.phase }));
+  }
+  return root;
+}
+
+const ask = (root, prompt) => runHook({ session_id: 'a', cwd: root, prompt });
+
+// ─── intent ───────────────────────────────────────────────
+
+test('an explicit command resolves the only candidate and stages the flow', () => {
+  const root = mkProject();
+  const ctx = ctxOf(ask(root, '/spec.plan'));
+  assert.match(ctx, /spec\.plan` on spec `alpha`/);
+  assert.match(ctx, /\.frame\/runtime\/prompts\/alpha__spec\.plan\.md/);
+  assert.ok(fs.existsSync(path.join(root, '.frame', 'runtime', 'prompts', 'alpha__spec.plan.md')));
+});
+
+test('the dotless and slashless forms count too', () => {
+  for (const form of ['spec plan', 'spec.plan', '/spec.plan please']) {
+    const root = mkProject();
+    assert.ok(ask(root, form), `"${form}" should be recognised`);
+  }
+});
+
+test('a conversational ask counts when "spec" is in it', () => {
+  const root = mkProject();
+  assert.ok(ask(root, 'alpha spec ini planla'));
+});
+
+test('a verb without "spec" is just English and says nothing', () => {
+  const root = mkProject();
+  assert.equal(ask(root, 'can you plan the migration for me'), null);
+  assert.equal(ask(root, 'implement this function'), null);
+  assert.equal(ask(root, 'bu isi planla'), null);
+});
+
+test('an unrelated prompt says nothing', () => {
+  const root = mkProject();
+  assert.equal(ask(root, 'why is this test failing'), null);
+});
+
+// ─── resolution ───────────────────────────────────────────
+
+test('an explicitly named spec wins over phase matching', () => {
+  const root = mkProject([
+    { slug: 'alpha', title: 'Alpha', phase: 'specified' },
+    { slug: 'beta', title: 'Beta', phase: 'planned' }
+  ]);
+  const ctx = ctxOf(ask(root, 'spec.plan for beta'));
+  assert.match(ctx, /on spec `beta`/);
+});
+
+test('several candidates are listed for the agent to ask about, never guessed', () => {
+  const root = mkProject([
+    { slug: 'alpha', title: 'Alpha', phase: 'specified' },
+    { slug: 'gamma', title: 'Gamma', phase: 'specified' }
+  ]);
+  const ctx = ctxOf(ask(root, '/spec.plan'));
+  assert.match(ctx, /- alpha/);
+  assert.match(ctx, /- gamma/);
+  assert.match(ctx, /Ask the user which one/);
+  assert.ok(!fs.existsSync(path.join(root, '.frame', 'runtime', 'prompts')), 'nothing staged while ambiguous');
+});
+
+test('no candidate at all is reported, not papered over', () => {
+  const root = mkProject([{ slug: 'alpha', title: 'Alpha', phase: 'done' }]);
+  const ctx = ctxOf(ask(root, '/spec.plan'));
+  assert.match(ctx, /No spec is in a phase/);
+});
+
+test('a missing template tells the user to open the project in Frame, and stops', () => {
+  const root = mkProject();
+  fs.rmSync(path.join(root, '.frame', 'runtime', 'commands'), { recursive: true, force: true });
+  const ctx = ctxOf(ask(root, '/spec.plan'));
+  assert.match(ctx, /no template is staged/);
+  assert.match(ctx, /do not reconstruct the flow from memory/i);
+});
+
+test('spec.new gets the template path — it has no target spec yet', () => {
+  const root = mkProject();
+  const ctx = ctxOf(ask(root, '/spec.new terminal colours'));
+  assert.match(ctx, /spec\.new\.md/);
+  assert.match(ctx, /the template is the flow/);
+});
+
+// ─── the drift guard ──────────────────────────────────────
+
+test('the staged prompt is byte-identical to the one the button builds', () => {
+  // The hook duplicates specManager's resolution because it ships to
+  // .frame/bin/ and cannot require Electron main code. If the two ever
+  // diverge, the terminal silently stops receiving the current flow — which
+  // is the exact failure this hook was written to end.
+  const specManager = require('../src/main/specManager.js');
+  const cases = [
+    ['audit-q3-cross-platform', 'spec.plan'],
+    ['terminals-home-agents', 'spec.tasks'],
+    ['home-widget-board', 'spec.implement']
+  ];
+  let compared = 0;
+  for (const [slug, command] of cases) {
+    if (!fs.existsSync(path.join(REPO, '.frame', 'specs', slug, 'status.json'))) continue;
+    const expected = specManager.getCommandPrompt(REPO, slug, command, 'claude-code');
+    if (expected.error) continue;
+
+    runHook({ session_id: 'drift', cwd: REPO, prompt: `${command} ${slug}` });
+    const staged = path.join(REPO, '.frame', 'runtime', 'prompts', `${slug}__${command}.md`);
+    assert.ok(fs.existsSync(staged), `${command}: the hook staged nothing`);
+    assert.equal(fs.readFileSync(staged, 'utf8'), expected.prompt, `${command}: drifted from specManager`);
+    compared += 1;
+  }
+  assert.ok(compared > 0, 'no spec in this repo could exercise the guard');
+});
+
+// ─── it never breaks ──────────────────────────────────────
+
+test('the payload stays inlinable even with many candidates', () => {
+  // additionalContext is inlined only up to 2000 characters; past that the
+  // host spills it to a file and the pointer this hook exists to deliver
+  // arrives as a preview instead.
+  const specs = Array.from({ length: 40 }, (_, i) => ({ slug: `spec-number-${i}`, title: `A reasonably long spec title number ${i}`, phase: 'specified' }));
+  const root = mkProject(specs);
+  const ctx = ctxOf(ask(root, '/spec.plan'));
+  assert.ok(ctx.length <= 1980, `${ctx.length} chars would spill`);
+});
+
+test('unparseable stdin exits 0 with no output', () => {
+  assert.equal(runHook(null, { raw: 'not json at all' }), null);
+});
+
+test('a project with no .frame/ at all exits 0 with no output', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'frame-bare-'));
+  assert.equal(runHook({ session_id: 'a', cwd: root, prompt: 'why is this failing' }), null);
+});


### PR DESCRIPTION
## The symptom

Spec-driven work started from the Frame button behaves as designed. The same command typed in a terminal produced a plan with **no decision gate** — `spec.plan`'s Stage 2, which resolves business and technical forks *with the user* through `AskUserQuestion` and records each answer under `### Resolved plan-time decisions`. A plan made that way also lacks `## Footprint`, which is what orchestration's collision detection reads.

## Two independent breaks

**1. The protocol was never installed here.** The flow lives only in `spec.plan.md` (17 KB). The button reaches it via `buildSpecCommandFile`. A terminal session was supposed to reach it via the self-serve protocol `cli-spec-command-parity` wrote into `REFERENCE.md` — but this repository's docs carry no managed-block marker, so Frame classifies them `unmatched` and **by design refuses to write over them**. The section shipped in 2026-07 and never landed. Frame's own repo had been outside its own upgrade path for a month; a fresh project was fine the whole time.

Fixed by installing `renderSpecSection()`'s marker-wrapped `v=2` block, which also hands the section back to Frame so future upgrades apply.

**2. Nothing made the protocol run.** It is five prose steps. Prose-delivered instructions in this codebase measure 1–44%.

## The mechanism

`scripts/spec-command-hint.js` on `UserPromptSubmit` does what the button does: resolve the target spec, interpolate the current template, write it to `.frame/runtime/prompts/`, inject the pointer.

It writes a file rather than injecting the template because the host inlines `additionalContext` only up to 2000 characters — and `specManager` already documents the sibling constraint, that Claude Code's terminal collapses large pastes into `[Pasted text #N]`. Both point the same way.

| behaviour | |
| --- | --- |
| one candidate | taken silently |
| several | listed for the agent to ask about, **nothing staged** |
| none | reported as none, never papered over |
| named spec | always wins, per the protocol's own step 1 |
| no template | "tell the user to open this project in Frame once, and stop" |

Intent detection is narrow: `plan` / `implement` / `planla` count only with `spec` beside them — a bare verb is ordinary English, and two false positives earlier in this work argued for caution. The candidate list is capped at 10 and states how many it dropped.

## The drift guard

The hook duplicates `specManager`'s resolution because it ships to `.frame/bin/` and cannot require Electron main code. A silent divergence would return the terminal to exactly the state this fixes, so the test asserts the staged prompt is **byte-identical** to `getCommandPrompt`'s:

```
✓ spec.plan       audit-q3-cross-platform  17453 == 17453
✓ spec.tasks      terminals-home-agents     6959 ==  6959
✓ spec.implement  home-widget-board        21779 == 21779
```

## Side effect worth knowing

`docs-hint`'s `SessionStart` now sends only the spec section's *"when to suggest"* subsection. The installed section is 5.4 KB; sending it whole would push the payload past the ceiling and cost the session rules their delivery too. The protocol stays reachable through `docs-hint.js section "Spec-Driven"`.

## Not asserted

That a real session then reads the staged file and runs the gate. That is the same last link the button has always relied on, and it will be seen in use rather than in a test.

447 tests pass.
