### PR TITLE
feat(top-bar): the tool select is back beside Start

### DIFF
--- a/.frame/STRUCTURE.json
+++ b/.frame/STRUCTURE.json
@@ -4605,6 +4605,7 @@
       "description": "AI Tool Selector Module",
       "exports": [
         "init",
+        "mountSelector",
         "getCurrentTool",
         "getAvailableTools",
         "getStartCommand",
@@ -4656,6 +4657,10 @@
             "feature"
           ],
           "purpose": "Check if current tool supports a feature"
+        },
+        "mountSelector": {
+          "line": 155,
+          "purpose": "Wire a freshly rendered `#ai-tool-selector`."
         }
       },
       "ipc": {
@@ -9882,7 +9887,8 @@
         "lucide",
         "htmlUtils",
         "laneStatus",
-        "notify"
+        "notify",
+        "aiToolSelector"
       ],
       "functions": {
         "lucideIcon": {

--- a/.frame/specs/home-widget-board/outcome.md
+++ b/.frame/specs/home-widget-board/outcome.md
@@ -166,3 +166,31 @@ the branch per the user's standing preference; T11's text does not name it.
 _Captured: 2026-08-27 · 6 file change(s)_
 
 ---
+## T08 — REVERSED (2026-09-01)
+
+The tool select is back beside Start in the top bar. T08 removed it on the
+grounds that "a rarely-changed default is not worth the top-bar width", with
+Home's Agents widget carrying it instead. In use that traded a cheap glance for
+a navigation: Start launches whatever the default is, and confirming which tool
+that was meant leaving the terminal for Home. The width argument still holds —
+it is simply the smaller cost of the two.
+
+What T08 said about the mechanism was right and is what made the reversal
+cheap: `aiToolSelector` guards on a missing `#ai-tool-selector`, and the
+`.lane-bar-launcher .ai-tool-select` rule T08 knowingly left behind in
+`terminal.css` was still there, so restoring the markup restored the styling
+with no CSS work.
+
+Home keeps its copy — this is a second view of one value, not a move back. Both
+write through `SET_AI_TOOL` and both redraw from `AI_TOOL_CHANGED`, so neither
+can show something the other contradicts.
+
+One thing T08 did not have to handle: `terminalTabBar._render()` can run either
+side of `init()`'s await on `GET_AI_TOOL_CONFIG`, so a select that exists only
+after `init()` finished would never be populated. `aiToolSelector` now exports
+`mountSelector()`, which `_render()` calls after appending — whichever of the
+two lands second, the dropdown ends up correct.
+
+_Reversed by: the user, 2026-09-01 · 2 file change(s)_
+
+---

--- a/src/renderer/aiToolSelector.js
+++ b/src/renderer/aiToolSelector.js
@@ -139,8 +139,28 @@ function supportsFeature(feature) {
   }
 }
 
+/**
+ * Wire a freshly rendered `#ai-tool-selector`.
+ *
+ * `init()` already populates the dropdown, but the top bar's select is created
+ * by `terminalTabBar._render()`, which can run either side of `init()`'s await
+ * on GET_AI_TOOL_CONFIG. Whichever of the two lands second calls this, so the
+ * dropdown ends up populated and showing the active tool under either
+ * ordering.
+ *
+ * A no-op before the config arrives: with no `currentTool` there is nothing
+ * truthful to draw, and the markup's placeholder options stand until `init()`
+ * finishes and calls `setupSelector()` itself.
+ */
+function mountSelector() {
+  if (!currentTool) return;
+  setupSelector();
+  updateUI();
+}
+
 module.exports = {
   init,
+  mountSelector,
   getCurrentTool,
   getAvailableTools,
   getStartCommand,

--- a/src/renderer/terminalTabBar.js
+++ b/src/renderer/terminalTabBar.js
@@ -139,11 +139,22 @@ class TerminalTabBar {
     this.element.innerHTML = `
       <div class="lane-bar-left"></div>
       <div class="terminal-tab-actions">
-        <!-- Default Agent launcher — a bare Start. The tool choice moved to
-             Home's Agents widget, where there is room for it; aiToolSelector
-             guards on a missing #ai-tool-selector, so nothing here breaks by
-             its absence. #sidebar-agent-launch keeps its id and its handler. -->
+        <!-- Default Agent launcher — the tool select sits beside Start again.
+             home-widget-board T08 removed it here on the grounds that a
+             rarely-changed default did not earn top-bar width; asked for back
+             on 2026-09-01 because Start launches whatever this says and
+             checking that meant leaving for Home. Home's Agents widget keeps
+             its copy — both write through SET_AI_TOOL and both redraw from
+             AI_TOOL_CHANGED, so neither can go stale.
+
+             The options below are a placeholder: setupSelector() repopulates
+             from the real tool list, which is why a third tool (gemini) is not
+             hardcoded here. #sidebar-agent-launch keeps its id and handler. -->
         <div class="lane-bar-launcher">
+          <select id="ai-tool-selector" class="ai-tool-select" tabindex="-1" title="Default agent">
+            <option value="claude">Claude</option>
+            <option value="codex">Codex</option>
+          </select>
           <button id="sidebar-agent-launch" class="sidebar-agent-launch" tabindex="-1" title="Start default agent">
             <svg width="12" height="12" viewBox="0 0 24 24" fill="currentColor" stroke="none" aria-hidden="true">
               <path d="M8 5v14l11-7z"/>
@@ -168,6 +179,12 @@ class TerminalTabBar {
     `;
 
     this.container.appendChild(this.element);
+    // The select exists only now. aiToolSelector.init() wires it too, but it
+    // does so after awaiting GET_AI_TOOL_CONFIG, so which of the two runs
+    // second is a race — whichever it is, this call leaves the dropdown
+    // populated and showing the active tool. Same reason the theme button is
+    // wired here rather than in index.js.
+    require('./aiToolSelector').mountSelector();
     this._setupEventHandlers();
   }
 


### PR DESCRIPTION
The Claude/Codex select sits beside Start in the top bar again.

## Why

`home-widget-board` T08 removed it on 2026-08-27, on the grounds that a
rarely-changed default did not earn the top-bar width, with Home's Agents
widget carrying it instead. In use that traded a cheap glance for a
navigation: Start launches whatever the default is, and confirming which tool
that was meant leaving the terminal for Home. The width argument still holds —
it is simply the smaller of the two costs.

The reversal is recorded in `.frame/specs/home-widget-board/outcome.md`, where
the decision it overturns lives, rather than only in this branch.

## Not a plain revert

Home's Agents widget **keeps** its copy. This is a second view of one value,
not a move back: both write through `SET_AI_TOOL` and both redraw from
`AI_TOOL_CHANGED`, so neither can show something the other contradicts.

And there is a race T08 never had to face. `terminalTabBar._render()` can run
either side of `aiToolSelector.init()`'s await on `GET_AI_TOOL_CONFIG`. A
select that only exists after `init()` finished would never be populated — it
would sit there showing the hardcoded placeholder options forever.
`aiToolSelector` now exports `mountSelector()`, which `_render()` calls after
appending; whichever of the two lands second, the dropdown ends up correct.

T08 called the mechanism correctly, which is what made the rest cheap:
`aiToolSelector` guards on a missing `#ai-tool-selector`, and the
`.lane-bar-launcher .ai-tool-select` rule it knowingly left behind in
`terminal.css` was still there — so the markup came back styled, with no CSS
change in this diff.

## Verification

No test covers the top-bar markup, so a green suite would not have meant much
here. `mountSelector()` was exercised directly against a stub DOM and IPC:

| case | result |
|---|---|
| called before config arrives | no-op, placeholder stands |
| after `init()` | populated with the real list — claude, codex, **gemini** |
| late render (the race above) | repopulates, selection preserved |
| user changes the dropdown | `set-ai-tool` sent with the right id |

That third row is the one this branch exists to get right.

Worth noting from row two: the real tool list has three entries, so the
markup's `claude`/`codex` options are a pre-paint placeholder only —
`setupSelector()` replaces them. That is why gemini is not hardcoded.

Full suite: 513/513.

The app was not launched to look at it — Playwright is not a dependency here
and installing it for one dropdown seemed disproportionate. Happy to if you
want eyes on it before merge.
