### PR TITLE
feat(orchestrator): start the conductor on request, not on open

### DIFF
--- a/.frame/STRUCTURE.json
+++ b/.frame/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Auto-generated module structure",
-  "lastUpdated": "2026-08-28",
+  "lastUpdated": "2026-08-31",
   "architecture": {},
   "modules": {
     "main/activityLog": {
@@ -6747,84 +6747,104 @@
           "line": 187
         },
         "stopSession": {
-          "line": 240,
+          "line": 248,
           "purpose": "Stop the whole session: teardown (worktrees removed, merged branches pruned,"
         },
+        "syncToolbar": {
+          "line": 260,
+          "params": [
+            "root"
+          ],
+          "purpose": "Stop & clean up only means something once a session exists."
+        },
         "renderConductorZone": {
-          "line": 251,
+          "line": 267,
           "params": [
             "root"
           ]
         },
+        "renderStartPanel": {
+          "line": 292,
+          "params": [
+            "zone"
+          ],
+          "purpose": "Idle state: the board is open but no conductor exists yet. The terminal zone"
+        },
+        "startFromPanel": {
+          "line": 308,
+          "params": [
+            "e"
+          ]
+        },
         "stageOf": {
-          "line": 285,
+          "line": 346,
           "params": [
             "w"
           ]
         },
         "renderPipeline": {
-          "line": 298,
+          "line": 359,
           "params": [
             "root"
           ]
         },
         "renderWorkerZone": {
-          "line": 341,
+          "line": 402,
           "params": [
             "root"
           ]
         },
         "mergeWorkerAction": {
-          "line": 391,
+          "line": 452,
           "params": [
             "slug"
           ]
         },
         "resumeWorkerAction": {
-          "line": 411,
+          "line": 472,
           "params": [
             "slug"
           ]
         },
         "removeWorkerAction": {
-          "line": 419,
+          "line": 480,
           "params": [
             "slug"
           ]
         },
         "_shortPath": {
-          "line": 428,
+          "line": 489,
           "params": [
             "p"
           ]
         },
         "_relTime": {
-          "line": 434,
+          "line": 495,
           "params": [
             "ts"
           ]
         },
         "loadSpecs": {
-          "line": 445,
+          "line": 506,
           "params": [
             "root"
           ]
         },
         "renderSpecRail": {
-          "line": 460,
+          "line": 521,
           "params": [
             "root",
             "specs"
           ]
         },
         "assignSpec": {
-          "line": 494,
+          "line": 556,
           "params": [
             "slug"
           ]
         },
         "nudgeConductor": {
-          "line": 508,
+          "line": 570,
           "params": [
             "projectPath"
           ]

--- a/src/renderer/orchestrator.js
+++ b/src/renderer/orchestrator.js
@@ -190,10 +190,17 @@ function createViewport() {
   let container = null;
 
   function navigate() {
-    // Opened/focused — ensure the session, then refresh so the conductor mounts.
-    ensureSession()
-      .then((ok) => { if (ok && host) host.notifySectionChanged(); })
-      .catch((err) => console.error('orchestrator: ensureSession failed', err));
+    // Opening the board must NOT spin up a conductor — that is an explicit act
+    // (the Start panel). Only an already-running session is re-attached here,
+    // so returning to the tab/project remounts its live conductor terminal.
+    const s = _curSess();
+    if (s && s.started) {
+      ensureSession()
+        .then((ok) => { if (ok && host) host.notifySectionChanged(); })
+        .catch((err) => console.error('orchestrator: ensureSession failed', err));
+    } else if (host) {
+      host.notifySectionChanged(); // nothing to start yet — just draw the board
+    }
   }
 
   function getChip() {
@@ -220,6 +227,7 @@ function createViewport() {
       </div>
     `;
     el.querySelector('.orch-stop').addEventListener('click', stopSession);
+    syncToolbar(el);
     renderPipeline(el);
     renderConductorZone(el);
     renderWorkerZone(el);
@@ -248,10 +256,20 @@ async function stopSession() {
 
 // ─── zones ────────────────────────────────────────────────
 
+// Stop & clean up only means something once a session exists.
+function syncToolbar(root) {
+  const stop = root.querySelector('.orch-stop');
+  if (!stop) return;
+  const s = _curSess();
+  stop.hidden = !(s && s.started);
+}
+
 function renderConductorZone(root) {
   const zone = root.querySelector('[data-zone="conductor"]');
   if (!zone) return;
-  const conductorId = _curSess() && _curSess().conductorId;
+  const s = _curSess();
+  if (!s || !s.started) { renderStartPanel(zone); return; }
+  const conductorId = s.conductorId;
   zone.innerHTML = `
     <div class="orch-zone-head">
       <span class="orch-zone-title">Conductor</span>
@@ -266,6 +284,49 @@ function renderConductorZone(root) {
     if (expand) expand.addEventListener('click', () => host.enterLane(conductorId));
   } else {
     hostEl.innerHTML = '<div class="orch-empty">Starting conductor…</div>';
+  }
+}
+
+// Idle state: the board is open but no conductor exists yet. The terminal zone
+// holds the call to action instead of a terminal nobody asked for.
+function renderStartPanel(zone) {
+  zone.innerHTML = `
+    <div class="orch-zone-head">
+      <span class="orch-zone-title">Conductor</span>
+    </div>
+    <div class="orch-conductor-host orch-start-host">
+      <div class="orch-start-panel">
+        <div class="orch-start-title">Orchestration is not running</div>
+        <p class="orch-start-sub">Starting opens a conductor Frame that reads CONDUCTOR.md, then dispatches the specs you assign into their own worktrees.</p>
+        <button type="button" class="orch-start-btn">Start Orchestrator</button>
+      </div>
+    </div>
+  `;
+  zone.querySelector('.orch-start-btn').addEventListener('click', startFromPanel);
+}
+
+async function startFromPanel(e) {
+  const btn = e.currentTarget;
+  btn.disabled = true;
+  btn.textContent = 'Starting…';
+  let ok = false;
+  try {
+    ok = await ensureSession();
+  } catch (err) {
+    console.error('orchestrator: ensureSession failed', err);
+  }
+  if (!ok) {
+    btn.disabled = false;
+    btn.textContent = 'Start Orchestrator';
+    return;
+  }
+  // The host re-renders the whole section (render() runs again), which mounts
+  // the conductor terminal and re-enables Assign — don't paint it twice here.
+  if (host) host.notifySectionChanged();
+  else if (liveContainer && document.body.contains(liveContainer)) {
+    syncToolbar(liveContainer);
+    renderConductorZone(liveContainer);
+    loadSpecs(liveContainer);
   }
 }
 
@@ -466,12 +527,13 @@ function renderSpecRail(root, specs) {
     return;
   }
   const cur = _curSess();
+  const started = !!(cur && cur.started);
   const assignedSet = (cur && cur.assigned) || new Set();
   for (const spec of specs) {
     const slug = specSlug(spec);
     if (!slug) continue;
     const phase = specPhase(spec);
-    const assignable = ASSIGNABLE_PHASES.includes(phase);
+    const assignable = started && ASSIGNABLE_PHASES.includes(phase);
     const isAssigned = assignedSet.has(slug);
     const row = document.createElement('div');
     row.className = 'orch-spec-row' + (assignable ? '' : ' disabled');
@@ -480,7 +542,7 @@ function renderSpecRail(root, specs) {
         <div class="orch-spec-title"></div>
         <div class="orch-spec-phase">${escapeHtml(phase)}</div>
       </div>
-      <button type="button" class="orch-spec-assign" ${assignable && !isAssigned ? '' : 'disabled'}>${isAssigned ? 'Assigned' : 'Assign'}</button>
+      <button type="button" class="orch-spec-assign" ${assignable && !isAssigned ? '' : 'disabled'}${started ? '' : ' title="Start the orchestrator first"'}>${isAssigned ? 'Assigned' : 'Assign'}</button>
     `;
     row.querySelector('.orch-spec-title').textContent = specTitle(spec);
     const btn = row.querySelector('.orch-spec-assign');

--- a/src/renderer/styles/components/orchestrator.css
+++ b/src/renderer/styles/components/orchestrator.css
@@ -212,6 +212,44 @@
   background: var(--bg-deep);
 }
 
+/* Idle conductor zone — the board opens without a session; this is where the
+   user starts one (nothing spawns until they click). */
+.orch-start-host {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-lg);
+}
+.orch-start-panel {
+  max-width: 380px;
+  text-align: center;
+}
+.orch-start-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: var(--space-sm);
+}
+.orch-start-sub {
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-tertiary);
+  margin: 0 0 var(--space-lg);
+}
+.orch-start-btn {
+  background: var(--accent-primary);
+  color: var(--bg-deep);
+  border: none;
+  border-radius: var(--radius-md);
+  padding: 12px 28px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter var(--transition-fast);
+}
+.orch-start-btn:hover { filter: brightness(1.08); }
+.orch-start-btn:disabled { opacity: 0.6; cursor: default; filter: none; }
+
 .orch-zone-title {
   font-size: 11px;
   text-transform: uppercase;


### PR DESCRIPTION
## Problem

Clicking **Orchestration** in the sidebar started a conductor session as a side effect of navigation: `navigate()` called `ensureSession()`, which created a Frame terminal, sent `START_ORCHESTRATION`, and dispatched the conductor agent. Just looking at the board cost a terminal and a live Claude session.

## Change

The board now opens idle. The conductor zone — where the terminal normally sits — holds a start panel with a large **Start Orchestrator** button; only that click calls `ensureSession()`.

- `navigate()` still re-attaches an **already-running** session, so returning to the tab or switching back to the project remounts the live conductor terminal exactly as before.
- The button shows `Starting…` while the lane comes up and reverts on failure.

### Follow-ons for coherence with the idle state

- "Stop & clean up" is hidden until a session exists — nothing to stop before that.
- Spec **Assign** buttons are disabled until the orchestrator is started (tooltip: *Start the orchestrator first*). Previously an assign before start pushed the set to main but nudged no conductor, so it silently did nothing.
- `isActive()` — and therefore the sidebar's "running" badge — now means "a conductor is actually running", which is stricter than before.

## Testing

`npm run build` passes; the flow was exercised in the running app.