### PR TITLE
refactor: make frameStore the only owner of .frame/specs paths

### DIFF
--- a/.frame/STRUCTURE.json
+++ b/.frame/STRUCTURE.json
@@ -3394,20 +3394,20 @@
       ],
       "functions": {
         "getSpecsRoot": {
-          "line": 62,
+          "line": 64,
           "params": [
             "projectPath"
           ]
         },
         "getSpecDir": {
-          "line": 66,
+          "line": 68,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "repairSpecStatus": {
-          "line": 92,
+          "line": 94,
           "params": [
             "obj",
             "folderName"
@@ -3415,26 +3415,26 @@
           "purpose": "Fill in the fields of a status.json that the folder itself already"
         },
         "validateSpecStatus": {
-          "line": 110,
+          "line": 112,
           "params": [
             "obj"
           ]
         },
         "readFileSafe": {
-          "line": 129,
+          "line": 131,
           "params": [
             "p"
           ]
         },
         "readStatus": {
-          "line": 138,
+          "line": 140,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "writeStatus": {
-          "line": 149,
+          "line": 151,
           "params": [
             "projectPath",
             "slug",
@@ -3442,33 +3442,33 @@
           ]
         },
         "indexStamp": {
-          "line": 180,
+          "line": 182,
           "params": [
             "projectPath"
           ],
           "purpose": "mtime of the derived index, or 0 — used to tell a rebuild from a no-op."
         },
         "scheduleIndexRefresh": {
-          "line": 189,
+          "line": 191,
           "params": [
             "projectPath"
           ]
         },
         "buildSpecCatalog": {
-          "line": 217,
+          "line": 219,
           "params": [
             "projectPath"
           ],
           "purpose": "One line per non-excluded spec for the spec.new catalog embed. Reads the"
         },
         "listSpecs": {
-          "line": 237,
+          "line": 239,
           "params": [
             "projectPath"
           ]
         },
         "listSpecReports": {
-          "line": 336,
+          "line": 338,
           "params": [
             "projectPath",
             "slug"
@@ -3476,7 +3476,7 @@
           "purpose": "Which of a spec's two generated reports exist on disk, named as the viewer"
         },
         "looksLikeSpecFolder": {
-          "line": 345,
+          "line": 347,
           "params": [
             "projectPath",
             "folderName"
@@ -3484,7 +3484,7 @@
           "purpose": "A folder is a spec if it carries at least one of the chain's artifacts."
         },
         "malformedSpec": {
-          "line": 357,
+          "line": 359,
           "params": [
             "folderName",
             "status",
@@ -3493,7 +3493,7 @@
           "purpose": "A spec folder Frame cannot read as a spec, rendered as itself rather than"
         },
         "fileExists": {
-          "line": 377,
+          "line": 379,
           "params": [
             "projectPath",
             "slug",
@@ -3501,7 +3501,7 @@
           ]
         },
         "derivePhase": {
-          "line": 381,
+          "line": 383,
           "params": [
             "projectPath",
             "slug",
@@ -3511,7 +3511,7 @@
           ]
         },
         "recordedTaskCount": {
-          "line": 422,
+          "line": 424,
           "params": [
             "projectPath",
             "slug",
@@ -3519,14 +3519,14 @@
           ]
         },
         "collectSpecTasks": {
-          "line": 428,
+          "line": 430,
           "params": [
             "slug",
             "tasksData"
           ]
         },
         "countPhaseWrite": {
-          "line": 449,
+          "line": 451,
           "params": [
             "projectPath",
             "slug",
@@ -3535,7 +3535,7 @@
           ]
         },
         "reconcilePhase": {
-          "line": 457,
+          "line": 459,
           "params": [
             "projectPath",
             "slug",
@@ -3543,14 +3543,14 @@
           ]
         },
         "getDefaultTemplatePath": {
-          "line": 504,
+          "line": 506,
           "params": [
             "aiTool",
             "command"
           ]
         },
         "getOverrideTemplatePath": {
-          "line": 508,
+          "line": 510,
           "params": [
             "projectPath",
             "aiTool",
@@ -3558,7 +3558,7 @@
           ]
         },
         "loadCommandTemplate": {
-          "line": 528,
+          "line": 530,
           "params": [
             "projectPath",
             "aiTool",
@@ -3566,7 +3566,7 @@
           ]
         },
         "interpolateValues": {
-          "line": 537,
+          "line": 539,
           "params": [
             "obj",
             "vars"
@@ -3574,14 +3574,14 @@
           "purpose": "Run `interpolate` over each value of an object. One pass, no recursion."
         },
         "interpolate": {
-          "line": 545,
+          "line": 547,
           "params": [
             "template",
             "vars"
           ]
         },
         "getCommandPrompt": {
-          "line": 558,
+          "line": 560,
           "params": [
             "projectPath",
             "slug",
@@ -3591,7 +3591,7 @@
           ]
         },
         "reportAssetRel": {
-          "line": 636,
+          "line": 638,
           "params": [
             "projectPath",
             "tool",
@@ -3600,34 +3600,34 @@
           "purpose": "Which staged report asset a tool's prompt should name."
         },
         "resolveVerificationCommand": {
-          "line": 703,
+          "line": 705,
           "params": [
             "projectPath"
           ],
           "purpose": "The project's own check, in descending order of what actually verifies a"
         },
         "buildImplementPermissions": {
-          "line": 718,
+          "line": 720,
           "params": [
             "verification"
           ]
         },
         "writeImplementPermissions": {
-          "line": 736,
+          "line": 738,
           "params": [
             "projectPath"
           ],
           "purpose": "Writes .frame/implement-permissions.json and reports what it resolved, so"
         },
         "resolveImplementLaunchHint": {
-          "line": 760,
+          "line": 762,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "getImplementLaunchFlags": {
-          "line": 776,
+          "line": 778,
           "params": [
             "projectPath",
             "slug",
@@ -3636,21 +3636,21 @@
           "purpose": "The flags the lane's launch line needs for this dispatch. Only the"
         },
         "specNewPromptFilename": {
-          "line": 797,
+          "line": 799,
           "params": [
             "date"
           ],
           "purpose": "A slug-less run has no stable name to key the prompt file on — `${slug}__`"
         },
         "uniquePromptFilename": {
-          "line": 802,
+          "line": 804,
           "params": [
             "promptsDir",
             "filename"
           ]
         },
         "buildSpecCommandFile": {
-          "line": 811,
+          "line": 813,
           "params": [
             "projectPath",
             "slug",
@@ -3660,53 +3660,53 @@
           ]
         },
         "parseTasksMarkdown": {
-          "line": 855,
+          "line": 857,
           "params": [
             "content"
           ]
         },
         "parseFootprintMarkdown": {
-          "line": 881,
+          "line": 883,
           "params": [
             "content"
           ]
         },
         "getSpecFootprint": {
-          "line": 900,
+          "line": 902,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "syncTasksFromMarkdown": {
-          "line": 905,
+          "line": 907,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "arraysEqual": {
-          "line": 985,
+          "line": 987,
           "params": [
             "a",
             "b"
           ]
         },
         "syncAllSpecTasks": {
-          "line": 992,
+          "line": 994,
           "params": [
             "projectPath"
           ]
         },
         "getSpec": {
-          "line": 1009,
+          "line": 1011,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "readSpecReport": {
-          "line": 1048,
+          "line": 1050,
           "params": [
             "projectPath",
             "slug",
@@ -3715,7 +3715,7 @@
           "purpose": "Read one of a spec's two generated HTML reports, for the in-app viewer."
         },
         "searchSpecs": {
-          "line": 1077,
+          "line": 1079,
           "params": [
             "projectPath",
             "query"
@@ -3723,7 +3723,7 @@
           "purpose": "Search specs by keyword over their spec.md content. Case-insensitive"
         },
         "updateSpecStatus": {
-          "line": 1098,
+          "line": 1100,
           "params": [
             "projectPath",
             "slug",
@@ -3731,14 +3731,14 @@
           ]
         },
         "deleteSpec": {
-          "line": 1121,
+          "line": 1123,
           "params": [
             "projectPath",
             "slug"
           ]
         },
         "renameSpec": {
-          "line": 1138,
+          "line": 1140,
           "params": [
             "projectPath",
             "oldSlug",
@@ -3747,48 +3747,48 @@
           "purpose": "Rename a spec: moves the folder, updates status.json's slug field, and"
         },
         "startWatching": {
-          "line": 1250,
+          "line": 1252,
           "params": [
             "projectPath"
           ]
         },
         "stopWatching": {
-          "line": 1341
+          "line": 1343
         },
         "markSpecNewLaunch": {
-          "line": 1389
+          "line": 1391
         },
         "consumeSpecNewLaunch": {
-          "line": 1393
+          "line": 1395
         },
         "resolveSpecOrigin": {
-          "line": 1406,
+          "line": 1408,
           "params": [
             "projectPath"
           ],
           "purpose": "How this spec was started, from Frame's own state — never guessed from the"
         },
         "trackNewlyAuthoredSpecs": {
-          "line": 1417,
+          "line": 1419,
           "params": [
             "projectPath",
             "specs"
           ]
         },
         "pushSpecData": {
-          "line": 1437,
+          "line": 1439,
           "params": [
             "projectPath"
           ]
         },
         "init": {
-          "line": 1460,
+          "line": 1462,
           "params": [
             "window"
           ]
         },
         "setupIPC": {
-          "line": 1464,
+          "line": 1466,
           "params": [
             "ipcMain"
           ]

--- a/.frame/STRUCTURE.json
+++ b/.frame/STRUCTURE.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0",
   "description": "Auto-generated module structure",
-  "lastUpdated": "2026-09-01",
+  "lastUpdated": "2026-09-06",
   "architecture": {},
   "modules": {
     "main/activityLog": {
@@ -1137,6 +1137,8 @@
       "description": "frameStore — the one module that knows where a project's meta files live.",
       "exports": [
         "resolvePath",
+        "specsRoot",
+        "resolveSpecDir",
         "setupIPC",
         "metaDir",
         "isLegacyLayout",
@@ -1213,15 +1215,30 @@
           ],
           "purpose": "Directory to watch for tasks.json — the root for an unmigrated project,"
         },
+        "specsRoot": {
+          "line": 120,
+          "params": [
+            "projectPath"
+          ],
+          "purpose": "Root of a project's spec folders: `<project>/.frame/specs`."
+        },
+        "resolveSpecDir": {
+          "line": 125,
+          "params": [
+            "projectPath",
+            "slug"
+          ],
+          "purpose": "One spec's folder: `<project>/.frame/specs/<slug>`."
+        },
         "readText": {
-          "line": 111,
+          "line": 131,
           "params": [
             "projectPath",
             "name"
           ]
         },
         "writeText": {
-          "line": 119,
+          "line": 139,
           "params": [
             "projectPath",
             "name",
@@ -1229,41 +1246,41 @@
           ]
         },
         "getTasks": {
-          "line": 132,
+          "line": 152,
           "params": [
             "projectPath"
           ],
           "purpose": "tasks.json, with fsSafe's corruption recovery. Returns the recovery record"
         },
         "saveTasks": {
-          "line": 136,
+          "line": 156,
           "params": [
             "projectPath",
             "data"
           ]
         },
         "getStructure": {
-          "line": 141,
+          "line": 161,
           "params": [
             "projectPath"
           ],
           "purpose": "STRUCTURE.json parsed, or null when it is missing or unparseable."
         },
         "saveStructure": {
-          "line": 151,
+          "line": 171,
           "params": [
             "projectPath",
             "structure"
           ]
         },
         "readNotes": {
-          "line": 155,
+          "line": 175,
           "params": [
             "projectPath"
           ]
         },
         "appendNote": {
-          "line": 163,
+          "line": 183,
           "params": [
             "projectPath",
             "text"
@@ -1271,40 +1288,40 @@
           "purpose": "Append an entry to PROJECT_NOTES.md, keeping one blank line between it and"
         },
         "readQuickstart": {
-          "line": 172,
+          "line": 192,
           "params": [
             "projectPath"
           ]
         },
         "readAgents": {
-          "line": 176,
+          "line": 196,
           "params": [
             "projectPath"
           ]
         },
         "writeAgents": {
-          "line": 180,
+          "line": 200,
           "params": [
             "projectPath",
             "text"
           ]
         },
         "getProjectId": {
-          "line": 187,
+          "line": 207,
           "params": [
             "projectPath"
           ],
           "purpose": "The project's stable id, or null if it has none yet."
         },
         "ensureProjectId": {
-          "line": 199,
+          "line": 219,
           "params": [
             "projectPath"
           ],
           "purpose": "Stamp a UUID into `.frame/config.json` once and return it; a project that"
         },
         "setupIPC": {
-          "line": 216,
+          "line": 236,
           "params": [
             "ipcMain"
           ],

--- a/.frame/STRUCTURE.json
+++ b/.frame/STRUCTURE.json
@@ -1166,20 +1166,20 @@
       ],
       "functions": {
         "configPath": {
-          "line": 41,
+          "line": 49,
           "params": [
             "projectPath"
           ]
         },
         "readConfig": {
-          "line": 49,
+          "line": 57,
           "params": [
             "projectPath"
           ],
           "purpose": "Read `.frame/config.json`. Returns null when it is missing or unreadable —"
         },
         "writeConfig": {
-          "line": 58,
+          "line": 66,
           "params": [
             "projectPath",
             "config"
@@ -1187,14 +1187,14 @@
           "purpose": "Write `.frame/config.json` atomically. Throws on failure, like fsSafe."
         },
         "legacyFileNames": {
-          "line": 68,
+          "line": 76,
           "params": [
             "projectPath"
           ],
           "purpose": "The names a legacy project recorded at init. Empty for a project written"
         },
         "resolvePath": {
-          "line": 81,
+          "line": 89,
           "params": [
             "projectPath",
             "name"
@@ -1202,28 +1202,28 @@
           "purpose": "Absolute path Frame should use for meta file `name` in this project."
         },
         "isLegacyLayout": {
-          "line": 96,
+          "line": 104,
           "params": [
             "projectPath"
           ],
           "purpose": "True while the project still carries Frame's pre-overlay layout: the"
         },
         "metaDir": {
-          "line": 105,
+          "line": 113,
           "params": [
             "projectPath"
           ],
           "purpose": "Directory to watch for tasks.json — the root for an unmigrated project,"
         },
         "specsRoot": {
-          "line": 120,
+          "line": 128,
           "params": [
             "projectPath"
           ],
           "purpose": "Root of a project's spec folders: `<project>/.frame/specs`."
         },
         "resolveSpecDir": {
-          "line": 125,
+          "line": 133,
           "params": [
             "projectPath",
             "slug"
@@ -1231,14 +1231,14 @@
           "purpose": "One spec's folder: `<project>/.frame/specs/<slug>`."
         },
         "readText": {
-          "line": 131,
+          "line": 139,
           "params": [
             "projectPath",
             "name"
           ]
         },
         "writeText": {
-          "line": 139,
+          "line": 147,
           "params": [
             "projectPath",
             "name",
@@ -1246,41 +1246,41 @@
           ]
         },
         "getTasks": {
-          "line": 152,
+          "line": 160,
           "params": [
             "projectPath"
           ],
           "purpose": "tasks.json, with fsSafe's corruption recovery. Returns the recovery record"
         },
         "saveTasks": {
-          "line": 156,
+          "line": 164,
           "params": [
             "projectPath",
             "data"
           ]
         },
         "getStructure": {
-          "line": 161,
+          "line": 169,
           "params": [
             "projectPath"
           ],
           "purpose": "STRUCTURE.json parsed, or null when it is missing or unparseable."
         },
         "saveStructure": {
-          "line": 171,
+          "line": 179,
           "params": [
             "projectPath",
             "structure"
           ]
         },
         "readNotes": {
-          "line": 175,
+          "line": 183,
           "params": [
             "projectPath"
           ]
         },
         "appendNote": {
-          "line": 183,
+          "line": 191,
           "params": [
             "projectPath",
             "text"
@@ -1288,40 +1288,40 @@
           "purpose": "Append an entry to PROJECT_NOTES.md, keeping one blank line between it and"
         },
         "readQuickstart": {
-          "line": 192,
+          "line": 200,
           "params": [
             "projectPath"
           ]
         },
         "readAgents": {
-          "line": 196,
+          "line": 204,
           "params": [
             "projectPath"
           ]
         },
         "writeAgents": {
-          "line": 200,
+          "line": 208,
           "params": [
             "projectPath",
             "text"
           ]
         },
         "getProjectId": {
-          "line": 207,
+          "line": 215,
           "params": [
             "projectPath"
           ],
           "purpose": "The project's stable id, or null if it has none yet."
         },
         "ensureProjectId": {
-          "line": 219,
+          "line": 227,
           "params": [
             "projectPath"
           ],
           "purpose": "Stamp a UUID into `.frame/config.json` once and return it; a project that"
         },
         "setupIPC": {
-          "line": 236,
+          "line": 244,
           "params": [
             "ipcMain"
           ],

--- a/.frame/specs/frame-storage-seam/digest.md
+++ b/.frame/specs/frame-storage-seam/digest.md
@@ -1,0 +1,27 @@
+---
+keywords: frameStore, meta path resolution, specs directory, storage seam, resolveSpecDir, guard test, path doctrine
+related: non-invasive-overlay, migration-consent-scope, frame-bin-out-of-repo, spec-knowledge-layer, cli-spec-command-parity
+supersedes: non-invasive-overlay
+---
+
+`frameStore` gained `specsRoot()` / `resolveSpecDir()`, and the three modules
+that joined `.frame/specs` themselves (`specManager.js:63`,
+`frameProject.js:241,933`) now ask for it. Named spec-specific functions beat a
+generic `resolveDir(...segments)`, which would have left `'specs'` at every
+call site and made the guard unenforceable. Both are flat joins, deliberately
+not routed through `resolvePath`: its overlay-then-root branch answers only for
+names a legacy project recorded in `config.files`, and specs were never in that
+record. `specManager`'s helpers stayed as one-line delegates rather than
+rewriting 17 call sites, and no `mkdirSync` moved — `migration-consent-scope`
+T05's `isLegacyLayout` gate had to keep guarding the specs-root write.
+
+Rules for future work: never build a `.frame/specs` path outside
+`frameStore.js` — `test/metaPathGuard.test.js` fails when a line both calls
+`path.join` and carries the `'specs'` literal. Two exemptions, both real:
+`frameStore.js` owns the literal, and `src/templates/bin/` ships into a user's
+`.frame/bin/` where frameStore is unreachable, so its copy is pinned by the
+drift test alongside `scripts/spec-index.js` and `scripts/spec-command-hint.js`
+instead. This is where `non-invasive-overlay`'s "`specManager.js` excepted, for
+specs" ends. Widening to `index/` or `runtime/` is a named function each.
+
+Chain: spec.md → plan.md → tasks.md → outcome.md

--- a/.frame/specs/frame-storage-seam/outcome.md
+++ b/.frame/specs/frame-storage-seam/outcome.md
@@ -1,0 +1,12 @@
+## T01 — Add specsRoot / resolveSpecDir to frameStore
+
+Added a `Specs` section to `src/main/frameStore.js` holding `SPECS_DIR_NAME`,
+`specsRoot(projectPath)` and `resolveSpecDir(projectPath, slug)`, both exported.
+Placed after the Layout section beside the file-shaped resolvers rather than
+inside `resolvePath`, and written as bare joins so no `config.files` lookup or
+root fallback can reach spec paths. Nothing calls them yet, so the app is
+unchanged.
+
+_Captured: 2026-09-06 · 1 file change_
+
+---

--- a/.frame/specs/frame-storage-seam/outcome.md
+++ b/.frame/specs/frame-storage-seam/outcome.md
@@ -10,3 +10,15 @@ unchanged.
 _Captured: 2026-09-06 · 1 file change_
 
 ---
+## T02 — Widen the frameStore header doctrine to spec folders
+
+Extended `src/main/frameStore.js`'s header: the "no other module joins those
+paths" sentence now names `.frame/specs/<slug>` alongside the five meta files,
+and a new paragraph records that `non-invasive-overlay`'s `specManager.js`
+exception is withdrawn and points at the guard test that replaces it. The
+paragraph forward-references `test/metaPathGuard.test.js`, which T06 creates —
+the sentence is false until that lands.
+
+_Captured: 2026-09-06 · 1 file change_
+
+---

--- a/.frame/specs/frame-storage-seam/outcome.md
+++ b/.frame/specs/frame-storage-seam/outcome.md
@@ -22,3 +22,16 @@ the sentence is false until that lands.
 _Captured: 2026-09-06 · 1 file change_
 
 ---
+## T03 — Cover the spec resolvers in frameStore's tests
+
+Added a `Spec paths` section to `test/frameStore.test.js` with two tests: the
+flat shape of both resolvers, and that neither moves when every condition
+`resolvePath`'s legacy branch needs is present at once — the `config.files`
+record, a root file making `isLegacyLayout` true, and a root-level `specs/`
+directory. The second test asserts `isLegacyLayout` is true first, so it fails
+loudly if the fixture stops reproducing the legacy state it is guarding
+against. File now runs 15 tests, all passing.
+
+_Captured: 2026-09-06 · 1 file change_
+
+---

--- a/.frame/specs/frame-storage-seam/outcome.md
+++ b/.frame/specs/frame-storage-seam/outcome.md
@@ -35,3 +35,14 @@ against. File now runs 15 tests, all passing.
 _Captured: 2026-09-06 · 1 file change_
 
 ---
+## T04 — Point specManager's helpers at frameStore
+
+Reduced `getSpecsRoot` and `getSpecDir` in `src/main/specManager.js` to one-line
+delegates and deleted the module's `SPECS_DIR_NAME`; the 17 call sites, every
+`mkdirSync` and the `isLegacyLayout` gate at line 1267 are untouched. No
+`path.join` carrying `'specs'` remains in the file. The five spec suites
+(49 tests) pass without edits, which is what S5 asks for.
+
+_Captured: 2026-09-06 · 1 file change_
+
+---

--- a/.frame/specs/frame-storage-seam/outcome.md
+++ b/.frame/specs/frame-storage-seam/outcome.md
@@ -46,3 +46,15 @@ delegates and deleted the module's `SPECS_DIR_NAME`; the 17 call sites, every
 _Captured: 2026-09-06 · 1 file change_
 
 ---
+## T05 — Point frameProject's two creation sites at the resolver
+
+Replaced the joins at `src/main/frameProject.js:241` (async, in
+`runProjectInit`) and `:933` (sync, in `ensureSpecDrivenArtifacts`) with
+`frameStore.specsRoot(projectPath)`; both keep their own `mkdir` and `.gitkeep`
+writes, and neither changes I/O shape. Two lines changed. With this, no
+`path.join` carrying `'specs'` remains anywhere in `src/main` or `src/shared`.
+The init, open, toggle and migration suites (62 tests) pass unchanged.
+
+_Captured: 2026-09-06 · 1 file change_
+
+---

--- a/.frame/specs/frame-storage-seam/outcome.md
+++ b/.frame/specs/frame-storage-seam/outcome.md
@@ -58,3 +58,21 @@ The init, open, toggle and migration suites (62 tests) pass unchanged.
 _Captured: 2026-09-06 · 1 file change_
 
 ---
+## T06 — Add the meta-path doctrine guard
+
+Added `test/metaPathGuard.test.js`: a recursive `src/` scan flagging any line
+that calls `path.join` / `path.posix.join` and carries a `'specs'` literal,
+exempting `src/main/frameStore.js` (the owner) and `src/templates/bin/` (ships
+into `.frame/bin/`, cannot require frameStore — the same answer `scripts/`
+gets). Verified by injecting a violation into `specManager.js` and watching the
+test name it, then reverting. **Diverges from plan.md step 4**, which says
+"every `.js` under `src/`" with no exemption: `implement-launch.js:33,174`
+would make that guard permanently red. A second test asserts the scanner still
+matches the exempt copies, so it cannot pass by matching nothing.
+
+Followup: plan.md step 4 and the plan report's S1 row still describe the
+unexempted guard; correct them or record the exemption there.
+
+_Captured: 2026-09-06 · 1 file change_
+
+---

--- a/.frame/specs/frame-storage-seam/outcome.md
+++ b/.frame/specs/frame-storage-seam/outcome.md
@@ -76,3 +76,17 @@ unexempted guard; correct them or record the exemption there.
 _Captured: 2026-09-06 · 1 file change_
 
 ---
+## T07 — Pin the shipped mirrors to the resolver
+
+Added the drift test to `test/metaPathGuard.test.js`: it extracts the joined
+segments from every spec-path join in `scripts/spec-index.js`,
+`scripts/spec-command-hint.js` and `src/templates/bin/implement-launch.js`
+(resolving each file's own `FRAME_DIR` constant) and asserts each carries the
+`['.frame', 'specs']` pair that `frameStore.specsRoot()` produces, failing too
+when a mirror stops building a spec path at all. Verified by rewriting
+`spec-index.js:37` to `.framev2` and watching it name the file, line and both
+segment lists. Full suite: 581 tests, all passing.
+
+_Captured: 2026-09-06 · 1 file change_
+
+---

--- a/.frame/specs/frame-storage-seam/plan.md
+++ b/.frame/specs/frame-storage-seam/plan.md
@@ -1,0 +1,134 @@
+# Plan — Frame storage seam — the last meta path joins frameStore
+
+## Architecture
+
+### Resolved plan-time decisions
+
+**Business**
+
+- **In-flight collision — proceed now.** Both target files sit in the active
+  footprint of `audit-q3-performance-resources` (implementing) and
+  `audit-q3-cross-platform` (planned). Chosen: proceed, accepting rebase risk.
+  Rationale: the change is mechanical and confined to path-join lines, while
+  those specs work on polling/timers and on Windows path correctness
+  respectively; consolidating spec-path construction into one function makes
+  the cross-platform work smaller, not larger.
+
+**Technical**
+
+- **Test posture — everything testable.** Chosen over "only the two guard
+  tests". Rationale: the testing record (PROJECT_NOTES, 2026-08-29) lists
+  `src/main/` and `src/shared/` as Covered across 35 test files, and
+  `test/frameStore.test.js` already exists with eight tests — unit-testing two
+  new resolvers there is the convention in force, not an addition to it.
+- **specManager keeps `getSpecsRoot` / `getSpecDir` as delegates** (silent).
+  Both become one-line calls into `frameStore`; the twenty internal call sites
+  and the module's shape are untouched. Rewriting all twenty would churn a
+  file two in-flight specs are editing, for no gain — the `'specs'` literal
+  lands in `frameStore` either way, which is what G2 and S1 ask for.
+- **The resolvers resolve; they never create** (silent). `migration-consent-scope`
+  T05 gated `startWatching`'s `mkdirSync` of the specs root on
+  `frameStore.isLegacyLayout()` (`specManager.js:1270`), and `frameProject`
+  creates the folder deliberately at init. Every existing `mkdirSync` stays
+  exactly where it is; the resolver returns a string, matching how
+  `resolvePath` already behaves.
+- **The guard matches path construction, not the word** (silent). A bare
+  `'specs'` scan would fail on correct code — `activityLog.js:132` filters it
+  as an event key and the renderer compares `viewMode === 'specs'`. The guard
+  therefore flags a line only when it both calls `path.join` and contains the
+  `'specs'` literal.
+- **The guard follows the project's own scanning precedent** (silent).
+  `projectAgnostic.test.js:180-183` reads source files and asserts on their
+  content; the new guard is written the same way rather than inventing a
+  lint step or a new dependency.
+
+### Shape
+
+`frameStore` gains a two-function Specs section beside its existing typed
+read/write helpers:
+
+```js
+function specsRoot(projectPath)            // <project>/.frame/specs
+function resolveSpecDir(projectPath, slug) // <project>/.frame/specs/<slug>
+```
+
+Both are flat joins over `FRAME_DIR` — deliberately **not** routed through
+`resolvePath`, whose overlay-then-root branch answers only for the six names in
+`FRAME_FILES` recorded in a legacy project's `config.files` (C3, S2). Specs
+were never in that record, and `specManager.js:63` has always been
+unconditional; passing them through `resolvePath` would introduce a legacy
+lookup that has never existed and would change behaviour.
+
+The three existing joins become calls:
+
+| Today | After |
+| --- | --- |
+| `specManager.js:63` `path.join(projectPath, FRAME_DIR, SPECS_DIR_NAME)` | `frameStore.specsRoot(projectPath)` |
+| `specManager.js:67` `path.join(getSpecsRoot(p), slug)` | `frameStore.resolveSpecDir(p, slug)` |
+| `frameProject.js:241` `path.join(frameDirPath, 'specs')` | `frameStore.specsRoot(projectPath)` |
+| `frameProject.js:933` `path.join(projectPath, FRAME_DIR, 'specs')` | `frameStore.specsRoot(projectPath)` |
+
+`SPECS_DIR_NAME` is deleted from `specManager.js`; the literal survives only
+inside `frameStore.js`.
+
+`scripts/` and the `.frame/bin/` copies are untouched (C4). Those four
+spec-path scripts ship into the user's project, where `node_modules` and
+Frame's tree are unreachable — `brief-context.js:20` records the rule. Their
+duplication is answered by a drift test that asserts the app's resolver and
+the shipped literal agree (S3), never by a shared require.
+
+## Files
+
+- `src/main/frameStore.js` — **Modified.** Adds the `specsRoot` /
+  `resolveSpecDir` pair and their exports; extends the header to say specs now
+  resolve here too.
+- `src/main/specManager.js` — **Modified.** `getSpecsRoot` and `getSpecDir`
+  delegate to `frameStore`; `SPECS_DIR_NAME` removed. No call site changes.
+- `src/main/frameProject.js` — **Modified.** The two init-time joins call
+  `frameStore.specsRoot()`; both keep their own `mkdir` and `.gitkeep` writes.
+- `test/frameStore.test.js` — **Modified.** Unit tests for the two resolvers:
+  the shape of each answer, and that neither consults `config.files` nor falls
+  back to the project root.
+- `test/metaPathGuard.test.js` — **New.** The two cross-module invariants: the
+  source-scanning guard over `src/`, and the drift test pinning the resolver
+  to the literal the `.frame/bin` scripts use.
+
+## Footprint
+
+- src/main/frameStore.js
+- src/main/specManager.js
+- src/main/frameProject.js
+- test/frameStore.test.js
+- test/metaPathGuard.test.js
+
+## Dependencies
+
+None. The guard uses `node:fs` and the project's existing `node --test`
+runner; no lint tooling and no package is added, which also keeps the suite
+runnable in CI, where `npm ci` deliberately does not run.
+
+## Sequencing
+
+1. **Add the resolvers to `frameStore`.** Write `specsRoot` and
+   `resolveSpecDir`, export both, and extend the module header to name specs
+   alongside the files it already lists. Add their unit tests to
+   `test/frameStore.test.js` in the same step: each returns the flat
+   `.frame/specs[/slug]` answer, and a legacy project with a `config.files`
+   record and a root-level `specs/` directory still resolves to the overlay
+   (C3, S2). Nothing calls them yet, so the app is unchanged.
+
+2. **Point `specManager` at them.** Reduce `getSpecsRoot` and `getSpecDir` to
+   delegates, delete `SPECS_DIR_NAME`. The twenty internal call sites and every
+   `mkdirSync` — including the `isLegacyLayout`-gated one at line 1270 — stay
+   as they are (S4).
+
+3. **Point `frameProject` at them.** Replace the two init-time joins with
+   `frameStore.specsRoot(projectPath)`, leaving the `mkdir` and `.gitkeep`
+   writes untouched so a fresh project is created exactly as before (S4).
+
+4. **Lock the doctrine.** Add `test/metaPathGuard.test.js` with the guard —
+   every `.js` under `src/`, excluding `frameStore.js`, has no line that both
+   calls `path.join` and contains `'specs'` (S1) — and the drift test that
+   asserts `frameStore.specsRoot()` agrees with the `.frame/bin` scripts'
+   literal (S3). This step follows 2 and 3 because the guard cannot pass until
+   they land.

--- a/.frame/specs/frame-storage-seam/spec.md
+++ b/.frame/specs/frame-storage-seam/spec.md
@@ -1,0 +1,114 @@
+---
+keywords: frameStore, meta path resolution, specs directory, storage seam, resolveSpecDir, guard test, path doctrine
+related: non-invasive-overlay, migration-consent-scope, frame-bin-out-of-repo, spec-knowledge-layer, cli-spec-command-parity
+supersedes: non-invasive-overlay
+---
+
+# Frame storage seam — the last meta path joins frameStore
+
+## Problem
+
+`non-invasive-overlay` made `frameStore.js` the one module that knows where a
+project's meta files live, and its own header still says so. But that spec
+wrote in an exception, recorded verbatim in its digest:
+
+> *"never join a meta path outside `frameStore.js` (`specManager.js` excepted,
+> for specs)"*
+
+The exception is now the only gap in the doctrine, and it did not stay in one
+module. Three places in `src/main/` answer "where do specs live", each on its
+own:
+
+- `specManager.js:63` — `path.join(projectPath, FRAME_DIR, SPECS_DIR_NAME)`
+- `frameProject.js:241` — `path.join(frameDirPath, 'specs')`
+- `frameProject.js:933` — `path.join(projectPath, FRAME_DIR, 'specs')`
+
+Today the cost is small: three copies of a rule that has not changed. It grows
+in two directions. Every new module that touches specs adds a fourth copy, and
+nothing catches it — the tracked meta files have a guard by convention, specs
+have none. And specs are the largest entry in `FRAME_FILE_CLASSES.data`, so the
+gap sits in the most-written part of `.frame/`: any later work that changes
+where spec content comes from has to find all three, and a miss fails silently.
+
+## Goal
+
+One resolver, and a test that keeps it the only one.
+
+- **`frameStore` resolves spec paths**, through named, spec-specific functions
+  — a root (`specsRoot`) and a folder (`resolveSpecDir`) — not a generic
+  segment joiner. A spec is a folder of files rather than a single file, so
+  these sit beside the existing file-shaped resolvers rather than inside them.
+- **Every spec path in `src/` comes from them.** `specManager.js` and
+  `frameProject.js` ask instead of joining, and the `'specs'` literal exists
+  in exactly one file afterwards.
+- **A guard test** fails when a `.frame/specs` path is built outside
+  `frameStore.js`, so the doctrine is enforced rather than remembered.
+- **Nothing else changes.** Same paths on disk, same reads, same writes.
+
+## Constraints
+
+- **This reverses one rule of `non-invasive-overlay`**, named above, and
+  declares it in `supersedes:` — the same shape as `frame-bin-out-of-repo`'s
+  reversal of that spec's T15. The rest of that spec stands.
+- **The resolver is spec-specific, not generic.** A `resolveDir(projectPath,
+  ...segments)` would leave `'specs'` at every call site, which moves the
+  duplication instead of removing it and makes the guard test below
+  unenforceable — a caller legitimately passing `'specs'` is indistinguishable
+  from a violation. Widening to `index/` or `runtime/` later is a named
+  function each, and is not done here.
+- **No legacy fallback for specs.** `resolvePath`'s overlay-then-root branch
+  exists for the six names in `FRAME_FILES` when a legacy project's
+  `config.files` record lists them (`migration-consent-scope`). Specs were
+  never in that record, and `specManager.js:63` has always been unconditional.
+  The spec resolver must be flat — `<project>/.frame/specs/<slug>`, no branch.
+  Inheriting the legacy logic would change behaviour, which is the one real
+  risk in this work.
+- **`scripts/` keeps its own resolution, and a shared module is not available
+  to it.** All four spec-path scripts — `spec-index.js`, `spec-command-hint.js`,
+  `spec-context.js`, `spec-hint.js` — ship into `.frame/bin/`, where the rule
+  is documented in `brief-context.js:20`: *"Dependency-free and app-tree-free,
+  because it ships into `.frame/bin/`"*, with `node_modules` unreachable
+  (`:136`). A `require` into `src/` resolves inside the *user's* project and
+  fails there, silenced by the hook guard. `frameStore`'s header already
+  accepts this mirroring. The duplication is answered by a test, not by
+  coupling.
+- **Zero user-visible change.** This is a refactor: no feature, no UI, no
+  channel, no payload, no watcher timing moves.
+- **frameStore stays synchronous and disk-backed.** Its "every read hits disk"
+  guarantee is load-bearing precisely because agents edit these files with
+  their own tools; nothing here introduces a cache or an async read.
+- **frameStore gains resolution only.** Spec parsing, `status.json` handling,
+  phase logic and reports stay in `specManager.js`. The seam moves paths, not
+  behaviour.
+
+## Success Criteria
+
+- When `src/` is scanned after this work, then no `path.join` outside
+  `frameStore.js` builds a path containing `'specs'`, and an automated guard
+  fails if one appears. The bare word elsewhere — `activityLog.js`'s key
+  filter, the renderer's `viewMode === 'specs'` — is not a path and is not
+  matched.
+- When a spec folder is resolved for any slug, then the answer is
+  `<project>/.frame/specs/<slug>` unconditionally, with no legacy-root branch
+  and no dependence on `config.files`.
+- When the resolver is compared against the literal the `.frame/bin` scripts
+  use, then a test asserts the two agree, so the mirrored rule cannot drift
+  unnoticed.
+- When the app runs, then every spec surface — list, search, read, rename,
+  status update, reports, the specs watcher and agent dispatch — behaves as it
+  did before, with no path changed and no timing shifted.
+- When `npm test` runs, then the existing spec and frameStore tests pass
+  unchanged, without edits to accommodate the refactor.
+
+## Out of Scope
+
+- A write notification on `frameStore` — no consumer exists until sync does.
+- Sync, auth, a third `gitSharing` mode, and every other server-side concern.
+- The renderer's transport seam (Electron IPC vs a second transport) — the
+  other axis, its own spec.
+- Resolvers for `index/`, `runtime/` and the other `.frame/` directories —
+  added when something asks, one named function each.
+- `scripts/spec-index.js`, `spec-command-hint.js`, `spec-context.js` and
+  `spec-hint.js` themselves — `spec-knowledge-layer` and
+  `cli-spec-command-parity` own those, and they run outside the app.
+- Entity-granular writes for `tasks.json` or spec files.

--- a/.frame/specs/frame-storage-seam/status.json
+++ b/.frame/specs/frame-storage-seam/status.json
@@ -1,7 +1,7 @@
 {
   "slug": "frame-storage-seam",
   "title": "Frame storage seam — the last meta path joins frameStore",
-  "phase": "implementing",
+  "phase": "done",
   "generated_task_ids": [
     "task-spec-frame-storage-seam-T01",
     "task-spec-frame-storage-seam-T02",
@@ -13,7 +13,7 @@
   ],
   "ai_tool": "claude-code",
   "created_at": "2026-09-04T07:22:28Z",
-  "updated_at": "2026-09-06T09:14:25.432Z",
-  "last_phase_at": "2026-09-06T09:14:25.432Z",
+  "updated_at": "2026-09-06T10:13:03.725Z",
+  "last_phase_at": "2026-09-06T10:13:03.725Z",
   "implement_mode": "step-by-step"
 }

--- a/.frame/specs/frame-storage-seam/status.json
+++ b/.frame/specs/frame-storage-seam/status.json
@@ -1,0 +1,19 @@
+{
+  "slug": "frame-storage-seam",
+  "title": "Frame storage seam — the last meta path joins frameStore",
+  "phase": "tasks_generated",
+  "generated_task_ids": [
+    "task-spec-frame-storage-seam-T01",
+    "task-spec-frame-storage-seam-T02",
+    "task-spec-frame-storage-seam-T03",
+    "task-spec-frame-storage-seam-T04",
+    "task-spec-frame-storage-seam-T05",
+    "task-spec-frame-storage-seam-T06",
+    "task-spec-frame-storage-seam-T07"
+  ],
+  "ai_tool": "claude-code",
+  "created_at": "2026-09-04T07:22:28Z",
+  "updated_at": "2026-09-06T09:10:22.578Z",
+  "last_phase_at": "2026-09-04T10:47:07.813Z",
+  "implement_mode": "step-by-step"
+}

--- a/.frame/specs/frame-storage-seam/status.json
+++ b/.frame/specs/frame-storage-seam/status.json
@@ -1,7 +1,7 @@
 {
   "slug": "frame-storage-seam",
   "title": "Frame storage seam — the last meta path joins frameStore",
-  "phase": "tasks_generated",
+  "phase": "implementing",
   "generated_task_ids": [
     "task-spec-frame-storage-seam-T01",
     "task-spec-frame-storage-seam-T02",
@@ -13,7 +13,7 @@
   ],
   "ai_tool": "claude-code",
   "created_at": "2026-09-04T07:22:28Z",
-  "updated_at": "2026-09-06T09:10:22.578Z",
-  "last_phase_at": "2026-09-04T10:47:07.813Z",
+  "updated_at": "2026-09-06T09:14:25.432Z",
+  "last_phase_at": "2026-09-06T09:14:25.432Z",
   "implement_mode": "step-by-step"
 }

--- a/.frame/specs/frame-storage-seam/tasks.md
+++ b/.frame/specs/frame-storage-seam/tasks.md
@@ -1,0 +1,9 @@
+# Tasks — Frame storage seam — the last meta path joins frameStore
+
+- T01 · Add `specsRoot(projectPath)` and `resolveSpecDir(projectPath, slug)` to `src/main/frameStore.js` as flat joins over `FRAME_DIR`, never routed through `resolvePath`, and export both
+- T02 · Extend `src/main/frameStore.js`'s header to name spec folders alongside the meta files it already lists, recording that `non-invasive-overlay`'s `specManager.js` exception is withdrawn
+- T03 · Add resolver unit tests to `test/frameStore.test.js`: each returns the flat `.frame/specs[/slug]` answer, and a legacy project carrying a `config.files` record plus a root-level `specs/` directory still resolves to the overlay
+- T04 · Reduce `getSpecsRoot` and `getSpecDir` in `src/main/specManager.js` to one-line delegates and delete the module's `SPECS_DIR_NAME`, leaving every call site and every `mkdirSync` — including the `isLegacyLayout`-gated one at line 1270 — untouched
+- T05 · Replace the two joins at `src/main/frameProject.js:241` and `:933` with `frameStore.specsRoot(projectPath)`, keeping both sites' `mkdir` and `.gitkeep` writes as they are
+- T06 · Add `test/metaPathGuard.test.js` with the source-scanning guard: no `.js` file under `src/` other than `frameStore.js` has a line that both calls `path.join` and carries the `'specs'` literal, excluding `src/templates/bin/` because those files ship into `.frame/bin/` under the same rule as `scripts/`
+- T07 · Add the drift test to `test/metaPathGuard.test.js` asserting `frameStore.specsRoot()` agrees with the `.frame/bin` literal used by `scripts/spec-index.js`, `scripts/spec-command-hint.js` and `src/templates/bin/implement-launch.js`

--- a/.frame/tasks.json
+++ b/.frame/tasks.json
@@ -7,7 +7,7 @@
   },
   "project": "Frame",
   "version": "2.0",
-  "lastUpdated": "2026-09-06T10:05:34.257Z",
+  "lastUpdated": "2026-09-06T10:07:22.439Z",
   "taskSchema": {
     "_comment": "This schema shows the expected structure for each task",
     "id": "unique-id (task-xxx format)",
@@ -7063,13 +7063,13 @@
       "title": "Replace the two joins at `src/main/frameProject.js:241` and `:933` with `frameStore.specsRoot(projectPath)`, keeping both sites' `mkdir` and `.gitkeep` writes as they are",
       "description": "",
       "source": "spec:frame-storage-seam:T05",
-      "status": "pending",
+      "status": "completed",
       "priority": "medium",
       "category": "feature",
       "context": "From spec: frame-storage-seam",
       "createdAt": "2026-09-04T10:47:08.107Z",
-      "updatedAt": "2026-09-04T10:47:08.107Z",
-      "completedAt": null
+      "updatedAt": "2026-09-06T10:07:22.439Z",
+      "completedAt": "2026-09-06T10:07:22.439Z"
     },
     {
       "id": "task-spec-frame-storage-seam-T06",

--- a/.frame/tasks.json
+++ b/.frame/tasks.json
@@ -7,7 +7,7 @@
   },
   "project": "Frame",
   "version": "2.0",
-  "lastUpdated": "2026-09-06T09:14:48.353Z",
+  "lastUpdated": "2026-09-06T09:59:51.512Z",
   "taskSchema": {
     "_comment": "This schema shows the expected structure for each task",
     "id": "unique-id (task-xxx format)",
@@ -7024,13 +7024,13 @@
       "title": "Extend `src/main/frameStore.js`'s header to name spec folders alongside the meta files it already lists, recording that `non-invasive-overlay`'s `specManager.js` exception is withdrawn",
       "description": "",
       "source": "spec:frame-storage-seam:T02",
-      "status": "pending",
+      "status": "completed",
       "priority": "medium",
       "category": "feature",
       "context": "From spec: frame-storage-seam",
       "createdAt": "2026-09-04T10:47:08.107Z",
-      "updatedAt": "2026-09-04T10:47:08.107Z",
-      "completedAt": null
+      "updatedAt": "2026-09-06T09:59:51.512Z",
+      "completedAt": "2026-09-06T09:59:51.512Z"
     },
     {
       "id": "task-spec-frame-storage-seam-T03",

--- a/.frame/tasks.json
+++ b/.frame/tasks.json
@@ -7,7 +7,7 @@
   },
   "project": "Frame",
   "version": "2.0",
-  "lastUpdated": "2026-09-06T10:04:02.492Z",
+  "lastUpdated": "2026-09-06T10:05:34.257Z",
   "taskSchema": {
     "_comment": "This schema shows the expected structure for each task",
     "id": "unique-id (task-xxx format)",
@@ -7050,13 +7050,13 @@
       "title": "Reduce `getSpecsRoot` and `getSpecDir` in `src/main/specManager.js` to one-line delegates and delete the module's `SPECS_DIR_NAME`, leaving every call site and every `mkdirSync` — including the `isLegacyLayout`-gated one at line 1270 — untouched",
       "description": "",
       "source": "spec:frame-storage-seam:T04",
-      "status": "pending",
+      "status": "completed",
       "priority": "medium",
       "category": "feature",
       "context": "From spec: frame-storage-seam",
       "createdAt": "2026-09-04T10:47:08.107Z",
-      "updatedAt": "2026-09-04T10:47:08.107Z",
-      "completedAt": null
+      "updatedAt": "2026-09-06T10:05:34.257Z",
+      "completedAt": "2026-09-06T10:05:34.257Z"
     },
     {
       "id": "task-spec-frame-storage-seam-T05",

--- a/.frame/tasks.json
+++ b/.frame/tasks.json
@@ -7,7 +7,7 @@
   },
   "project": "Frame",
   "version": "2.0",
-  "lastUpdated": "2026-09-06T10:10:40.793Z",
+  "lastUpdated": "2026-09-06T10:13:03.725Z",
   "taskSchema": {
     "_comment": "This schema shows the expected structure for each task",
     "id": "unique-id (task-xxx format)",
@@ -7089,13 +7089,13 @@
       "title": "Add the drift test to `test/metaPathGuard.test.js` asserting `frameStore.specsRoot()` agrees with the `.frame/bin` literal used by `scripts/spec-index.js`, `scripts/spec-command-hint.js` and `src/templates/bin/implement-launch.js`",
       "description": "",
       "source": "spec:frame-storage-seam:T07",
-      "status": "pending",
+      "status": "completed",
       "priority": "medium",
       "category": "feature",
       "context": "From spec: frame-storage-seam",
       "createdAt": "2026-09-04T10:47:08.107Z",
-      "updatedAt": "2026-09-04T10:47:08.107Z",
-      "completedAt": null
+      "updatedAt": "2026-09-06T10:13:03.725Z",
+      "completedAt": "2026-09-06T10:13:03.725Z"
     }
   ],
   "metadata": {

--- a/.frame/tasks.json
+++ b/.frame/tasks.json
@@ -7,7 +7,7 @@
   },
   "project": "Frame",
   "version": "2.0",
-  "lastUpdated": "2026-09-06T10:07:22.439Z",
+  "lastUpdated": "2026-09-06T10:10:40.793Z",
   "taskSchema": {
     "_comment": "This schema shows the expected structure for each task",
     "id": "unique-id (task-xxx format)",
@@ -7076,13 +7076,13 @@
       "title": "Add `test/metaPathGuard.test.js` with the source-scanning guard: no `.js` file under `src/` other than `frameStore.js` has a line that both calls `path.join` and carries the `'specs'` literal, excluding `src/templates/bin/` because those files ship into `.frame/bin/` under the same rule as `scripts/`",
       "description": "",
       "source": "spec:frame-storage-seam:T06",
-      "status": "pending",
+      "status": "completed",
       "priority": "medium",
       "category": "feature",
       "context": "From spec: frame-storage-seam",
       "createdAt": "2026-09-04T10:47:08.107Z",
-      "updatedAt": "2026-09-04T10:47:08.107Z",
-      "completedAt": null
+      "updatedAt": "2026-09-06T10:10:40.793Z",
+      "completedAt": "2026-09-06T10:10:40.793Z"
     },
     {
       "id": "task-spec-frame-storage-seam-T07",

--- a/.frame/tasks.json
+++ b/.frame/tasks.json
@@ -7,7 +7,7 @@
   },
   "project": "Frame",
   "version": "2.0",
-  "lastUpdated": "2026-09-06T09:59:51.512Z",
+  "lastUpdated": "2026-09-06T10:04:02.492Z",
   "taskSchema": {
     "_comment": "This schema shows the expected structure for each task",
     "id": "unique-id (task-xxx format)",
@@ -7037,13 +7037,13 @@
       "title": "Add resolver unit tests to `test/frameStore.test.js`: each returns the flat `.frame/specs[/slug]` answer, and a legacy project carrying a `config.files` record plus a root-level `specs/` directory still resolves to the overlay",
       "description": "",
       "source": "spec:frame-storage-seam:T03",
-      "status": "pending",
+      "status": "completed",
       "priority": "medium",
       "category": "feature",
       "context": "From spec: frame-storage-seam",
       "createdAt": "2026-09-04T10:47:08.107Z",
-      "updatedAt": "2026-09-04T10:47:08.107Z",
-      "completedAt": null
+      "updatedAt": "2026-09-06T10:04:02.492Z",
+      "completedAt": "2026-09-06T10:04:02.492Z"
     },
     {
       "id": "task-spec-frame-storage-seam-T04",

--- a/.frame/tasks.json
+++ b/.frame/tasks.json
@@ -7,7 +7,7 @@
   },
   "project": "Frame",
   "version": "2.0",
-  "lastUpdated": "2026-08-31T21:33:41.054Z",
+  "lastUpdated": "2026-09-04T10:47:08.107Z",
   "taskSchema": {
     "_comment": "This schema shows the expected structure for each task",
     "id": "unique-id (task-xxx format)",
@@ -7005,10 +7005,101 @@
       "createdAt": "2026-09-01T05:57:13.685Z",
       "updatedAt": "2026-09-01T05:57:13.685Z",
       "completedAt": null
+    },
+    {
+      "id": "task-spec-frame-storage-seam-T01",
+      "title": "Add `specsRoot(projectPath)` and `resolveSpecDir(projectPath, slug)` to `src/main/frameStore.js` as flat joins over `FRAME_DIR`, never routed through `resolvePath`, and export both",
+      "description": "",
+      "source": "spec:frame-storage-seam:T01",
+      "status": "pending",
+      "priority": "medium",
+      "category": "feature",
+      "context": "From spec: frame-storage-seam",
+      "createdAt": "2026-09-04T10:47:08.107Z",
+      "updatedAt": "2026-09-04T10:47:08.107Z",
+      "completedAt": null
+    },
+    {
+      "id": "task-spec-frame-storage-seam-T02",
+      "title": "Extend `src/main/frameStore.js`'s header to name spec folders alongside the meta files it already lists, recording that `non-invasive-overlay`'s `specManager.js` exception is withdrawn",
+      "description": "",
+      "source": "spec:frame-storage-seam:T02",
+      "status": "pending",
+      "priority": "medium",
+      "category": "feature",
+      "context": "From spec: frame-storage-seam",
+      "createdAt": "2026-09-04T10:47:08.107Z",
+      "updatedAt": "2026-09-04T10:47:08.107Z",
+      "completedAt": null
+    },
+    {
+      "id": "task-spec-frame-storage-seam-T03",
+      "title": "Add resolver unit tests to `test/frameStore.test.js`: each returns the flat `.frame/specs[/slug]` answer, and a legacy project carrying a `config.files` record plus a root-level `specs/` directory still resolves to the overlay",
+      "description": "",
+      "source": "spec:frame-storage-seam:T03",
+      "status": "pending",
+      "priority": "medium",
+      "category": "feature",
+      "context": "From spec: frame-storage-seam",
+      "createdAt": "2026-09-04T10:47:08.107Z",
+      "updatedAt": "2026-09-04T10:47:08.107Z",
+      "completedAt": null
+    },
+    {
+      "id": "task-spec-frame-storage-seam-T04",
+      "title": "Reduce `getSpecsRoot` and `getSpecDir` in `src/main/specManager.js` to one-line delegates and delete the module's `SPECS_DIR_NAME`, leaving every call site and every `mkdirSync` — including the `isLegacyLayout`-gated one at line 1270 — untouched",
+      "description": "",
+      "source": "spec:frame-storage-seam:T04",
+      "status": "pending",
+      "priority": "medium",
+      "category": "feature",
+      "context": "From spec: frame-storage-seam",
+      "createdAt": "2026-09-04T10:47:08.107Z",
+      "updatedAt": "2026-09-04T10:47:08.107Z",
+      "completedAt": null
+    },
+    {
+      "id": "task-spec-frame-storage-seam-T05",
+      "title": "Replace the two joins at `src/main/frameProject.js:241` and `:933` with `frameStore.specsRoot(projectPath)`, keeping both sites' `mkdir` and `.gitkeep` writes as they are",
+      "description": "",
+      "source": "spec:frame-storage-seam:T05",
+      "status": "pending",
+      "priority": "medium",
+      "category": "feature",
+      "context": "From spec: frame-storage-seam",
+      "createdAt": "2026-09-04T10:47:08.107Z",
+      "updatedAt": "2026-09-04T10:47:08.107Z",
+      "completedAt": null
+    },
+    {
+      "id": "task-spec-frame-storage-seam-T06",
+      "title": "Add `test/metaPathGuard.test.js` with the source-scanning guard: no `.js` file under `src/` other than `frameStore.js` has a line that both calls `path.join` and carries the `'specs'` literal, excluding `src/templates/bin/` because those files ship into `.frame/bin/` under the same rule as `scripts/`",
+      "description": "",
+      "source": "spec:frame-storage-seam:T06",
+      "status": "pending",
+      "priority": "medium",
+      "category": "feature",
+      "context": "From spec: frame-storage-seam",
+      "createdAt": "2026-09-04T10:47:08.107Z",
+      "updatedAt": "2026-09-04T10:47:08.107Z",
+      "completedAt": null
+    },
+    {
+      "id": "task-spec-frame-storage-seam-T07",
+      "title": "Add the drift test to `test/metaPathGuard.test.js` asserting `frameStore.specsRoot()` agrees with the `.frame/bin` literal used by `scripts/spec-index.js`, `scripts/spec-command-hint.js` and `src/templates/bin/implement-launch.js`",
+      "description": "",
+      "source": "spec:frame-storage-seam:T07",
+      "status": "pending",
+      "priority": "medium",
+      "category": "feature",
+      "context": "From spec: frame-storage-seam",
+      "createdAt": "2026-09-04T10:47:08.107Z",
+      "updatedAt": "2026-09-04T10:47:08.107Z",
+      "completedAt": null
     }
   ],
   "metadata": {
-    "totalCreated": 505,
+    "totalCreated": 512,
     "totalCompleted": 28
   },
   "categories": {

--- a/.frame/tasks.json
+++ b/.frame/tasks.json
@@ -7,7 +7,7 @@
   },
   "project": "Frame",
   "version": "2.0",
-  "lastUpdated": "2026-09-04T10:47:08.107Z",
+  "lastUpdated": "2026-09-06T09:14:48.353Z",
   "taskSchema": {
     "_comment": "This schema shows the expected structure for each task",
     "id": "unique-id (task-xxx format)",
@@ -7011,13 +7011,13 @@
       "title": "Add `specsRoot(projectPath)` and `resolveSpecDir(projectPath, slug)` to `src/main/frameStore.js` as flat joins over `FRAME_DIR`, never routed through `resolvePath`, and export both",
       "description": "",
       "source": "spec:frame-storage-seam:T01",
-      "status": "pending",
+      "status": "completed",
       "priority": "medium",
       "category": "feature",
       "context": "From spec: frame-storage-seam",
       "createdAt": "2026-09-04T10:47:08.107Z",
-      "updatedAt": "2026-09-04T10:47:08.107Z",
-      "completedAt": null
+      "updatedAt": "2026-09-06T09:14:48.353Z",
+      "completedAt": "2026-09-06T09:14:48.353Z"
     },
     {
       "id": "task-spec-frame-storage-seam-T02",

--- a/src/main/frameProject.js
+++ b/src/main/frameProject.js
@@ -238,7 +238,7 @@ async function runProjectInit(projectPath, projectName, options = {}) {
   // .frame/specs/ — Spec-Driven Development is on for new projects, so the
   // folder exists from the start (tracked by .gitkeep) instead of appearing
   // the first time someone opts in.
-  const specsDirPath = path.join(frameDirPath, 'specs');
+  const specsDirPath = frameStore.specsRoot(projectPath);
   await fsp.mkdir(specsDirPath, { recursive: true });
   await createFileIfNotExists(path.join(specsDirPath, '.gitkeep'), '');
 
@@ -930,7 +930,7 @@ function ensureSpecDrivenArtifacts(projectPath, config) {
   }
 
   // Make sure .frame/specs/ exists with a .gitkeep so it's version-tracked
-  const specsDir = path.join(projectPath, FRAME_DIR, 'specs');
+  const specsDir = frameStore.specsRoot(projectPath);
   fs.mkdirSync(specsDir, { recursive: true });
   const gitkeepPath = path.join(specsDir, '.gitkeep');
   if (!fs.existsSync(gitkeepPath)) {

--- a/src/main/frameStore.js
+++ b/src/main/frameStore.js
@@ -106,6 +106,26 @@ function metaDir(projectPath) {
   return path.dirname(resolvePath(projectPath, FRAME_FILES.TASKS));
 }
 
+// ─── Specs ────────────────────────────────────────────────────
+//
+// A spec is a folder of files rather than one of the FRAME_FILES names, so it
+// gets its own named pair instead of a case inside resolvePath. Deliberately
+// flat: the overlay-then-root branch above answers only for names a legacy
+// project recorded in `config.files`, and specs were never in that record, so
+// routing them through it would invent a legacy lookup that has never existed.
+
+const SPECS_DIR_NAME = 'specs';
+
+/** Root of a project's spec folders: `<project>/.frame/specs`. */
+function specsRoot(projectPath) {
+  return path.join(projectPath, FRAME_DIR, SPECS_DIR_NAME);
+}
+
+/** One spec's folder: `<project>/.frame/specs/<slug>`. */
+function resolveSpecDir(projectPath, slug) {
+  return path.join(specsRoot(projectPath), slug);
+}
+
 // ─── Typed read/write ─────────────────────────────────────────
 
 function readText(projectPath, name) {
@@ -224,6 +244,8 @@ function setupIPC(ipcMain) {
 
 module.exports = {
   resolvePath,
+  specsRoot,
+  resolveSpecDir,
   setupIPC,
   metaDir,
   isLegacyLayout,

--- a/src/main/frameStore.js
+++ b/src/main/frameStore.js
@@ -5,7 +5,8 @@
  * Projects initialized before that keep the root layout until the user
  * consents to migrate, so both layouts have to work at once. Every read and
  * write of AGENTS.md / PROJECT_NOTES.md / QUICKSTART.md / STRUCTURE.json /
- * tasks.json goes through here; no other module joins those paths.
+ * tasks.json goes through here, and so does every `.frame/specs/<slug>` path;
+ * no other module joins those paths.
  *
  * Resolution rule (mirrored by the .frame/bin scripts):
  *
@@ -21,6 +22,13 @@
  *
  * `.frame/config.json` itself is never resolved: it has always lived in
  * `.frame/`, and it is the record the rule reads.
+ *
+ * Spec folders answer to `specsRoot` / `resolveSpecDir` rather than to the
+ * rule above, and they are flat — see the Specs section for why a legacy
+ * fallback would be wrong there. `non-invasive-overlay` originally excepted
+ * `specManager.js` from this doctrine "for specs"; that exception is
+ * withdrawn, and `test/metaPathGuard.test.js` now fails when a spec path is
+ * built outside this module.
  *
  * Files are the source of truth. Every read hits disk — agents edit these
  * files with their own tools and Frame must see the result immediately — so

--- a/src/main/specManager.js
+++ b/src/main/specManager.js
@@ -24,7 +24,6 @@ const telemetry = require('./telemetry');
 const activityLog = require('./activityLog');
 const perfMonitor = require('./perfMonitor');
 
-const SPECS_DIR_NAME = 'specs';
 const STATUS_FILE = 'status.json';
 const SPEC_FILE = 'spec.md';
 const PLAN_FILE = 'plan.md';
@@ -59,12 +58,15 @@ const busySpecSlugs = new Set();
 
 // ─── Path helpers ──────────────────────────────────────────
 
+// Delegates, not joins: frameStore owns every meta path, spec folders
+// included. Kept as local names so the call sites below read unchanged.
+
 function getSpecsRoot(projectPath) {
-  return path.join(projectPath, FRAME_DIR, SPECS_DIR_NAME);
+  return frameStore.specsRoot(projectPath);
 }
 
 function getSpecDir(projectPath, slug) {
-  return path.join(getSpecsRoot(projectPath), slug);
+  return frameStore.resolveSpecDir(projectPath, slug);
 }
 
 // ─── Validation ────────────────────────────────────────────

--- a/test/frameStore.test.js
+++ b/test/frameStore.test.js
@@ -127,6 +127,33 @@ test('metaDir points at the directory tasks.json actually lives in', () => {
   assert.equal(frameStore.metaDir(projectDir), frameDir(), 'overlay layout: watch .frame/');
 });
 
+// ─── Spec paths ───────────────────────────────────────────────
+
+test('spec paths are flat joins under .frame/specs', () => {
+  assert.equal(frameStore.specsRoot(projectDir), path.join(frameDir(), 'specs'));
+  assert.equal(
+    frameStore.resolveSpecDir(projectDir, 'frame-storage-seam'),
+    path.join(frameDir(), 'specs', 'frame-storage-seam')
+  );
+});
+
+test('spec paths never fall back to the project root, legacy record or not', () => {
+  // Everything resolvePath's legacy branch asks for, all at once: the
+  // config.files fingerprint plus a real directory at the root. Specs were
+  // never in that record, so the answer must not move.
+  writeConfig({ version: '1.0', files: legacyFilesRecord() });
+  writeRootFile(FRAME_FILES.STRUCTURE, '{}');
+  fs.mkdirSync(path.join(projectDir, 'specs', 'legacy-slug'), { recursive: true });
+
+  assert.equal(frameStore.isLegacyLayout(projectDir), true, 'the fallback conditions really are met');
+  assert.equal(frameStore.specsRoot(projectDir), path.join(frameDir(), 'specs'));
+  assert.equal(
+    frameStore.resolveSpecDir(projectDir, 'legacy-slug'),
+    path.join(frameDir(), 'specs', 'legacy-slug'),
+    'a root-level specs/ is not a legacy spec store'
+  );
+});
+
 // ─── Typed read/write ─────────────────────────────────────────
 
 test('typed read/write round-trips', () => {

--- a/test/metaPathGuard.test.js
+++ b/test/metaPathGuard.test.js
@@ -1,5 +1,5 @@
 /**
- * Meta-path doctrine guard (frame-storage-seam T06).
+ * Meta-path doctrine guard and mirror drift test (frame-storage-seam T06/T07).
  *
  * `frameStore` is the one module that knows where a project's meta files live.
  * `non-invasive-overlay` excepted `specManager.js` from that rule "for specs",
@@ -31,6 +31,8 @@ const { test } = require('node:test');
 const assert = require('node:assert/strict');
 const fs = require('fs');
 const path = require('path');
+
+const frameStore = require('../src/main/frameStore');
 
 const REPO_ROOT = path.join(__dirname, '..');
 const SRC_DIR = 'src';
@@ -81,4 +83,87 @@ test('the guard is live — it still finds the joins in the exempt shipped tree'
   // real spec-path joins that are meant to be there.
   const shipped = jsFilesUnder(SHIPPED_TREE).flatMap(specPathLines);
   assert.ok(shipped.length > 0, 'the scanner matched nothing at all — it is broken, not the tree clean');
+});
+
+// ─── Mirror drift ─────────────────────────────────────────────
+//
+// These three ship into a user project's `.frame/bin/` and each carries its
+// own copy of the `.frame/specs` literal, because none of them can require
+// frameStore from there. Coupling is impossible, so the answer is a test: the
+// segments they join must be the ones frameStore resolves to.
+
+const MIRRORS = [
+  path.join('scripts', 'spec-index.js'),
+  path.join('scripts', 'spec-command-hint.js'),
+  path.join('src', 'templates', 'bin', 'implement-launch.js')
+];
+
+/** The segments frameStore puts between a project and its specs: ['.frame', 'specs']. */
+function expectedSegments() {
+  const projectPath = path.join(path.sep, 'p');
+  return path.relative(projectPath, frameStore.specsRoot(projectPath)).split(path.sep);
+}
+
+/**
+ * The arguments of the `path.join(` call starting at `from`, as a flat list.
+ * String literals become their value; anything else stays as written, so an
+ * identifier can be resolved (or not) by the caller.
+ */
+function joinArguments(line, from) {
+  const open = line.indexOf('(', from);
+  let depth = 0;
+  let end = open;
+  for (let i = open; i < line.length; i += 1) {
+    if (line[i] === '(') depth += 1;
+    else if (line[i] === ')') {
+      depth -= 1;
+      if (depth === 0) { end = i; break; }
+    }
+  }
+  return line
+    .slice(open + 1, end)
+    .split(',')
+    .map((arg) => arg.trim())
+    .filter(Boolean)
+    .map((arg) => (/^(['"`]).*\1$/.test(arg) ? arg.slice(1, -1) : arg));
+}
+
+/** Every spec-path join in `relFile`, with its segments resolved where we can. */
+function specPathJoins(relFile) {
+  const source = fs.readFileSync(path.join(REPO_ROOT, relFile), 'utf8');
+  // A shipped script declares its own FRAME_DIR; resolve it so the comparison
+  // sees the same '.frame' the literal-carrying scripts write inline.
+  const frameDirConst = source.match(/const FRAME_DIR = ['"`]([^'"`]+)['"`]/);
+  const joins = [];
+  source.split('\n').forEach((line, i) => {
+    const match = JOIN_CALL.exec(line);
+    if (!match || !SPECS_LITERAL.test(line)) return;
+    const segments = joinArguments(line, match.index).map(
+      (arg) => (arg === 'FRAME_DIR' && frameDirConst ? frameDirConst[1] : arg)
+    );
+    joins.push({ where: `${relFile}:${i + 1}`, segments });
+  });
+  return joins;
+}
+
+test('the .frame/bin mirrors join the same segments frameStore resolves to', () => {
+  const expected = expectedSegments();
+
+  for (const relFile of MIRRORS) {
+    const joins = specPathJoins(relFile);
+    // A mirror that stopped building a spec path would otherwise make this
+    // test vacuous rather than red.
+    assert.ok(joins.length > 0, `${relFile} builds no spec path any more — the mirror moved`);
+
+    for (const { where, segments } of joins) {
+      const at = segments.findIndex(
+        (_, i) => expected.every((seg, k) => segments[i + k] === seg)
+      );
+      assert.ok(
+        at !== -1,
+        `${where} joins [${segments.join(', ')}], which does not carry ` +
+        `[${expected.join(', ')}] — the shipped literal has drifted from frameStore.specsRoot()`
+      );
+    }
+  }
 });

--- a/test/metaPathGuard.test.js
+++ b/test/metaPathGuard.test.js
@@ -1,0 +1,84 @@
+/**
+ * Meta-path doctrine guard (frame-storage-seam T06).
+ *
+ * `frameStore` is the one module that knows where a project's meta files live.
+ * `non-invasive-overlay` excepted `specManager.js` from that rule "for specs",
+ * and the exception spread: three modules ended up answering "where do specs
+ * live" on their own. This test replaces the convention with a check.
+ *
+ * The rule is path construction, not the word: `activityLog.js:132` filters
+ * `'specs'` as an event key and the renderer compares `viewMode === 'specs'`,
+ * both legitimate. A line is a violation only when it calls `path.join` (or
+ * `path.posix.join`) *and* carries the `'specs'` literal.
+ *
+ * Two paths under `src/` are exempt, for different reasons:
+ *
+ *   src/main/frameStore.js  — the owner. This is where the literal belongs.
+ *   src/templates/bin/      — ships into a user project's `.frame/bin/`, where
+ *                             `node_modules` and Frame's own tree are both
+ *                             unreachable (`brief-context.js:20`), so these
+ *                             files cannot require frameStore at all. Their
+ *                             copy of the literal is pinned by the drift test
+ *                             below instead — the same answer `scripts/` gets.
+ *
+ * Known limit, accepted: matching per line means a join whose segment comes
+ * from a variable declared elsewhere goes unseen. The guard closes the
+ * copy-paste path that produced the three original duplicates; it is not a
+ * defence against a deliberately obfuscated join.
+ */
+
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.join(__dirname, '..');
+const SRC_DIR = 'src';
+
+// The owner of the literal, and the tree that cannot reach it.
+const OWNER = path.join('src', 'main', 'frameStore.js');
+const SHIPPED_TREE = path.join('src', 'templates', 'bin');
+
+const JOIN_CALL = /\bpath\.(?:posix\.)?join\s*\(/;
+const SPECS_LITERAL = /(['"`])specs\1|['"`][^'"`]*\/specs(?:\/|['"`])/;
+
+/** Every `.js` file under `dir`, as repo-relative paths. */
+function jsFilesUnder(dir) {
+  const out = [];
+  for (const entry of fs.readdirSync(path.join(REPO_ROOT, dir), { withFileTypes: true })) {
+    const rel = path.join(dir, entry.name);
+    if (entry.isDirectory()) out.push(...jsFilesUnder(rel));
+    else if (entry.name.endsWith('.js')) out.push(rel);
+  }
+  return out;
+}
+
+/** Lines in `relFile` that build a path with a `specs` segment, as `file:line`. */
+function specPathLines(relFile) {
+  const lines = fs.readFileSync(path.join(REPO_ROOT, relFile), 'utf8').split('\n');
+  const hits = [];
+  lines.forEach((line, i) => {
+    if (JOIN_CALL.test(line) && SPECS_LITERAL.test(line)) hits.push(`${relFile}:${i + 1}`);
+  });
+  return hits;
+}
+
+test('no module but frameStore builds a .frame/specs path', () => {
+  const offenders = jsFilesUnder(SRC_DIR)
+    .filter((rel) => rel !== OWNER && !rel.startsWith(SHIPPED_TREE + path.sep))
+    .flatMap(specPathLines);
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `spec paths must come from frameStore.specsRoot / resolveSpecDir:\n  ${offenders.join('\n  ')}`
+  );
+});
+
+test('the guard is live — it still finds the joins in the exempt shipped tree', () => {
+  // Without this, a matcher that quietly stopped matching anything would
+  // report a clean tree forever. The exempt copies are the fixture: they are
+  // real spec-path joins that are meant to be there.
+  const shipped = jsFilesUnder(SHIPPED_TREE).flatMap(specPathLines);
+  assert.ok(shipped.length > 0, 'the scanner matched nothing at all — it is broken, not the tree clean');
+});


### PR DESCRIPTION
## What this adds

`frameStore` becomes the only module in `src/` that knows where a project's spec folders live. Two named resolvers, `specsRoot(projectPath)` and `resolveSpecDir(projectPath, slug)`, replace the three places that each joined `.frame/specs` on their own, and a new test fails the suite if a fourth ever appears.

| Before | After |
| --- | --- |
| `specManager.js` `path.join(projectPath, FRAME_DIR, SPECS_DIR_NAME)` | `frameStore.specsRoot(projectPath)` |
| `specManager.js` `path.join(getSpecsRoot(p), slug)` | `frameStore.resolveSpecDir(p, slug)` |
| `frameProject.js` (init) `path.join(frameDirPath, 'specs')` | `frameStore.specsRoot(projectPath)` |
| `frameProject.js` (ensureSpecDrivenArtifacts) `path.join(projectPath, FRAME_DIR, 'specs')` | `frameStore.specsRoot(projectPath)` |

Pure refactor: same paths on disk, same reads and writes, no UI, IPC or watcher change. 44 source lines across three files, plus two test files.

## Why

`non-invasive-overlay` made `frameStore.js` the one place meta paths are built, but wrote in an exception for specs: *"never join a meta path outside `frameStore.js` (`specManager.js` excepted, for specs)"*. The exception did not stay in one module. Three sites in `src/main/` answered "where do specs live" independently, and nothing caught a fourth. Specs are the most-written part of `.frame/`, so any later change to where spec content comes from had to find all three, and a miss would fail silently.

## Design decisions worth reviewing

- **Spec-specific resolvers, not a generic `resolveDir(projectPath, ...segments)`.** A generic joiner would leave the `'specs'` literal at every call site, which moves the duplication instead of removing it, and it would make the guard test unenforceable because a caller legitimately passing `'specs'` is indistinguishable from a violation. Widening to `index/` or `runtime/` later is one named function each.

- **The resolvers are flat and deliberately bypass `resolvePath`.** `resolvePath`'s overlay-then-root branch answers only for the six `FRAME_FILES` names a legacy project recorded in `config.files`. Specs were never in that record, and `specManager`'s join has always been unconditional. Routing specs through `resolvePath` would invent a legacy lookup that never existed and change behaviour for unmigrated projects. A unit test builds every condition the legacy branch needs, including a root-level `specs/` directory, and asserts the spec resolvers do not move.

- **`specManager` keeps `getSpecsRoot` / `getSpecDir` as one-line delegates** rather than rewriting its 17 call sites. The literal lands in `frameStore` either way, and two in-flight specs are editing that file.

- **The resolvers resolve, they never create.** Every existing `mkdirSync` stays where it is, including the `isLegacyLayout`-gated one that `migration-consent-scope` T05 installed in `startWatching`. The two `frameProject` sites also keep their own sync/async shape; collapsing them into one helper would force the async site to block.

- **The guard matches path construction, not the word.** A line is flagged only when it both calls `path.join` (or `path.posix.join`) and carries a `'specs'` literal. A bare-word scan would fail on correct code: `activityLog.js` filters `'specs'` as an event key and the renderer compares `viewMode === 'specs'`.

- **`src/templates/bin/` is exempt from the guard, which diverges from plan.md step 4.** The plan exempted only `frameStore.js`. `implement-launch.js` ships into a user project's `.frame/bin/`, where neither `node_modules` nor Frame's tree is reachable, so it cannot require `frameStore` and would leave the guard permanently red. It gets the same answer `scripts/` gets: a drift test extracts the segments each shipped copy joins, resolves each file's own `FRAME_DIR` constant, and asserts they carry the `['.frame', 'specs']` pair `frameStore.specsRoot()` produces. Expected segments come from the resolver, not a second literal, so drift is caught from either side.

- **This supersedes one rule of `non-invasive-overlay`.** The "`specManager.js` excepted, for specs" clause is withdrawn, declared in the spec's `supersedes:` field the same way `frame-bin-out-of-repo` reversed that spec's T15. The rest of that spec stands, and the `frameStore.js` header now records the withdrawal and points at the guard test.

## Before merging — things for the maintainer

1. **The doctrine change is yours to accept.** `non-invasive-overlay` wrote the specs exception on purpose. This PR reverses it and records the reversal in the spec archive; if you would rather keep spec paths in `specManager`, the guard test and the header paragraph are the two things to drop.
2. **`plan.md` step 4 is stale.** It still describes a guard with no `src/templates/bin/` exemption. The divergence is recorded in `outcome.md` T06 and in the commit body, but the plan itself was not corrected, so the archive reads as "plan says X, outcome says Y". Say if you want it amended in this PR.

## Testing

- `npm test`: 581 tests, all passing, on the branch rebased onto current `upstream/main`.
- The existing spec and frameStore suites pass **without edits**, which is the spec's own success criterion for "nothing else changed".
- Both new guard tests were verified red before green: a `path.join(..., 'specs')` injected into `specManager.js` was named by file and line, and rewriting `spec-index.js`'s literal to `.framev2` made the drift test name the file, line and both segment lists. Both changes were then reverted.
- **Deliberately untested:** the drift test's `MIRRORS` list is hand-maintained (`spec-index.js`, `spec-command-hint.js`, `implement-launch.js`). A new script added to `src/templates/bin/` or `scripts/` with its own spec-path join would be neither guarded nor pinned until someone adds it to that list. `scripts/spec-context.js` and `spec-hint.js` are not in the list because the spec left `scripts/` out of scope.
- The guard matches per line, so a join whose `'specs'` segment arrives through a variable declared elsewhere goes unseen. It closes the copy-paste path that produced the three original duplicates; it is not a defence against a deliberately indirect join.

