### PR TITLE
fix: migration agent review false alarms

### DIFF
--- a/.frame/STRUCTURE.json
+++ b/.frame/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Auto-generated module structure",
-  "lastUpdated": "2026-08-27",
+  "lastUpdated": "2026-08-28",
   "architecture": {},
   "modules": {
     "main/activityLog": {
@@ -2160,14 +2160,31 @@
             "to"
           ]
         },
+        "hasSection": {
+          "line": 311,
+          "params": [
+            "text",
+            "stem"
+          ],
+          "purpose": "Does the document carry a heading like this one? Matched on a lowercase,"
+        },
+        "lineNeedsReview": {
+          "line": 334,
+          "params": [
+            "text",
+            "to",
+            "section"
+          ],
+          "purpose": "Is a line Frame could not find actually worth a human's attention?"
+        },
         "upgradeAgentsText": {
-          "line": 317,
+          "line": 353,
           "params": [
             "text"
           ]
         },
         "execute": {
-          "line": 346,
+          "line": 384,
           "params": [
             "projectPath",
             "activePlan",
@@ -2177,7 +2194,7 @@
           "purpose": "The steps themselves, in order, writing what happened into `state`. Split"
         },
         "run": {
-          "line": 458,
+          "line": 496,
           "params": [
             "projectPath",
             "migrationPlan",
@@ -2186,14 +2203,14 @@
           "purpose": "Execute a plan. Reports progress through `onProgress({ step, detail })` and"
         },
         "pendingDecisions": {
-          "line": 524,
+          "line": 562,
           "params": [
             "projectPath"
           ],
           "purpose": "What is left for the user to answer, derived rather than stored."
         },
         "applyDecisions": {
-          "line": 554,
+          "line": 592,
           "params": [
             "projectPath",
             "decisions = []"

--- a/.frame/tasks.json
+++ b/.frame/tasks.json
@@ -7,7 +7,7 @@
   },
   "project": "Frame",
   "version": "2.0",
-  "lastUpdated": "2026-08-27T15:27:31.207Z",
+  "lastUpdated": "2026-08-28T08:14:21.385Z",
   "taskSchema": {
     "_comment": "This schema shows the expected structure for each task",
     "id": "unique-id (task-xxx format)",
@@ -6105,6 +6105,21 @@
       "createdAt": "2026-08-27T14:12:47.220Z",
       "updatedAt": "2026-08-27T15:27:31.207Z",
       "completedAt": "2026-08-27T15:27:31.207Z"
+    },
+    {
+      "id": "task-agents-review-false-alarms",
+      "title": "Stop reporting AGENTS.md lines that were never in the file",
+      "description": "upgradeAgentsText's review list currently means 'one of Frame's seven known lines was not found', which conflates two unrelated cases: the user edited or removed the line, and the document is from a template generation that never carried it. Every real project hits the second case, so the list fires 7-8 times on documents where nothing is wrong. Replace the single includes() check with three: the line found in its old form is replaced; the line found in its upgraded form is already done and says nothing; a line whose section heading is absent from the document belongs to another generation and says nothing. Only a line whose section is present while neither form is counts as review-worthy. Section headings are matched by stem, tolerant of emoji and trailing words, following the SPEC_HEADING_STEMS pattern already in frameProject.js. Files: src/main/layoutMigration.js, test/layoutMigration.test.js.",
+      "userRequest": "User said: [comeety ekran goruntuleri] Hala daha Agents.md soruyor ve Update dedikten sonra boyle oluyor => bunlar neden oluyor / bir fix task'i acalim ve o task'a ait bir branch acalim oyle yapalim bu fix'i",
+      "acceptanceCriteria": "Measured against four real documents: comeety's pre-Update AGENTS.md (old full generation) goes 7 review items to 0; Frame's own AGENTS.md and the untouched current lean template both go 8 to 0; a lean template with one navigation line deleted by the user goes 8 to exactly 1, naming that line. The existing customised-AGENTS.md test is reshaped to keep Frame's section heading while changing the line, because that is the case the review list exists for. npm test green.",
+      "notes": "Found in the field on comeety after the migration-consent-scope modal shipped. upgradeAgentsText is byte-identical to main - the function dates from non-invasive-overlay T08 and was never touched by the migration branch; what that branch changed is that the list now reaches a user through a modal instead of sitting in a receipt nobody saw, because before it a legacy project could not migrate at all. This also violates a rule already recorded in spec-docs-delivery-invariant's digest: 'when reasoning about an older generation of a Frame-written doc, compare headings first - a matcher that misses may point at a section that was never there.' Branched off fix/migration-consent-scope rather than main: the bug is latent on main (no legacy project can migrate there), and test/layoutMigration.test.js differs too much between the two to fix it independently. Separate from the ownership-split work in .frame/specs/migration-consent-scope/followup-agents-ownership.md - this fix does not stop the modal appearing, it only stops it lying about what it left alone.",
+      "status": "completed",
+      "priority": "high",
+      "category": "fix",
+      "context": "Session 2026-08-28 - field report from comeety after the migration modal shipped",
+      "createdAt": "2026-08-28T08:11:32.066Z",
+      "updatedAt": "2026-08-28T08:14:21.385Z",
+      "completedAt": "2026-08-28T08:14:21.385Z"
     }
   ],
   "metadata": {

--- a/src/main/layoutMigration.js
+++ b/src/main/layoutMigration.js
@@ -287,19 +287,55 @@ function copyVerified(from, to) {
 }
 
 /**
- * The AGENTS.md lines the old templates wrote, and their `.frame/` forms. A
- * line that isn't found is left alone and named in the receipt's review list:
- * people customise AGENTS.md, and a full rewrite would be hostile.
+ * The AGENTS.md lines the old templates wrote, their `.frame/` forms, and the
+ * section each one lives in. A line that isn't found is left alone; whether
+ * that is worth *reporting* is a separate question, and the section is how it
+ * gets answered — see `lineNeedsReview`.
  */
 const AGENTS_LINE_EDITS = [
-  ['1. **STRUCTURE.json**', '1. **`.frame/STRUCTURE.json`**'],
-  ['2. **PROJECT_NOTES.md**', '2. **`.frame/PROJECT_NOTES.md`**'],
-  ['3. **tasks.json**', '3. **`.frame/tasks.json`**'],
-  ['| tasks.json  ', '| `.frame/tasks.json`  '],
-  ['| PROJECT_NOTES.md ', '| `.frame/PROJECT_NOTES.md` '],
-  ['| STRUCTURE.json ', '| `.frame/STRUCTURE.json` '],
-  ['| QUICKSTART.md ', '| `.frame/QUICKSTART.md` ']
+  ['1. **STRUCTURE.json**', '1. **`.frame/STRUCTURE.json`**', 'project navigation'],
+  ['2. **PROJECT_NOTES.md**', '2. **`.frame/PROJECT_NOTES.md`**', 'project navigation'],
+  ['3. **tasks.json**', '3. **`.frame/tasks.json`**', 'project navigation'],
+  ['| tasks.json  ', '| `.frame/tasks.json`  ', 'writing frame meta files'],
+  ['| PROJECT_NOTES.md ', '| `.frame/PROJECT_NOTES.md` ', 'writing frame meta files'],
+  ['| STRUCTURE.json ', '| `.frame/STRUCTURE.json` ', 'writing frame meta files'],
+  ['| QUICKSTART.md ', '| `.frame/QUICKSTART.md` ', 'writing frame meta files']
 ];
+
+/**
+ * Does the document carry a heading like this one? Matched on a lowercase,
+ * letters-only stem so a generation that wrote `## 📝 Project Navigation` or
+ * `## Writing Frame meta files — read the reference first` still counts —
+ * the `SPEC_HEADING_STEMS` approach in frameProject.js, applied here.
+ */
+function hasSection(text, stem) {
+  return text.split('\n').some((line) => {
+    const heading = line.match(/^#{1,3}\s+(.*)$/);
+    if (!heading) return false;
+    return heading[1].toLowerCase().replace(/[^a-z ]/g, '').trim().includes(stem);
+  });
+}
+
+/**
+ * Is a line Frame could not find actually worth a human's attention?
+ *
+ * Only when the user changed it. Three cases say nothing, and lumping them in
+ * is what made this list fire seven or eight times on documents where nothing
+ * was wrong: the line is already in its upgraded form; the section it belongs
+ * to is missing entirely, so this generation of the template never wrote it;
+ * or — the case that survives — the section is right there and neither form
+ * of the line is, which means somebody edited it.
+ *
+ * `spec-docs-delivery-invariant` recorded the rule this implements: when
+ * reasoning about an older generation of a Frame-written doc, compare headings
+ * first, because a matcher that misses may be pointing at a section that was
+ * never there.
+ */
+function lineNeedsReview(text, to, section) {
+  if (text.includes(to)) return false;
+  if (section && !hasSection(text, section)) return false;
+  return true;
+}
 
 // The whole note paragraph, however it is wrapped: templates have written it
 // as one long line, as several wrapped lines, and as a blockquote. Matching a
@@ -319,9 +355,9 @@ function upgradeAgentsText(text) {
   let next = text;
   const review = [];
 
-  for (const [from, to] of AGENTS_LINE_EDITS) {
+  for (const [from, to, section] of AGENTS_LINE_EDITS) {
     if (next.includes(from)) next = next.replace(from, to);
-    else review.push(from.trim());
+    else if (lineNeedsReview(next, to, section)) review.push(from.trim());
   }
 
   const match = next.match(AGENTS_SYMLINK_NOTE);
@@ -331,7 +367,9 @@ function upgradeAgentsText(text) {
     const prefix = match[2] || '';
     const quoted = AGENTS_POINTER_NOTE.map((line) => `${prefix}${line}`).join('\n');
     next = next.replace(AGENTS_SYMLINK_NOTE, `${match[1]}${quoted}`);
-  } else {
+  } else if (!next.includes(AGENTS_POINTER_NOTE[0])) {
+    // Neither the old note nor the one that replaces it — the paragraph is
+    // the user's now, or was never there.
     review.push('the CLAUDE.md symlink note');
   }
 

--- a/test/layoutMigration.test.js
+++ b/test/layoutMigration.test.js
@@ -299,14 +299,61 @@ test('the move leaves AGENTS.md alone; applyDecisions is what rewrites it', () =
   assert.equal(frameStore.readAgents(projectDir), agents);
 });
 
-test('applyDecisions leaves a customised AGENTS.md alone and lists it for review', () => {
+test('a line the user edited out of a section Frame wrote is named for review', () => {
+  // The case the review list exists for, and the only one that should reach a
+  // human: the section is right there, and the line inside it has been changed.
+  const edited = `# demo
+
+## Project Navigation
+
+1. **STRUCTURE.json** — module map
+2. **PROJECT_NOTES.md** — notes
+3. (my own third entry)
+
+**Note:** This file is named \`AGENTS.md\` to be AI-tool agnostic. A \`CLAUDE.md\` symlink is provided for Claude Code compatibility.
+`;
+  const upgraded = layoutMigration.upgradeAgentsText(edited);
+  assert.deepEqual(upgraded.review, ['3. **tasks.json**'], 'exactly the line that was changed');
+  assert.match(upgraded.text, /1\. \*\*`\.frame\/STRUCTURE\.json`\*\*/, 'the untouched lines still upgrade');
+  assert.match(upgraded.text, /3\. \(my own third entry\)/, "and the user's line is left alone");
+});
+
+test('a document from another generation reports nothing to review', () => {
+  // Frame's older full-generation AGENTS.md carried none of the lean core's
+  // navigation lines. Reporting seven "could not find" items for lines that
+  // were never in this generation is what made the list meaningless — the
+  // rule spec-docs-delivery-invariant recorded: compare headings first.
+  const olderGeneration = `# demo
+
+## Task Management (tasks.json)
+
+Rules live here.
+
+## 📝 Context Preservation
+
+More rules.
+
+**Note:** This file is named \`AGENTS.md\` to be AI-tool agnostic. A \`CLAUDE.md\` symlink is provided for Claude Code compatibility.
+`;
+  const upgraded = layoutMigration.upgradeAgentsText(olderGeneration);
+  assert.deepEqual(upgraded.review, [], 'no section, so no line was ever there');
+  assert.match(upgraded.text, /This file lives at `\.frame\/AGENTS\.md`/, 'the note still gets replaced');
+});
+
+test('an already-upgraded document reports nothing to review', () => {
+  const current = templates.getAgentsTemplate('demo', {});
+  const upgraded = layoutMigration.upgradeAgentsText(current);
+  assert.deepEqual(upgraded.review, [], 'every line is already in its .frame/ form');
+  assert.equal(upgraded.text, current, 'and nothing is rewritten');
+});
+
+test('applyDecisions leaves a customised AGENTS.md alone', () => {
   projectDir = makeLegacyProject({ commit: true });
   layoutMigration.run(projectDir, layoutMigration.plan(projectDir));
   frameStore.writeAgents(projectDir, '# My own file\n\nNothing Frame wrote.\n');
 
   const receipt = layoutMigration.applyDecisions(projectDir, [{ kind: 'agents-prose' }]);
   assert.equal(receipt.ran, false, 'no line matched, so nothing was written');
-  assert.ok(receipt.review.length > 0, 'and every line it could not find is named');
   assert.equal(frameStore.readAgents(projectDir), '# My own file\n\nNothing Frame wrote.\n');
 
   // An empty decision list is a no-op, whatever the project looks like.


### PR DESCRIPTION
## What the user saw

  After the migration modal's **Update**, the receipt listed seven things to
  "check by hand" — all seven of them lines that were never in that document.
  The modal itself made the same claim before the click, naming seven lines
  under *"Anything Frame did not write is left alone"* when Frame had in fact
  written them, in a different generation, and none were in the file.

  Nothing was damaged: the Update changed exactly the one line it should have,
  and `.claude/rules/frame.md` refreshed correctly. The work was right; the
  report about it was wrong.

  ## Cause

  `upgradeAgentsText`'s review list meant *"one of Frame's seven known lines was
  not found"*, which conflates two unrelated things:

  - the user edited or removed the line → genuinely worth a look
  - the document is from a template generation that never carried it → nothing
    to look at

  `AGENTS_LINE_EDITS` targets the lean core template's `## Project Navigation`
  and meta-file table. A project on the older full generation has neither
  section, so all seven miss and all seven get reported. Every real project
  hits this.

  The function is unchanged since `non-invasive-overlay` T08 — #130 did not
  introduce the bug, it made it visible: before it, a legacy project could not
  migrate at all, so the list sat in a receipt nobody ever saw. Now it reaches
  a user through a modal they click through.

  This also breaks a rule already recorded in `spec-docs-delivery-invariant`'s
  digest:

  > when reasoning about an older generation of a Frame-written doc, compare
  > headings first — a matcher that misses may point at a section that was
  > never there.

  ## The fix

  Three checks where there was one:

  1. the line found in its old form → replaced, nothing said
  2. the line already in its `.frame/` form → nothing said
  3. the line's section heading absent from the document → another generation,
     nothing said

  Only a line whose **section is present while neither form is** counts as
  review-worthy — somebody edited it. Section headings match on a lowercase
  letters-only stem, so an older `## 📝 Project Navigation` or the current
  `## Writing Frame meta files — read the reference first` both count. That
  follows `SPEC_HEADING_STEMS` in `frameProject.js` rather than inventing a
  second convention.

  The symlink note gets the same treatment: reported only when neither the old
  note nor the pointer that replaces it is present.

  ## Measured

  Four real documents, before → after:

  | Document | Review items now | After |
  | --- | --- | --- |
  | A field project on the old full generation | 7 | **0** |
  | Frame's own `.frame/AGENTS.md` | 8 | **0** |
  | The current lean template, untouched | 8 | **0** |
  | The lean template with one nav line deleted by hand | 8 | **1 — that line** |

  The last row is the point: the list starts working for the case it exists
  for, and only that case. Confirmed in the app afterwards — the modal's
  "left alone" sentence ends without a list, and the receipt's "Worth a look"
  section does not render at all.

  `npm test` — **450 passing, 0 failing.**

  ## Test changes worth a look

  The existing `applyDecisions leaves a customised AGENTS.md alone and lists it
  for review` test kept passing after the fix — but only because it asserted
  `review.length > 0` and the count had quietly gone from 7 to 1. That is not a
  test of anything, so it is split into four:

  - a section Frame wrote with one line edited inside it → names exactly that line
  - a document from another generation → reports nothing
  - an already-upgraded document → reports nothing, rewrites nothing
  - the customised file → still left alone

  ## Scope

  One function in `src/main/layoutMigration.js` plus its tests. No behaviour
  change to what gets written — only to what gets reported. The modal still
  appears for a project whose symlink note is stale, because that note is
  genuinely false after migration; whether it should appear at all is the
  ownership question written up in
  `.frame/specs/migration-consent-scope/followup-agents-ownership.md`.